### PR TITLE
test(vision): fix unawaited _handle_vision_analyze in auxiliary-bridge tests (restore green CI)

### DIFF
--- a/tests/agent/test_auxiliary_config_bridge.py
+++ b/tests/agent/test_auxiliary_config_bridge.py
@@ -4,11 +4,12 @@ are properly mapped to environment variables by both CLI and gateway loaders.
 Also tests the vision_tools and browser_tool model override env vars.
 """
 
+import asyncio
 import json
 import os
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
 import yaml
@@ -244,9 +245,13 @@ class TestVisionModelOverride:
     def test_env_var_overrides_default(self, monkeypatch):
         monkeypatch.setenv("AUXILIARY_VISION_MODEL", "openai/gpt-4o")
         from tools.vision_tools import _handle_vision_analyze
-        with patch("tools.vision_tools.vision_analyze_tool", new_callable=MagicMock) as mock_tool:
+        # Force the aux path (no native fast-path / cascade) and await the now-async handler.
+        with patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock) as mock_tool, \
+             patch("tools.vision_tools._supports_media_in_tool_results", return_value=False):
             mock_tool.return_value = '{"success": true}'
-            _handle_vision_analyze({"image_url": "http://test.jpg", "question": "test"})
+            asyncio.get_event_loop().run_until_complete(
+                _handle_vision_analyze({"image_url": "http://test.jpg", "question": "test"})
+            )
             call_args = mock_tool.call_args
             # 3rd positional arg = model
             assert call_args[0][2] == "openai/gpt-4o"
@@ -254,9 +259,12 @@ class TestVisionModelOverride:
     def test_default_model_when_no_override(self, monkeypatch):
         monkeypatch.delenv("AUXILIARY_VISION_MODEL", raising=False)
         from tools.vision_tools import _handle_vision_analyze
-        with patch("tools.vision_tools.vision_analyze_tool", new_callable=MagicMock) as mock_tool:
+        with patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock) as mock_tool, \
+             patch("tools.vision_tools._supports_media_in_tool_results", return_value=False):
             mock_tool.return_value = '{"success": true}'
-            _handle_vision_analyze({"image_url": "http://test.jpg", "question": "test"})
+            asyncio.get_event_loop().run_until_complete(
+                _handle_vision_analyze({"image_url": "http://test.jpg", "question": "test"})
+            )
             call_args = mock_tool.call_args
             # With no AUXILIARY_VISION_MODEL env var, model should be None
             # (the centralized call_llm router picks the provider default)


### PR DESCRIPTION
PR #19 made _handle_vision_analyze async; two tests in test_auxiliary_config_bridge.py still called it unawaited and inspected call_args (None -> TypeError), reddening tests.yml on main (4790 passed, 2 failed). Await + AsyncMock + force aux path. 19 passed. Restores green CI. 🤖 Generated with [Claude Code](https://claude.com/claude-code)