### PR TITLE
fix(signal): classify PDF/document attachments as DOCUMENT so the agent sees them

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -791,6 +791,13 @@ class SignalAdapter(BasePlatformAdapter):
                 msg_type = MessageType.VOICE
             elif any(mt.startswith("image/") for mt in media_types):
                 msg_type = MessageType.PHOTO
+            else:
+                # Any other successfully-fetched attachment (PDF, docx, txt, …)
+                # is a document. Without this, run.py's document handler (which
+                # is gated on MessageType.DOCUMENT) never fires, so the file is
+                # downloaded but never surfaced to the agent — the user sends a
+                # PDF and the bot reports "I don't see an attachment".
+                msg_type = MessageType.DOCUMENT
 
         # Parse timestamp from envelope data (milliseconds since epoch)
         ts_ms = envelope_data.get("timestamp", 0)

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch, AsyncMock
 from urllib.parse import quote
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageType
 
 
 @pytest.fixture(autouse=True)
@@ -2026,6 +2027,58 @@ class TestObserveOnlyReactionSuppression:
         await adapter.on_processing_start(event)
 
         adapter.send_reaction.assert_called_once()
+
+
+class TestSignalMessageTypeClassification:
+    """Inbound attachments must be classified so run.py surfaces them.
+
+    Regression: a PDF arrived with media_urls populated but message_type=TEXT,
+    so run.py's document handler (gated on MessageType.DOCUMENT) never fired and
+    the bot reported 'I don't see a PDF'."""
+
+    async def _capture(self, monkeypatch, content_type, ext):
+        adapter = _make_signal_adapter(monkeypatch)
+        captured = {}
+
+        async def fake_handle(event):
+            captured["event"] = event
+        adapter.handle_message = fake_handle
+
+        async def fake_fetch(att_id):
+            return (f"/opt/data/cache/documents/file{ext}", ext)
+        adapter._fetch_attachment = fake_fetch
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+15550001111",
+                "sourceUuid": "uuid-sender",
+                "sourceName": "Tester",
+                "timestamp": 1000000000,
+                "dataMessage": {
+                    "message": "see attached",
+                    "attachments": [
+                        {"id": "abc", "contentType": content_type, "size": 1000, "filename": f"f{ext}"}
+                    ],
+                },
+            }
+        })
+        return captured["event"]
+
+    @pytest.mark.asyncio
+    async def test_pdf_classified_as_document(self, monkeypatch):
+        event = await self._capture(monkeypatch, "application/pdf", ".pdf")
+        assert event.message_type == MessageType.DOCUMENT
+        assert any(p.endswith(".pdf") for p in event.media_urls)
+
+    @pytest.mark.asyncio
+    async def test_image_still_classified_as_photo(self, monkeypatch):
+        event = await self._capture(monkeypatch, "image/jpeg", ".jpg")
+        assert event.message_type == MessageType.PHOTO
+
+    @pytest.mark.asyncio
+    async def test_audio_still_classified_as_voice(self, monkeypatch):
+        event = await self._capture(monkeypatch, "audio/ogg", ".ogg")
+        assert event.message_type == MessageType.VOICE
 
 
 class TestAttachmentArg:


### PR DESCRIPTION
PDFs were fetched but never surfaced: the Signal adapter set message_type to VOICE/PHOTO/TEXT but never DOCUMENT, and run.py gates document handling on MessageType.DOCUMENT. So a PDF arrived with media_urls populated but message_type=TEXT and the bot said "I dont see a PDF". Fix: classify any non-image/non-audio fetched attachment as DOCUMENT; run.py then injects the document context note (agent reads via ocr-and-documents/pymupdf). Tests: PDF→DOCUMENT, image→PHOTO, audio→VOICE; full signal suite 120 passed. 🤖 Generated with [Claude Code](https://claude.com/claude-code)