### PR TITLE
fix(vision): cascade local/aux vision to native main model on failure

### DIFF
--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -211,3 +211,76 @@ class TestHandleVisionAnalyzeFastPath:
 
         assert not (isinstance(result, dict) and result.get("_multimodal") is True), \
             "Fast path fired for unknown provider; should have fallen through"
+
+
+# ─── _handle_vision_analyze local→native cascade ─────────────────────────────
+
+
+class TestHandleVisionAnalyzeCascade:
+    """When a local/aux vision model is configured but fails (e.g. an ollama
+    runner that crashes), fall back to the vision-capable main model so the
+    user still gets an answer instead of a 500."""
+
+    def _run(self, img):
+        coro = _handle_vision_analyze({"image_url": str(img), "question": "?"})
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_aux_success_does_not_call_native(self, tmp_path):
+        img = tmp_path / "x.png"; img.write_bytes(_TINY_PNG)
+
+        async def _aux_ok(*a, **k):
+            return '{"success": true, "analysis": "a cat"}'
+
+        async def _native_should_not_run(*a, **k):
+            raise AssertionError("native fallback called despite aux success")
+
+        from agent.auxiliary_client import set_runtime_main, clear_runtime_main
+        set_runtime_main("openrouter", "anthropic/claude-opus-4.6")  # native-capable
+        try:
+            with patch("agent.image_routing.decide_image_input_mode", return_value="describe"), \
+                 patch("tools.vision_tools.vision_analyze_tool", side_effect=_aux_ok), \
+                 patch("tools.vision_tools._vision_analyze_native", side_effect=_native_should_not_run):
+                result = self._run(img)
+        finally:
+            clear_runtime_main()
+        assert json.loads(result)["analysis"] == "a cat"
+
+    def test_aux_failure_cascades_to_native(self, tmp_path):
+        img = tmp_path / "x.png"; img.write_bytes(_TINY_PNG)
+
+        async def _aux_fail(*a, **k):
+            return '{"success": false, "analysis": "Error analyzing image: 500 ollama"}'
+
+        async def _native(*a, **k):
+            return {"_multimodal": True, "content": []}
+
+        from agent.auxiliary_client import set_runtime_main, clear_runtime_main
+        set_runtime_main("openrouter", "anthropic/claude-opus-4.6")  # native-capable
+        try:
+            with patch("agent.image_routing.decide_image_input_mode", return_value="describe"), \
+                 patch("tools.vision_tools.vision_analyze_tool", side_effect=_aux_fail), \
+                 patch("tools.vision_tools._vision_analyze_native", side_effect=_native):
+                result = self._run(img)
+        finally:
+            clear_runtime_main()
+        assert isinstance(result, dict) and result.get("_multimodal") is True
+
+    def test_aux_failure_without_native_returns_aux_error(self, tmp_path):
+        img = tmp_path / "x.png"; img.write_bytes(_TINY_PNG)
+
+        async def _aux_fail(*a, **k):
+            return '{"success": false, "analysis": "Error analyzing image: 500 ollama"}'
+
+        async def _native_should_not_run(*a, **k):
+            raise AssertionError("native fallback called when main model is not vision-capable")
+
+        from agent.auxiliary_client import set_runtime_main, clear_runtime_main
+        set_runtime_main("brand-new-provider", "some-model")  # NOT native-capable
+        try:
+            with patch("agent.image_routing.decide_image_input_mode", return_value="describe"), \
+                 patch("tools.vision_tools.vision_analyze_tool", side_effect=_aux_fail), \
+                 patch("tools.vision_tools._vision_analyze_native", side_effect=_native_should_not_run):
+                result = self._run(img)
+        finally:
+            clear_runtime_main()
+        assert json.loads(result)["success"] is False

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -194,16 +194,18 @@ class TestHandleVisionAnalyze:
         """The full prompt should incorporate the user's question."""
         with patch(
             "tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock
-        ) as mock_tool:
+        ) as mock_tool, patch(
+            "tools.vision_tools._supports_media_in_tool_results", return_value=False
+        ):
             mock_tool.return_value = json.dumps({"result": "ok"})
-            coro = _handle_vision_analyze(
-                {
-                    "image_url": "https://example.com/img.png",
-                    "question": "Describe the cat",
-                }
+            asyncio.get_event_loop().run_until_complete(
+                _handle_vision_analyze(
+                    {
+                        "image_url": "https://example.com/img.png",
+                        "question": "Describe the cat",
+                    }
+                )
             )
-            # Clean up coroutine
-            coro.close()
             call_args = mock_tool.call_args
             full_prompt = call_args[0][1]  # second positional arg
             assert "Describe the cat" in full_prompt
@@ -216,12 +218,14 @@ class TestHandleVisionAnalyze:
                 "tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock
             ) as mock_tool,
             patch.dict(os.environ, {"AUXILIARY_VISION_MODEL": "custom/model-v1"}),
+            patch("tools.vision_tools._supports_media_in_tool_results", return_value=False),
         ):
             mock_tool.return_value = json.dumps({"result": "ok"})
-            coro = _handle_vision_analyze(
-                {"image_url": "https://example.com/img.png", "question": "test"}
+            asyncio.get_event_loop().run_until_complete(
+                _handle_vision_analyze(
+                    {"image_url": "https://example.com/img.png", "question": "test"}
+                )
             )
-            coro.close()
             call_args = mock_tool.call_args
             model = call_args[0][2]  # third positional arg
             assert model == "custom/model-v1"
@@ -233,14 +237,16 @@ class TestHandleVisionAnalyze:
                 "tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock
             ) as mock_tool,
             patch.dict(os.environ, {}, clear=False),
