### PR TITLE
fix(signal): bridge top-level require_mention to Signal group gate

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1062,8 +1062,15 @@ def load_gateway_config() -> GatewayConfig:
             # Signal settings → env vars (env vars take precedence)
             signal_cfg = yaml_cfg.get("signal", {})
             if isinstance(signal_cfg, dict):
-                if "require_mention" in signal_cfg and not os.getenv("SIGNAL_REQUIRE_MENTION"):
-                    os.environ["SIGNAL_REQUIRE_MENTION"] = str(signal_cfg["require_mention"]).lower()
+                # Prefer signal.require_mention; fall back to the top-level
+                # shorthand. Users write `require_mention: true` at the top
+                # level (alongside group_sessions_per_user) expecting it to gate
+                # every platform — Telegram already honors this (see above), so
+                # Signal must too, otherwise agents reply to unmentioned group
+                # messages despite the setting.
+                _signal_rm = signal_cfg.get("require_mention", yaml_cfg.get("require_mention"))
+                if _signal_rm is not None and not os.getenv("SIGNAL_REQUIRE_MENTION"):
+                    os.environ["SIGNAL_REQUIRE_MENTION"] = str(_signal_rm).lower()
 
             # DingTalk settings → env vars (env vars take precedence)
             dingtalk_cfg = yaml_cfg.get("dingtalk", {})

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -343,6 +343,43 @@ class TestLoadGatewayConfig:
         # Env value preserved, not clobbered by yaml.
         assert os.environ.get("DISCORD_THREAD_REQUIRE_MENTION") == "true"
 
+    def test_top_level_require_mention_bridges_to_signal(self, tmp_path, monkeypatch):
+        """A top-level `require_mention: true` should gate Signal groups, the same
+        way it already bridges to Telegram (config.py:957). Users write the
+        shorthand alongside `group_sessions_per_user` expecting it to apply to
+        every platform — Signal silently ignored it, so agents kept replying to
+        unmentioned group messages (hermes-personal incident)."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "require_mention: true\n"
+            "signal:\n"
+            "  home_channel: support bus\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("SIGNAL_REQUIRE_MENTION", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("SIGNAL_REQUIRE_MENTION") == "true"
+
+    def test_signal_require_mention_yaml_does_not_overwrite_env(self, tmp_path, monkeypatch):
+        """Explicit SIGNAL_REQUIRE_MENTION env wins over the top-level shorthand."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("require_mention: true\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SIGNAL_REQUIRE_MENTION", "false")  # user override
+
+        load_gateway_config()
+
+        assert os.environ.get("SIGNAL_REQUIRE_MENTION") == "false"
+
     def test_bridges_quoted_false_platform_enabled_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_signal_require_mention.py
+++ b/tests/gateway/test_signal_require_mention.py
@@ -1,0 +1,104 @@
+"""Regression tests for the Signal group mention gate (``require_mention``).
+
+Reproduces the production incident where ``hermes-cyborg`` — which had
+``SIGNAL_REQUIRE_MENTION=true`` — still replied to a plain, unmentioned group
+message ("Testing if I can message without agents replying"). With the gate
+on, an unmentioned group message must be dispatched ``observe_only`` (recorded
+for context, no agent response).
+"""
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_signal_adapter(monkeypatch, account="+15551234567", **extra):
+    """Create a SignalAdapter with test defaults, mirroring test_signal_enhancements."""
+    monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", extra.pop("group_allowed", "*"))
+    from gateway.platforms.signal import SignalAdapter
+    config = PlatformConfig()
+    config.enabled = True
+    config.extra = {
+        "http_url": "http://localhost:8080",
+        "account": account,
+        **extra,
+    }
+    return SignalAdapter(config)
+
+
+def _group_text_envelope(text, *, sender="+15559999999", group_id="grp-abc-123", mentions=None):
+    data_message = {
+        "message": text,
+        "groupInfo": {"groupId": group_id},
+    }
+    if mentions is not None:
+        data_message["mentions"] = mentions
+    return {
+        "envelope": {
+            "sourceNumber": sender,
+            "sourceUuid": "66666666-6666-6666-6666-666666666666",
+            "sourceName": "Juni",
+            "dataMessage": data_message,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_unmentioned_group_message_is_observe_only(monkeypatch):
+    """require_mention=True + plain unmentioned group message → observe_only.
+
+    This is the exact cyborg scenario.
+    """
+    adapter = _make_signal_adapter(monkeypatch, require_mention=True)
+    # Precondition: the gate is actually enabled on this adapter.
+    assert adapter.require_mention is True
+
+    captured = []
+
+    async def fake_handle_message(event):
+        captured.append(event)
+
+    adapter.handle_message = fake_handle_message
+
+    envelope = _group_text_envelope(
+        "Testing if I can message without agents replying"
+    )
+    await adapter._handle_envelope(envelope)
+
+    assert len(captured) == 1, "message should be dispatched exactly once"
+    assert captured[0].observe_only is True, (
+        "an unmentioned group message must be observe_only (no agent response)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mentioned_group_message_responds_and_strips_mention(monkeypatch):
+    """require_mention=True + a message that @mentions the bot → full response,
+    and the bot's own @mention is stripped from the text before dispatch.
+
+    This is why the production log showed clean text ("Testing if I can
+    message without agents replying") even though the bot responded: the
+    inbound @mention was stripped at signal.py:694-700 before logging.
+    """
+    account = "+15551234567"
+    adapter = _make_signal_adapter(monkeypatch, account=account, require_mention=True)
+
+    captured = []
+
+    async def fake_handle_message(event):
+        captured.append(event)
+
+    adapter.handle_message = fake_handle_message
+
+    # Juni @mentions the bot by account number, then types the same text.
+    envelope = _group_text_envelope(
+        f"@{account} Testing if I can message without agents replying"
+    )
+    await adapter._handle_envelope(envelope)
+
+    assert len(captured) == 1
+    assert captured[0].observe_only is False, (
+        "a message that @mentions the bot must trigger a full response"
+    )
+    assert captured[0].text == "Testing if I can message without agents replying", (
+        "the bot's own @mention must be stripped from the dispatched text"
+    )


### PR DESCRIPTION
## Why
Agents were replying in a Signal group without being @mentioned despite `require_mention` being "set everywhere."

Root cause (code + live logs): the Signal gate (`signal.py:646`) is correct, but a **top-level `require_mention: true` in config.yaml was honored by Telegram (`config.py:957`) and silently ignored by Signal** — Signal only read nested `signal.require_mention` or the `SIGNAL_REQUIRE_MENTION` env var. Agents using the top-level shorthand kept replying to unmentioned group messages.

## What
- `config.py`: Signal falls back to the top-level `require_mention` shorthand, mirroring Telegram. Env var still takes precedence.

## Tests
- `test_top_level_require_mention_bridges_to_signal` — the failing test that drove the fix.
- `test_signal_require_mention_yaml_does_not_overwrite_env` — explicit env wins.
- `test_signal_require_mention.py`: unmentioned group msg → `observe_only`; mentioned msg → responds and strips the bot's own @mention from dispatched text (explains the clean incident log).

187 passed across `test_config.py` + `test_signal*.py`.

Note: branch also carries the prior `fix: suppress reactions on observe-only group messages` commit (same area, no PR yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)