### PR TITLE
fix(signal): stop SSE reconnect churn + demote benign reconnect logs

### DIFF
--- a/gateway/platforms/_http_client_limits.py
+++ b/gateway/platforms/_http_client_limits.py
@@ -82,3 +82,19 @@ def platform_httpx_limits() -> "httpx.Limits | None":
         # Leave max_connections at httpx default (100) — plenty of headroom.
         keepalive_expiry=keepalive_expiry,
     )
+
+
+def sse_httpx_limits() -> "httpx.Limits | None":
+    """Return ``httpx.Limits`` for a dedicated long-lived SSE stream client.
+
+    An SSE stream is a single long-lived GET, not a pool of short calls.
+    Sharing the regular pool (``keepalive_expiry=2s``) meant the stream could
+    reuse a socket the daemon had already closed, raising "Server disconnected"
+    and forcing a reconnect every few minutes. Disabling keepalive pooling
+    (``max_keepalive_connections=0``) gives the stream a fresh connection and
+    nothing to reuse, eliminating that churn. Returns ``None`` when httpx isn't
+    importable so callers fall back to the httpx default.
+    """
+    if httpx is None:
+        return None
+    return httpx.Limits(max_keepalive_connections=0)

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -65,6 +65,17 @@ HEALTH_CHECK_INTERVAL = 30.0  # seconds between health checks
 HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without SSE activity before concern
 
 
+def _sse_reconnect_log_level(backoff: float) -> int:
+    """Log level for an SSE reconnect, given the current backoff.
+
+    A reconnect while backoff is still at its initial value is the benign,
+    self-healing pooled-socket churn — log it at DEBUG so it doesn't spam
+    WARNINGs. Once the backoff has grown the daemon is persistently
+    unreachable, which is a real problem worth a WARNING.
+    """
+    return logging.DEBUG if backoff <= SSE_RETRY_DELAY_INITIAL else logging.WARNING
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -218,6 +229,9 @@ class SignalAdapter(BasePlatformAdapter):
 
         # HTTP client
         self.client: Optional[httpx.AsyncClient] = None
+        # Dedicated client for the long-lived SSE stream — no keepalive pooling,
+        # so it never reuses a daemon-closed socket (the reconnect-churn fix).
+        self.sse_client: Optional[httpx.AsyncClient] = None
 
         # Background tasks
         self._sse_task: Optional[asyncio.Task] = None
@@ -280,8 +294,17 @@ class SignalAdapter(BasePlatformAdapter):
             logger.warning("Signal: Could not acquire phone lock (non-fatal): %s", e)
 
         # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
-        from gateway.platforms._http_client_limits import platform_httpx_limits
+        from gateway.platforms._http_client_limits import (
+            platform_httpx_limits,
+            sse_httpx_limits,
+        )
         self.client = httpx.AsyncClient(timeout=30.0, limits=platform_httpx_limits())
+        # Separate client for the SSE stream: no keepalive pool, read timeout
+        # disabled (the stream stays open indefinitely).
+        self.sse_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(30.0, read=None),
+            limits=sse_httpx_limits(),
+        )
         try:
             # Health check — verify signal-cli daemon is reachable
             try:
@@ -312,6 +335,9 @@ class SignalAdapter(BasePlatformAdapter):
                 if self.client:
                     await self.client.aclose()
                     self.client = None
+                if self.sse_client:
+                    await self.sse_client.aclose()
+                    self.sse_client = None
                 if lock_acquired:
                     self._release_platform_lock()
 
@@ -342,6 +368,10 @@ class SignalAdapter(BasePlatformAdapter):
             await self.client.aclose()
             self.client = None
 
+        if self.sse_client:
+            await self.sse_client.aclose()
+            self.sse_client = None
+
         self._release_platform_lock()
 
         logger.info("Signal: disconnected")
@@ -358,7 +388,7 @@ class SignalAdapter(BasePlatformAdapter):
         while self._running:
             try:
                 logger.debug("Signal SSE: connecting to %s", url)
