### PR TITLE
Single-agent deployment + team group chat patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,13 @@ testlogs
 # CLI config (may contain sensitive SSH paths)
 cli-config.yaml
 
+# Deployment secrets — never commit actual config/secrets
+config.yaml
+SOUL.md
+*.key
+*.json.key
+service-account*.json
+
 # Skills Hub state (lives in ~/.hermes/skills/.hub/ at runtime, but just in case)
 skills/.hub/
 ignored/

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,113 @@
+# Deploying Hermes Agent
+
+Single-agent deployment for a team Telegram group (or Mattermost channel).
+
+## Quick Start
+
+```bash
+# 1. Clone
+git clone git@github.com:NimbleCoOrg/hermes-agent.git
+cd hermes-agent
+
+# 2. Create data directory
+mkdir -p ~/.hermes
+
+# 3. Set up secrets
+cp .env.example ~/.hermes/.env
+# Edit ~/.hermes/.env — at minimum set:
+#   ANTHROPIC_API_KEY (or another LLM provider key)
+#   TELEGRAM_BOT_TOKEN (from @BotFather)
+
+# 4. Set up config
+cp config.yaml.example ~/.hermes/config.yaml
+# Edit if needed (defaults are sensible)
+
+# 5. Build and run
+docker compose up -d
+
+# 6. Check logs
+docker logs hermes-agent -f
+```
+
+## Configuration
+
+All runtime config lives in `~/.hermes/` on the host, mounted into the container at `/opt/data`.
+
+| File | Purpose | Template |
+|------|---------|----------|
+| `.env` | API keys, bot tokens, secrets | `.env.example` |
+| `config.yaml` | Model routing, session policy, platform settings | `config.yaml.example` |
+| `SOUL.md` | Agent persona (auto-created on first run) | `docker/SOUL.md` |
+
+### Required Environment Variables
+
+For Telegram:
+```
+ANTHROPIC_API_KEY=sk-ant-...
+TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
+```
+
+For Mattermost:
+```
+ANTHROPIC_API_KEY=sk-ant-...
+MATTERMOST_URL=https://mattermost.example.com
+MATTERMOST_TOKEN=your-bot-token
+```
+
+### Key Config Settings
+
+```yaml
+# Model — change provider/model as needed
+model:
+  default: "anthropic/claude-sonnet-4-20250514"
+  provider: "anthropic"
+
+# Session persistence — keeps conversation history across restarts
+session_reset:
+  mode: none
+
+# Shared group sessions — everyone in the group shares context
+group_sessions_per_user: false
+```
+
+## Platform Setup
+
+### Telegram
+
+1. Create a bot via [@BotFather](https://t.me/BotFather)
+2. Set `TELEGRAM_BOT_TOKEN` in `~/.hermes/.env`
+3. Add the bot to your group
+4. The bot sees all messages for context, responds when @mentioned (configurable via `telegram_require_mention` in config.yaml)
+
+### Mattermost
+
+1. Create a bot account in Mattermost (System Console > Integrations > Bot Accounts)
+2. Set `MATTERMOST_URL` and `MATTERMOST_TOKEN` in `~/.hermes/.env`
+3. Add the bot to channels
+4. The bot requires @mention in channels, always responds in DMs
+
+## Auth Model
+
+- **DMs:** Only users in `TELEGRAM_ALLOWED_USERS` / `MATTERMOST_ALLOWED_USERS` can DM the bot
+- **Groups/Channels:** Anyone present can interact (channel membership is the authorization)
+- If no allowed users are set, DMs are open to everyone
+
+## Rebuilding
+
+```bash
+# Rebuild image (after pulling upstream changes)
+docker compose build
+
+# Restart with new image
+docker compose down && docker compose up -d
+```
+
+## Updating from Upstream
+
+```bash
+git remote add upstream https://github.com/NousResearch/hermes-agent.git
+git fetch upstream
+git merge upstream/main
+# Resolve any conflicts with custom patches, rebuild
+docker compose build
+```

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -75,9 +75,10 @@ group_sessions_per_user: false
 ### Telegram
 
 1. Create a bot via [@BotFather](https://t.me/BotFather)
-2. Set `TELEGRAM_BOT_TOKEN` in `~/.hermes/.env`
-3. Add the bot to your group
-4. The bot sees all messages for context, responds when @mentioned (configurable via `telegram_require_mention` in config.yaml)
+2. **Restrict group access:** Send `/setjoingroups` to @BotFather and select "Disable". This prevents anyone from adding the bot to random groups. You can still add it to your team group manually.
+3. Set `TELEGRAM_BOT_TOKEN` in `~/.hermes/.env`
+4. Add the bot to your team group
+5. The bot sees all messages for context, responds when @mentioned (configurable via `telegram_require_mention` in config.yaml)
 
 ### Mattermost
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,31 @@
+# Hermes Agent Configuration
+# Copy to ~/.hermes/config.yaml (or let the container create it on first run)
+
+# -- Model --
+model:
+  default: "anthropic/claude-sonnet-4-20250514"
+  provider: "anthropic"
+
+# -- Session persistence --
+# Prevents conversation history from being wiped on container restart.
+# Options: none (keep forever), idle (reset after inactivity), daily
+session_reset:
+  mode: none
+
+# -- Group chat sessions --
+# false = everyone in a group/channel shares one session (recommended for teams)
+# true  = each person gets their own isolated session with the agent
+group_sessions_per_user: false
+
+# -- Telegram --
+# Bot responds to all messages in groups it's in, not just @mentions.
+# Set to true to require @mention in groups.
+# telegram_require_mention: false
+
+# -- Mattermost --
+# Bot requires @mention in channels (DMs always respond).
+# Set to false to respond to all channel messages.
+# mattermost_require_mention: true
+
+# -- Verbose logging --
+# verbose: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+# Hermes Agent — Single-agent deployment
+#
+# Setup:
+#   1. Copy .env.example to .env and fill in your keys
+#   2. Copy config.yaml.example to config.yaml and customize
+#   3. docker compose up -d
+#
+# Data lives in ~/.hermes/ on the host (mounted as /opt/data in container).
+# Edit ~/.hermes/.env for secrets, ~/.hermes/config.yaml for settings,
+# ~/.hermes/SOUL.md for the agent persona.
+
+services:
+  hermes:
+    build: .
+    container_name: hermes-agent
+    volumes:
+      - ~/.hermes:/opt/data
+    env_file:
+      - .env
+    ports:
+      - "8642:8642"
+    restart: unless-stopped
+    command: gateway

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -467,25 +467,46 @@ def get_audio_cache_dir() -> Path:
     return AUDIO_CACHE_DIR
 
 
-def cache_audio_from_bytes(data: bytes, ext: str = ".ogg") -> str:
+def cache_audio_from_bytes(
+    data: bytes,
+    ext: str = ".ogg",
+    *,
+    chat_id: str | None = None,
+    message_id: str | None = None,
+) -> str:
     """
     Save raw audio bytes to the cache and return the absolute file path.
 
     Args:
         data: Raw audio bytes.
         ext:  File extension including the dot (e.g. ".ogg", ".mp3").
+        chat_id: Optional chat/channel identifier for traceability.
+        message_id: Optional message identifier for traceability.
 
     Returns:
         Absolute path to the cached audio file as a string.
     """
     cache_dir = get_audio_cache_dir()
-    filename = f"audio_{uuid.uuid4().hex[:12]}{ext}"
+    parts = ["audio"]
+    if chat_id:
+        parts.append(str(chat_id))
+    if message_id:
+        parts.append(str(message_id))
+    parts.append(uuid.uuid4().hex[:12])
+    filename = f"{'_'.join(parts)}{ext}"
     filepath = cache_dir / filename
     filepath.write_bytes(data)
     return str(filepath)
 
 
-async def cache_audio_from_url(url: str, ext: str = ".ogg", retries: int = 2) -> str:
+async def cache_audio_from_url(
+    url: str,
+    ext: str = ".ogg",
+    retries: int = 2,
+    *,
+    chat_id: str | None = None,
+    message_id: str | None = None,
+) -> str:
     """
     Download an audio file from a URL and save it to the local cache.
 
@@ -525,7 +546,7 @@ async def cache_audio_from_url(url: str, ext: str = ".ogg", retries: int = 2) ->
                     },
                 )
                 response.raise_for_status()
-                return cache_audio_from_bytes(response.content, ext)
+                return cache_audio_from_bytes(response.content, ext, chat_id=chat_id, message_id=message_id)
             except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
                 if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code < 429:
                     raise

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -726,6 +726,11 @@ class MessageEvent:
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
 
+    # Observe-only flag — message is recorded in session context but does not
+    # trigger agent response.  Used for channel messages where the bot listens
+    # for context but only responds when @mentioned.
+    observe_only: bool = False
+
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     
@@ -1905,14 +1910,24 @@ class BasePlatformAdapter(ABC):
     async def handle_message(self, event: MessageEvent) -> None:
         """
         Process an incoming message.
-        
+
         This method returns quickly by spawning background tasks.
         This allows new messages to be processed even while an agent is running,
         enabling interruption support.
         """
         if not self._message_handler:
             return
-        
+
+        # Observe-only messages bypass session locking and background tasks —
+        # they are recorded in the transcript by the runner but never trigger
+        # agent response generation.
+        if getattr(event, "observe_only", False):
+            try:
+                await self._message_handler(event)
+            except Exception as e:
+                logger.error("[%s] Observe-only handler failed: %s", self.name, e)
+            return
+
         session_key = build_session_key(
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -611,6 +611,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
+        _observe_only = False
 
         # Mention-gating for non-DM channels.
         # Config (env vars):
@@ -635,11 +636,7 @@ class MattermostAdapter(BasePlatformAdapter):
             )
 
             if require_mention and not is_free_channel and not has_mention:
-                logger.debug(
-                    "Mattermost: skipping non-DM message without @mention (channel=%s)",
-                    channel_id,
-                )
-                return
+                _observe_only = True
 
             # Strip @mention from the message text so the agent sees clean input.
             if has_mention:
@@ -732,6 +729,7 @@ class MattermostAdapter(BasePlatformAdapter):
             media_urls=media_urls if media_urls else None,
             media_types=media_types if media_types else None,
             channel_prompt=_channel_prompt,
+            observe_only=_observe_only,
         )
 
         await self.handle_message(msg_event)

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -594,11 +594,8 @@ class MattermostAdapter(BasePlatformAdapter):
         if post.get("user_id") == self._bot_user_id:
             return
 
-        # Ignore system posts (join/leave/header changes etc.) but allow
-        # bot messages through — bots are legitimate participants in channels.
-        post_type = post.get("type", "")
-        if post_type and post_type.startswith("system_"):
-            return
+        # All post types are allowed through — system posts (join/leave/header
+        # changes) and bot messages are useful context for the agent.
 
         post_id = post.get("id", "")
 

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -684,7 +684,10 @@ class MattermostAdapter(BasePlatformAdapter):
                             media_types.append(mime)
                         elif mime.startswith("audio/"):
                             from gateway.platforms.base import cache_audio_from_bytes
-                            local_path = cache_audio_from_bytes(file_data, ext or ".ogg")
+                            local_path = cache_audio_from_bytes(
+                                file_data, ext or ".ogg",
+                                chat_id=channel_id, message_id=fid,
+                            )
                             media_urls.append(local_path)
                             media_types.append(mime)
                         else:

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -594,8 +594,10 @@ class MattermostAdapter(BasePlatformAdapter):
         if post.get("user_id") == self._bot_user_id:
             return
 
-        # Ignore system posts.
-        if post.get("type"):
+        # Ignore system posts (join/leave/header changes etc.) but allow
+        # bot messages through — bots are legitimate participants in channels.
+        post_type = post.get("type", "")
+        if post_type and post_type.startswith("system_"):
             return
 
         post_id = post.get("id", "")

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2611,14 +2611,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 try:
                     file_obj = await msg.voice.get_file()
                     audio_bytes = await file_obj.download_as_bytearray()
-                    cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".ogg")
+                    cached_path = cache_audio_from_bytes(
+                        bytes(audio_bytes), ext=".ogg",
+                        chat_id=str(msg.chat.id), message_id=str(msg.message_id),
+                    )
                     from tools.transcription_tools import transcribe_audio
                     import asyncio
                     result = await asyncio.to_thread(transcribe_audio, cached_path)
                     if result.get("success"):
-                        event.text = f'[voice message: "{result["transcript"]}"]'
+                        event.text = f'[voice message: "{result["transcript"]}" (audio: {cached_path})]'
                     else:
-                        event.text = "[shared voice message]"
+                        event.text = f"[shared voice message (audio: {cached_path})]"
                 except Exception as e:
                     logger.warning("[Telegram] Observe-only voice transcription failed: %s", e)
                     event.text = "[shared voice message]"
@@ -2670,7 +2673,10 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 file_obj = await msg.voice.get_file()
                 audio_bytes = await file_obj.download_as_bytearray()
-                cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".ogg")
+                cached_path = cache_audio_from_bytes(
+                    bytes(audio_bytes), ext=".ogg",
+                    chat_id=str(msg.chat.id), message_id=str(msg.message_id),
+                )
                 event.media_urls = [cached_path]
                 event.media_types = ["audio/ogg"]
                 logger.info("[Telegram] Cached user voice at %s", cached_path)
@@ -2680,7 +2686,10 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 file_obj = await msg.audio.get_file()
                 audio_bytes = await file_obj.download_as_bytearray()
-                cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".mp3")
+                cached_path = cache_audio_from_bytes(
+                    bytes(audio_bytes), ext=".mp3",
+                    chat_id=str(msg.chat.id), message_id=str(msg.message_id),
+                )
                 event.media_urls = [cached_path]
                 event.media_types = ["audio/mp3"]
                 logger.info("[Telegram] Cached user audio at %s", cached_path)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2392,11 +2392,15 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not update.message or not update.message.text:
             return
-        if not self._should_process_message(update.message):
+        _should_respond = self._should_process_message(update.message)
+        if not _should_respond and not self._is_group_chat(update.message):
             return
 
         event = self._build_message_event(update.message, MessageType.TEXT, update_id=update.update_id)
-        event.text = self._clean_bot_trigger_text(event.text)
+        if not _should_respond:
+            event.observe_only = True
+        else:
+            event.text = self._clean_bot_trigger_text(event.text)
         self._enqueue_text_event(event)
     
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2576,11 +2576,12 @@ class TelegramAdapter(BasePlatformAdapter):
         """Handle incoming media messages, downloading images to local cache."""
         if not update.message:
             return
-        if not self._should_process_message(update.message):
+        _should_respond = self._should_process_message(update.message)
+        if not _should_respond and not self._is_group_chat(update.message):
             return
-        
+
         msg = update.message
-        
+
         # Determine media type
         if msg.sticker:
             msg_type = MessageType.STICKER
@@ -2596,12 +2597,35 @@ class TelegramAdapter(BasePlatformAdapter):
             msg_type = MessageType.DOCUMENT
         else:
             msg_type = MessageType.DOCUMENT
-        
+
         event = self._build_message_event(msg, msg_type, update_id=update.update_id)
-        
+
         # Add caption as text
         if msg.caption:
             event.text = self._clean_bot_trigger_text(msg.caption)
+
+        # Observe-only: record metadata, auto-transcribe voice messages.
+        if not _should_respond:
+            event.observe_only = True
+            if msg_type == MessageType.VOICE and msg.voice:
+                try:
+                    file_obj = await msg.voice.get_file()
+                    audio_bytes = await file_obj.download_as_bytearray()
+                    cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".ogg")
+                    from tools.transcription_tools import transcribe_audio
+                    import asyncio
+                    result = await asyncio.to_thread(transcribe_audio, cached_path)
+                    if result.get("success"):
+                        event.text = f'[voice message: "{result["transcript"]}"]'
+                    else:
+                        event.text = "[shared voice message]"
+                except Exception as e:
+                    logger.warning("[Telegram] Observe-only voice transcription failed: %s", e)
+                    event.text = "[shared voice message]"
+            elif not event.text:
+                event.text = f"[shared {msg_type.value}]"
+            await self.handle_message(event)
+            return
         
         # Handle stickers: describe via vision tool with caching
         if msg.sticker:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3870,6 +3870,23 @@ class GatewayRunner:
             ts = datetime.now().isoformat()
             sender = source.user_name or source.user_id or "unknown"
             content = event.text or ""
+
+            # Auto-transcribe voice/audio attachments for context
+            if not content and event.media_urls and event.media_types:
+                for url, mtype in zip(event.media_urls, event.media_types):
+                    if mtype.startswith("audio/"):
+                        try:
+                            from tools.transcription_tools import transcribe_audio
+                            import asyncio
+                            result = await asyncio.to_thread(transcribe_audio, url)
+                            if result.get("success"):
+                                content = f'[voice message: "{result["transcript"]}"]'
+                        except Exception as e:
+                            logger.debug("Observe-only transcription failed: %s", e)
+                if not content:
+                    content = "[shared media]"
+
+            # Prefix with sender name so the agent knows who said what
             tagged_content = f"[{sender}]: {content}" if content else f"[{sender} sent a message]"
             self.session_store.append_to_transcript(
                 session_entry.session_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3880,7 +3880,7 @@ class GatewayRunner:
                             import asyncio
                             result = await asyncio.to_thread(transcribe_audio, url)
                             if result.get("success"):
-                                content = f'[voice message: "{result["transcript"]}"]'
+                                content = f'[voice message: "{result["transcript"]}" (audio: {url})]'
                         except Exception as e:
                             logger.debug("Observe-only transcription failed: %s", e)
                 if not content:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3155,39 +3155,43 @@ class GatewayRunner:
             logger.debug("Ignoring message with no user_id from %s", source.platform.value)
             return None
         elif not self._is_user_authorized(source):
-            logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
-            # In DMs: offer pairing code. In groups: silently ignore.
-            if source.chat_type == "dm" and self._get_unauthorized_dm_behavior(source.platform) == "pair":
-                platform_name = source.platform.value if source.platform else "unknown"
-                # Rate-limit ALL pairing responses (code or rejection) to
-                # prevent spamming the user with repeated messages when
-                # multiple DMs arrive in quick succession.
-                if self.pairing_store._is_rate_limited(platform_name, source.user_id):
-                    return None
-                code = self.pairing_store.generate_code(
-                    platform_name, source.user_id, source.user_name or ""
-                )
-                if code:
-                    adapter = self.adapters.get(source.platform)
-                    if adapter:
-                        await adapter.send(
-                            source.chat_id,
-                            f"Hi~ I don't recognize you yet!\n\n"
-                            f"Here's your pairing code: `{code}`\n\n"
-                            f"Ask the bot owner to run:\n"
-                            f"`hermes pairing approve {platform_name} {code}`"
-                        )
-                else:
-                    adapter = self.adapters.get(source.platform)
-                    if adapter:
-                        await adapter.send(
-                            source.chat_id,
-                            "Too many pairing requests right now~ "
-                            "Please try again later!"
-                        )
-                    # Record rate limit so subsequent messages are silently ignored
-                    self.pairing_store._record_rate_limit(platform_name, source.user_id)
-            return None
+            # Channel/group messages: anyone present in the channel is
+            # implicitly authorized (membership IS the auth).  ALLOWED_USERS
+            # only gates DMs.
+            if source.chat_type not in ("group", "channel"):
+                logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
+                if source.chat_type == "dm" and self._get_unauthorized_dm_behavior(source.platform) == "pair":
+                    platform_name = source.platform.value if source.platform else "unknown"
+                    # Rate-limit ALL pairing responses (code or rejection) to
+                    # prevent spamming the user with repeated messages when
+                    # multiple DMs arrive in quick succession.
+                    if self.pairing_store._is_rate_limited(platform_name, source.user_id):
+                        return None
+                    code = self.pairing_store.generate_code(
+                        platform_name, source.user_id, source.user_name or ""
+                    )
+                    if code:
+                        adapter = self.adapters.get(source.platform)
+                        if adapter:
+                            await adapter.send(
+                                source.chat_id,
+                                f"Hi~ I don't recognize you yet!\n\n"
+                                f"Here's your pairing code: `{code}`\n\n"
+                                f"Ask the bot owner to run:\n"
+                                f"`hermes pairing approve {platform_name} {code}`"
+                            )
+                    else:
+                        adapter = self.adapters.get(source.platform)
+                        if adapter:
+                            await adapter.send(
+                                source.chat_id,
+                                "Too many pairing requests right now~ "
+                                "Please try again later!"
+                            )
+                        # Record rate limit so subsequent messages are silently ignored
+                        self.pairing_store._record_rate_limit(platform_name, source.user_id)
+                return None
+            # Group/channel message from non-allowlisted user — allowed through
         
         # Intercept messages that are responses to a pending /update prompt.
         # The update process (detached) wrote .update_prompt.json; the watcher
@@ -3855,6 +3859,32 @@ class GatewayRunner:
         # Pending exec approvals are handled by /approve and /deny commands above.
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
+
+        # ── Observe-only: record in session context, skip agent ───────
+        # Messages the bot sees but doesn't respond to (e.g. channel messages
+        # without @mention).  Stored as "user" role so the LLM can read them
+        # as conversational context; tagged with observe_only so the gateway
+        # knows no response was generated.
+        if getattr(event, "observe_only", False):
+            session_entry = self.session_store.get_or_create_session(source)
+            ts = datetime.now().isoformat()
+            sender = source.user_name or source.user_id or "unknown"
+            content = event.text or ""
+            tagged_content = f"[{sender}]: {content}" if content else f"[{sender} sent a message]"
+            self.session_store.append_to_transcript(
+                session_entry.session_id,
+                {
+                    "role": "user",
+                    "content": tagged_content,
+                    "timestamp": ts,
+                    "observe_only": True,
+                },
+            )
+            logger.debug(
+                "Observed message from %s in %s (no response)",
+                sender, source.chat_id,
+            )
+            return None
 
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -767,6 +767,15 @@ class SessionStore:
                 # existing ``.restart_failure_counts`` stuck-loop counter
                 # still converge to a clean slate.
                 if entry.suspended:
+                    policy = self.config.get_reset_policy(
+                        platform=source.platform,
+                        session_type=getattr(source, 'chat_type', 'dm'),
+                    )
+                    if policy.mode == "none":
+                        entry.suspended = False
+                        entry.updated_at = now
+                        self._save()
+                        return entry
                     reset_reason = "suspended"
                 elif entry.resume_pending:
                     # Restart-interrupted session: preserve the session_id


### PR DESCRIPTION
## Summary

Sets up NimbleCoOrg/hermes-agent for simple single-agent deployment (one bot, one Telegram group, team members).

**Deployment files:**
- `docker-compose.yml` — single service, `~/.hermes` volume mount
- `config.yaml.example` — sensible defaults (session persistence, shared group sessions)
- `DEPLOYMENT.md` — setup guide for Telegram and Mattermost
- `.gitignore` — excludes secrets and runtime config

**Portable patches from hermes-swarm:**
- Auth scoping: `ALLOWED_USERS` only gates DMs, anyone in a group/channel can interact
- Observe-only messages: non-mention channel messages stored as session context
- Session persistence: `session_reset.mode: none` prevents context wipe on container restart

No Swarm-Map dependency. No Google Workspace MCP. No group allowlist. Just a clean deployment that works with env vars.

## Test plan
- [x] Mattermost adapter tests pass (14/14, 1 pre-existing aiohttp dep failure)
- [ ] Manual: docker compose up with Telegram bot token
- [ ] Manual: verify group messages observed without response, @mention triggers response

🤖 Generated with [Claude Code](https://claude.com/claude-code)