+            patch("tools.vision_tools._supports_media_in_tool_results", return_value=False),
         ):
             # Ensure AUXILIARY_VISION_MODEL is not set
             os.environ.pop("AUXILIARY_VISION_MODEL", None)
             mock_tool.return_value = json.dumps({"result": "ok"})
-            coro = _handle_vision_analyze(
-                {"image_url": "https://example.com/img.png", "question": "test"}
+            asyncio.get_event_loop().run_until_complete(
+                _handle_vision_analyze(
+                    {"image_url": "https://example.com/img.png", "question": "test"}
+                )
             )
-            coro.close()
             call_args = mock_tool.call_args
             model = call_args[0][2]
             # With no AUXILIARY_VISION_MODEL set, model should be None

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1026,15 +1026,32 @@ VISION_ANALYZE_SCHEMA = {
 }
 
 
-def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
+def _vision_result_failed(result: Any) -> bool:
+    """True when a ``vision_analyze_tool`` JSON result signals failure.
+
+    ``vision_analyze_tool`` catches its own errors and returns
+    ``{"success": false, ...}`` rather than raising, so the cascade detects
+    a dead local model by inspecting that flag. Unparseable / non-JSON
+    results are treated as success (don't double-call on an odd shape).
+    """
+    if not isinstance(result, str):
+        return False
+    try:
+        data = json.loads(result)
+    except (ValueError, TypeError):
+        return False
+    return isinstance(data, dict) and data.get("success") is False
+
+
+async def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> str:
     image_url = args.get("image_url", "")
     question = args.get("question", "")
 
-    # Fast path: when the active main model supports native vision AND the
-    # provider supports image content inside tool results, short-circuit
-    # the auxiliary LLM and return the image bytes as a multimodal
-    # tool-result envelope. The main model sees the pixels directly on its
-    # next turn — no aux call, no information loss, no extra latency.
+    # Resolve the active main model once — used for the native fast path AND
+    # as the cascade fallback when a configured local/aux vision model is
+    # unavailable (e.g. an ollama runner that OOMs / crashes on this host).
+    _provider = _model = _mode = None
+    _native_ok = False
     try:
         from agent.auxiliary_client import _read_main_provider, _read_main_model
         from agent.image_routing import decide_image_input_mode
@@ -1044,22 +1061,44 @@ def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
         _model = _read_main_model()
         _cfg = load_config()
         _mode = decide_image_input_mode(_provider, _model, _cfg)
-        if _mode == "native" and _supports_media_in_tool_results(_provider, _model):
-            logger.info(
-                "vision_analyze: native fast path (provider=%s, model=%s)",
-                _provider, _model,
-            )
-            return _vision_analyze_native(image_url, question)
+        _native_ok = _supports_media_in_tool_results(_provider, _model)
     except Exception as exc:
-        logger.debug("Native vision fast-path check failed; using aux LLM: %s", exc)
+        logger.debug("Vision routing check failed: %s", exc)
 
-    # Legacy path: aux LLM describes the image and we return its text.
+    # Fast path: no aux vision model configured and the main model reads
+    # images natively — hand the pixels straight to it (no aux call, no
+    # information loss, no extra latency).
+    if _mode == "native" and _native_ok:
+        logger.info(
+            "vision_analyze: native fast path (provider=%s, model=%s)",
+            _provider, _model,
+        )
+        return await _vision_analyze_native(image_url, question)
+
+    # Local/aux first, then cascade to the native main model on failure.
+    # A configured local model (e.g. minicpm-v via ollama) is tried first to
+    # keep vision cheap and private; if it errors (model-runner crash,
+    # timeout, connection refused) we fall back to the vision-capable main
+    # model so the user still gets an answer instead of a cryptic 500.
     full_prompt = (
         "Fully describe and explain everything about this image, then answer the "
         f"following question:\n\n{question}"
     )
     model = os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
-    return vision_analyze_tool(image_url, full_prompt, model)
+    result = await vision_analyze_tool(image_url, full_prompt, model)
+
+    if not _native_ok or not _vision_result_failed(result):
+        return result
+
+    logger.warning(
+        "vision_analyze: local/aux vision failed; cascading to native main "
+        "model (provider=%s, model=%s)", _provider, _model,
+    )
+    try:
+        return await _vision_analyze_native(image_url, question)
+    except Exception as exc:
+        logger.error("vision_analyze: native fallback also failed: %s", exc)
+        return result
 
 
 registry.register(


### PR DESCRIPTION
## Summary

Image attachments silently failed across the fleet: the configured **local vision model (minicpm-v via ollama)** crashes on the host (`model runner has unexpectedly stopped` — resource limits), and `vision_analyze` had **no fallback**, so the agent received no image and replied *"I don't see an attachment."* (Confirmed live: receive/fetch works; only the vision model was dying.)

`_handle_vision_analyze` now implements a **local→native cascade**:
- No aux model configured → native fast path (unchanged).
- Aux/local model configured → try it **first** (cheap, private); if it returns a failure envelope, **cascade to the vision-capable main model** (e.g. Claude Sonnet 4.5) so the user still gets an answer.

Config keeps `auxiliary.vision: minicpm-v` as the default — **the fallback lives in code**, so it applies to every agent on rebuild with no per-agent config change (and nothing new for the HSM wizard to set).

The handler became `async` so it can await the aux call, inspect the result, and await the native fallback. `_vision_result_failed()` detects the `{"success": false}` envelope `vision_analyze_tool` returns (it catches its own errors instead of raising).

**Voice** transcription already defaults to local faster-whisper (in-process, doesn't touch ollama), so it was unaffected and is left as-is.

## Tests
- New cascade tests: aux-success short-circuits (native not called); aux-failure cascades to native; aux-failure with a non-vision main model returns the aux error (no spurious native call).
- Updated 3 existing tests for the now-async handler.
- Full vision suite: **85 passed, 6 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