-                async with self.client.stream(
+                async with self.sse_client.stream(
                     "GET", url,
                     headers={"Accept": "text/event-stream"},
                     timeout=None,
@@ -402,10 +432,12 @@ class SignalAdapter(BasePlatformAdapter):
                 break
             except httpx.HTTPError as e:
                 if self._running:
-                    logger.warning("Signal SSE: HTTP error: %s (reconnecting in %.0fs)", e, backoff)
+                    logger.log(_sse_reconnect_log_level(backoff),
+                               "Signal SSE: HTTP error: %s (reconnecting in %.0fs)", e, backoff)
             except Exception as e:
                 if self._running:
-                    logger.warning("Signal SSE: error: %s (reconnecting in %.0fs)", e, backoff)
+                    logger.log(_sse_reconnect_log_level(backoff),
+                               "Signal SSE: error: %s (reconnecting in %.0fs)", e, backoff)
 
             if self._running:
                 # Add 20% jitter to prevent thundering herd on reconnection

--- a/tests/gateway/test_platform_http_client_limits.py
+++ b/tests/gateway/test_platform_http_client_limits.py
@@ -72,6 +72,23 @@ def test_env_override_rejects_garbage(monkeypatch):
     assert limits.max_keepalive_connections > 0
 
 
+def test_sse_limits_disable_keepalive_pooling():
+    """The long-lived Signal SSE stream uses a dedicated client that must NOT
+    pool/reuse connections — reusing a daemon-closed keepalive socket is what
+    produced the recurring "Server disconnected" reconnect churn."""
+    import httpx
+    from gateway.platforms._http_client_limits import sse_httpx_limits
+    limits = sse_httpx_limits()
+    assert isinstance(limits, httpx.Limits)
+    assert limits.max_keepalive_connections == 0
+
+
+def test_sse_limits_none_when_httpx_unavailable(monkeypatch):
+    import gateway.platforms._http_client_limits as mod
+    monkeypatch.setattr(mod, "httpx", None)
+    assert mod.sse_httpx_limits() is None
+
+
 def test_helper_is_importable_from_every_platform_that_uses_it():
     """Every persistent-httpx-client platform adapter imports this helper.
     If any of those modules fails to import, this test surfaces it before

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -119,9 +119,12 @@ class TestSignalConnectCleanup:
             result = await adapter.connect()
 
         assert result is False
-        mock_client.aclose.assert_awaited_once()
+        # Both the API client and the dedicated SSE client are created from the
+        # same patched AsyncClient and must both be closed on failed connect.
+        assert mock_client.aclose.await_count == 2
         mock_release.assert_called_once_with("signal-phone", "+15551234567")
         assert adapter.client is None
+        assert adapter.sse_client is None
         assert adapter._platform_lock_identity is None
 
 

--- a/tests/gateway/test_signal_sse.py
+++ b/tests/gateway/test_signal_sse.py
@@ -1,0 +1,22 @@
+"""Tests for Signal SSE reconnect log-noise handling.
+
+The Signal SSE stream reconnects ~5-6x/hour with a benign, self-healing
+"Server disconnected" (httpx pooled-socket churn). Those transient reconnects
+should not surface as WARNING spam — only a persistent, backing-off failure
+should warn.
+"""
+import logging
+
+from gateway.platforms.signal import _sse_reconnect_log_level, SSE_RETRY_DELAY_INITIAL
+
+
+def test_transient_reconnect_logs_at_debug():
+    # First reconnect (backoff still at the initial value) is benign and
+    # self-heals on the next connect → debug, not warning.
+    assert _sse_reconnect_log_level(SSE_RETRY_DELAY_INITIAL) == logging.DEBUG
+
+
+def test_escalating_reconnect_logs_at_warning():
+    # Once the backoff has grown, the daemon is persistently unreachable →
+    # warn so a real outage is visible.
+    assert _sse_reconnect_log_level(SSE_RETRY_DELAY_INITIAL * 4) == logging.WARNING


### PR DESCRIPTION
## Why
Agents logged `Signal SSE: HTTP error: Server disconnected ... (reconnecting in 4s)` ~5-6×/hour. Investigation: **cosmetic, self-healing, no message loss** — but noisy. Root cause: the SSE stream shared the adapter's httpx client whose pool uses `keepalive_expiry=2s` (tuned for short RPC calls, #18451). The long-lived stream reused a pooled socket the daemon had already closed → "Server disconnected" → reconnect.

## What
- `sse_httpx_limits()` (`max_keepalive_connections=0`) + a **dedicated** httpx client for the SSE stream, so it never reuses a stale pooled socket.
- Transient reconnects (backoff at initial) now log at **DEBUG**; only escalating backoff (a real outage) logs **WARNING**.
- Both clients are closed on disconnect / failed connect.

## Tests (201 pass)
- SSE limits disable keepalive pooling; helper returns None without httpx.
- Reconnect log level: debug when transient, warning when escalating.
- Failed-connect cleanup closes both clients.

## Note
Takes effect when agents run the new image; the spam is benign until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)