### PR TITLE
Provision agent git credentials in the runtime, not HSM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,6 +187,7 @@ RUN mkdir -p /etc/cont-init.d && \
     chmod +x /etc/cont-init.d/01-hermes-setup
 COPY --chmod=0755 docker/cont-init.d/015-supervise-perms /etc/cont-init.d/015-supervise-perms
 COPY --chmod=0755 docker/cont-init.d/02-reconcile-profiles /etc/cont-init.d/02-reconcile-profiles
+COPY --chmod=0755 docker/cont-init.d/03-provision-git-credentials /etc/cont-init.d/03-provision-git-credentials
 
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist

--- a/docker/cont-init.d/03-provision-git-credentials
+++ b/docker/cont-init.d/03-provision-git-credentials
@@ -1,0 +1,27 @@
+#!/command/with-contenv sh
+# shellcheck shell=sh
+# Container-boot provisioning of per-agent git credentials.
+#
+# Runs as root after 01-hermes-setup (the stage2 hook) has chowned the
+# volume and seeded $HERMES_HOME, and after 02-reconcile-profiles, but
+# before s6-rc starts user services. /etc/cont-init.d/* scripts run in
+# lexicographic order, so the `03-` prefix guarantees ordering.
+#
+# Each agent runs `git` in a tool subprocess whose HOME is overridden to
+# {HERMES_HOME}/home (see tools/environments/local.py +
+# hermes_constants.get_subprocess_home). Provider secrets — including
+# GITHUB_TOKEN — are deliberately blocklisted from that subprocess env, so
+# the agent can't read its own token to set up git auth from the inside.
+# This step reads the token from the agent's .env (readable here on the
+# persistent volume) and writes git's `store` credential file +
+# {HERMES_HOME}/home/.gitconfig so HTTPS GitHub auth just works. Walks the
+# default profile (HERMES_HOME root) and every named profile under
+# {HERMES_HOME}/profiles/. Inert when no GitHub token is configured;
+# apply-if-absent, so it never clobbers a user's existing git setup.
+#
+# Runs as the hermes user so the credential files are owned by the same
+# UID the tool subprocess runs under (UID 10000), and the token-bearing
+# .git-credentials is created 0600 by that user — never root-owned.
+set -e
+
+exec s6-setuidgid hermes /opt/hermes/.venv/bin/python -m hermes_cli.git_credentials_boot

--- a/hermes_cli/git_credentials_boot.py
+++ b/hermes_cli/git_credentials_boot.py
@@ -160,8 +160,14 @@ def provision_all(hermes_home: Path) -> list[ProvisionResult]:
 
     Mirrors ``container_boot``'s model: the HERMES_HOME root is the implicit
     default profile, and named profiles live under ``{HERMES_HOME}/profiles/<name>/``.
+
+    The root's basename is uninformative in production (``/opt/data`` → "data"),
+    so the git identity for the default profile comes from ``HERMES_AGENT_NAME``
+    when set — commits are authored as the agent, not "data". A named profile is
+    its own agent and is identified by its profile directory name.
     """
-    results = [provision_git_credentials(hermes_home)]
+    root_name = os.environ.get("HERMES_AGENT_NAME") or None
+    results = [provision_git_credentials(hermes_home, name=root_name)]
     profiles_dir = hermes_home / "profiles"
     if profiles_dir.is_dir():
         for profile in sorted(p for p in profiles_dir.iterdir() if p.is_dir()):

--- a/hermes_cli/git_credentials_boot.py
+++ b/hermes_cli/git_credentials_boot.py
@@ -1,0 +1,186 @@
+"""Boot-time provisioning of per-agent git credentials.
+
+This is the runtime-side port of HSM's ``lib/services/git-credentials.ts``.
+It moves "make the agent's own GitHub token usable by git" out of the
+swarm-manager and into the agent runtime, where it belongs:
+
+  * The tool subprocess (where the agent runs ``git``) deliberately CANNOT
+    see ``GITHUB_TOKEN`` — provider secrets are blocklisted from the
+    subprocess env (``tools/environments/local.py`` /
+    ``hermes_cli/auth.py``). So a credential file is the only path, and the
+    skill that runs *inside* the subprocess can't read the raw token to
+    write one.
+  * This module runs in-process at container boot (a cont-init.d step),
+    where the agent's ``.env`` is readable on the mounted volume and
+    ``get_subprocess_home()`` (``{HERMES_HOME}/home``) is known directly.
+
+It writes the agent's OWN token (from its ``.env``) into
+``{HERMES_HOME}/home/.git-credentials`` + ``.gitconfig`` so git's ``store``
+helper picks it up. Tokens never cross-pollinate — each home reads only its
+own ``.env``. Creating ``{HERMES_HOME}/home`` is also what activates the
+tool subprocess's HOME override (see ``get_subprocess_home``).
+
+Mirrors ``container_boot.py``: a pure, per-home function plus a profile-aware
+``provision_all`` and a ``main()`` entry point wired into the image as a
+cont-init.d hook. No HSM dependence on a runtime-internal path — the runtime
+owns the path now.
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+GIT_HOST = "github.com"
+
+# Checked in order; a dedicated GITHUB_PAT wins over the copilot GITHUB_TOKEN.
+TOKEN_VARS = ("GITHUB_PAT", "GITHUB_TOKEN", "GH_TOKEN")
+
+
+# ---------------------------------------------------------------------------
+# Pure content builders
+# ---------------------------------------------------------------------------
+
+
+def build_git_credentials_content(token: str) -> str:
+    """The ``~/.git-credentials`` line the ``store`` helper reads for HTTPS."""
+    return f"https://x-access-token:{token}@{GIT_HOST}\n"
+
+
+def build_git_config_content(*, name: str, email: str) -> str:
+    """Minimal ``~/.gitconfig``: store helper + identity + ssh→https rewrites."""
+    return "\n".join(
+        [
+            "[credential]",
+            "\thelper = store",
+            "[user]",
+            f"\tname = {name}",
+            f"\temail = {email}",
+            f'[url "https://{GIT_HOST}/"]',
+            f"\tinsteadOf = git@{GIT_HOST}:",
+            f"\tinsteadOf = ssh://git@{GIT_HOST}/",
+            "",
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# .env token extraction
+# ---------------------------------------------------------------------------
+
+
+def _read_env_token(env_path: Path) -> Optional[tuple[str, str]]:
+    """Return ``(token, source_var)`` from ``env_path`` or ``None``.
+
+    Reads a flat ``.env`` file (no shell expansion). The first non-empty
+    match across ``TOKEN_VARS`` (in precedence order) wins.
+    """
+    try:
+        content = env_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    for key in TOKEN_VARS:
+        m = re.search(rf"^{re.escape(key)}=(.*)$", content, re.MULTILINE)
+        if m:
+            val = re.sub(r'^["\']|["\']$', "", m.group(1).strip())
+            if val:
+                return val, key
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Provisioning
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProvisionResult:
+    home: Path
+    provisioned: bool
+    reason: Optional[str] = None
+    source: Optional[str] = None
+
+
+def provision_git_credentials(
+    home_dir: Path,
+    *,
+    name: Optional[str] = None,
+    email: Optional[str] = None,
+    force: bool = False,
+) -> ProvisionResult:
+    """Provision git auth for one agent home from its own ``.env`` token.
+
+    ``home_dir`` is a HERMES_HOME-shaped directory: it holds ``.env`` at the
+    root and the tool subprocess HOME at ``{home_dir}/home``. Idempotent;
+    a no-op (``provisioned=False``) when no token is configured.
+
+    Apply-if-absent: never clobbers an existing ``.git-credentials`` /
+    ``.gitconfig`` (e.g. an imported agent's own setup) unless ``force``.
+    """
+    found = _read_env_token(home_dir / ".env")
+    if found is None:
+        return ProvisionResult(home_dir, False, reason="no GitHub token configured")
+    token, source = found
+
+    subprocess_home = home_dir / "home"
+    cred_path = subprocess_home / ".git-credentials"
+    cfg_path = subprocess_home / ".gitconfig"
+
+    if not force and (cred_path.exists() or cfg_path.exists()):
+        return ProvisionResult(
+            home_dir,
+            False,
+            reason="git config already present (pass force to overwrite)",
+            source=source,
+        )
+
+    resolved_name = name or home_dir.name
+    resolved_email = email or f"{resolved_name}@users.noreply.github.com"
+
+    subprocess_home.mkdir(parents=True, exist_ok=True)
+    _write_file(cred_path, build_git_credentials_content(token), mode=0o600)
+    _write_file(
+        cfg_path,
+        build_git_config_content(name=resolved_name, email=resolved_email),
+        mode=0o644,
+    )
+    return ProvisionResult(home_dir, True, source=source)
+
+
+def _write_file(path: Path, content: str, *, mode: int) -> None:
+    """Write ``content`` then force ``mode`` (umask-independent)."""
+    path.write_text(content, encoding="utf-8")
+    os.chmod(path, mode)
+
+
+def provision_all(hermes_home: Path) -> list[ProvisionResult]:
+    """Provision the default profile (HERMES_HOME root) + each named profile.
+
+    Mirrors ``container_boot``'s model: the HERMES_HOME root is the implicit
+    default profile, and named profiles live under ``{HERMES_HOME}/profiles/<name>/``.
+    """
+    results = [provision_git_credentials(hermes_home)]
+    profiles_dir = hermes_home / "profiles"
+    if profiles_dir.is_dir():
+        for profile in sorted(p for p in profiles_dir.iterdir() if p.is_dir()):
+            results.append(provision_git_credentials(profile))
+    return results
+
+
+def main() -> int:
+    """Entry point invoked from /etc/cont-init.d/03-provision-git-credentials."""
+    hermes_home = Path(os.environ.get("HERMES_HOME", "/opt/data"))
+    for r in provision_all(hermes_home):
+        status = (
+            f"provisioned (source={r.source})"
+            if r.provisioned
+            else f"skipped ({r.reason})"
+        )
+        print(f"git-credentials: home={r.home} {status}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -215,13 +215,33 @@ grep "github.com" ~/.git-credentials 2>/dev/null | head -1 | sed 's|https://[^:]
 Use this pattern at the start of any GitHub workflow:
 
 ```bash
-# Try gh first, fall back to git + curl
+# Try gh first, fall back to git + curl.
+#
+# The agent's .env lives at ${HERMES_HOME}/.env — NOT ~/.hermes/.env. In a
+# tool subprocess HOME is redirected to ${HERMES_HOME}/home (so git/ssh/gh
+# write their configs into the data dir), which means ~ no longer points at
+# ${HERMES_HOME}. Always resolve the .env via $HERMES_HOME, falling back to
+# ~/.hermes only when it isn't set. Token vars are checked in the same
+# precedence the runtime provisions with: GITHUB_PAT > GITHUB_TOKEN > GH_TOKEN.
+HERMES_ENV="${HERMES_HOME:-$HOME/.hermes}/.env"
+# Read the first present token var, in precedence order (not .env line order).
+hermes_env_token() {
+  [ -f "$HERMES_ENV" ] || return 1
+  for _v in GITHUB_PAT GITHUB_TOKEN GH_TOKEN; do
+    _line=$(grep -E "^${_v}=" "$HERMES_ENV" | head -1)
+    if [ -n "$_line" ]; then
+      printf '%s' "$_line" | cut -d= -f2- | tr -d '\n\r' | sed 's/^["'\'']//;s/["'\'']$//'
+      return 0
+    fi
+  done
+  return 1
+}
 if command -v gh &>/dev/null && gh auth status &>/dev/null; then
   echo "AUTH_METHOD=gh"
 elif [ -n "$GITHUB_TOKEN" ]; then
   echo "AUTH_METHOD=curl"
-elif [ -f ~/.hermes/.env ] && grep -q "^GITHUB_TOKEN=" ~/.hermes/.env; then
-  export GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" ~/.hermes/.env | head -1 | cut -d= -f2 | tr -d '\n\r')
+elif _tok=$(hermes_env_token) && [ -n "$_tok" ]; then
+  export GITHUB_TOKEN="$_tok"
   echo "AUTH_METHOD=curl"
 elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
   export GITHUB_TOKEN=$(grep "github.com" ~/.git-credentials | head -1 | sed 's|https://[^:]*:\([^@]*\)@.*|\1|')
@@ -231,6 +251,11 @@ else
   echo "Need to set up authentication first"
 fi
 ```
+
+> **Note:** in a Hermes container the runtime already provisions
+> `${HERMES_HOME}/home/.git-credentials` at boot (the `store` helper reads it
+> automatically), so `git` push/pull/clone over HTTPS works without any of the
+> above. This fallback is for the `curl` API path and for non-container setups.
 
 ---
 

--- a/tests/hermes_cli/test_git_credentials_boot.py
+++ b/tests/hermes_cli/test_git_credentials_boot.py
@@ -1,0 +1,216 @@
+"""Tests for hermes_cli.git_credentials_boot — boot-time provisioning of
+per-agent git credentials from the agent's own configured GitHub token.
+
+This is the runtime-side port of HSM's lib/services/git-credentials.ts.
+It runs in-process at container boot (a cont-init.d step), where the agent's
+.env is readable on the mounted volume and HERMES_HOME / get_subprocess_home()
+are known directly — unlike the tool subprocess, which cannot see the token
+(GITHUB_TOKEN is blocklisted from the subprocess env by design).
+
+Tests run against a fake $HERMES_HOME under tmp_path. No container, no git.
+"""
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.git_credentials_boot import (
+    build_git_config_content,
+    build_git_credentials_content,
+    provision_all,
+    provision_git_credentials,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_env(home: Path, body: str) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text(body)
+
+
+def _cred_path(home: Path) -> Path:
+    return home / "home" / ".git-credentials"
+
+
+def _cfg_path(home: Path) -> Path:
+    return home / "home" / ".gitconfig"
+
+
+def _mode(p: Path) -> int:
+    return stat.S_IMODE(p.stat().st_mode)
+
+
+# ---------------------------------------------------------------------------
+# Pure content builders
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_content_uses_x_access_token_https_line():
+    assert build_git_credentials_content("ghp_abc") == (
+        "https://x-access-token:ghp_abc@github.com\n"
+    )
+
+
+def test_config_content_has_store_helper_identity_and_insteadof():
+    cfg = build_git_config_content(name="cyborg", email="cyborg@users.noreply.github.com")
+    assert "helper = store" in cfg
+    assert "name = cyborg" in cfg
+    assert "email = cyborg@users.noreply.github.com" in cfg
+    # ssh-style remotes get rewritten through HTTPS so the agent doesn't die on
+    # "Host key verification failed" when it reaches for an SSH URL.
+    assert 'insteadOf = git@github.com:' in cfg
+    assert 'insteadOf = ssh://git@github.com/' in cfg
+
+
+# ---------------------------------------------------------------------------
+# provision_git_credentials — single home
+# ---------------------------------------------------------------------------
+
+
+def test_writes_credentials_and_config_from_env_token(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=ghp_secret\n")
+
+    result = provision_git_credentials(tmp_path)
+
+    assert result.provisioned is True
+    assert result.source == "GITHUB_PAT"
+    assert _cred_path(tmp_path).read_text() == "https://x-access-token:ghp_secret@github.com\n"
+    assert "helper = store" in _cfg_path(tmp_path).read_text()
+
+
+def test_credentials_file_is_chmod_600(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=ghp_secret\n")
+    provision_git_credentials(tmp_path)
+    assert _mode(_cred_path(tmp_path)) == 0o600
+
+
+def test_config_file_is_chmod_644(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=ghp_secret\n")
+    provision_git_credentials(tmp_path)
+    assert _mode(_cfg_path(tmp_path)) == 0o644
+
+
+def test_token_precedence_pat_beats_github_token_beats_gh_token(tmp_path):
+    _write_env(tmp_path, "GH_TOKEN=gh_v\nGITHUB_TOKEN=ght_v\nGITHUB_PAT=pat_v\n")
+    result = provision_git_credentials(tmp_path)
+    assert result.source == "GITHUB_PAT"
+    assert "pat_v" in _cred_path(tmp_path).read_text()
+
+
+def test_falls_back_to_gh_token_when_only_one_present(tmp_path):
+    _write_env(tmp_path, "GH_TOKEN=gh_only\n")
+    result = provision_git_credentials(tmp_path)
+    assert result.source == "GH_TOKEN"
+    assert "gh_only" in _cred_path(tmp_path).read_text()
+
+
+def test_strips_quotes_and_whitespace_from_token(tmp_path):
+    _write_env(tmp_path, 'GITHUB_PAT="ghp_quoted"  \n')
+    provision_git_credentials(tmp_path)
+    assert _cred_path(tmp_path).read_text() == "https://x-access-token:ghp_quoted@github.com\n"
+
+
+def test_no_token_is_inert(tmp_path):
+    _write_env(tmp_path, "OPENAI_API_KEY=sk-whatever\n")
+    result = provision_git_credentials(tmp_path)
+    assert result.provisioned is False
+    assert result.reason == "no GitHub token configured"
+    assert not _cred_path(tmp_path).exists()
+    assert not (tmp_path / "home").exists()
+
+
+def test_missing_env_is_inert(tmp_path):
+    result = provision_git_credentials(tmp_path)
+    assert result.provisioned is False
+    assert not _cred_path(tmp_path).exists()
+
+
+def test_empty_token_value_is_inert(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=\n")
+    result = provision_git_credentials(tmp_path)
+    assert result.provisioned is False
+
+
+# ---------------------------------------------------------------------------
+# Apply-if-absent (the data-loss guard from HSM PR #53)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_if_absent_does_not_clobber_existing_credentials(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=ghp_new\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".git-credentials").write_text("PRE-EXISTING\n")
+
+    result = provision_git_credentials(tmp_path)
+
+    assert result.provisioned is False
+    assert "already present" in (result.reason or "")
+    assert (home / ".git-credentials").read_text() == "PRE-EXISTING\n"
+
+
+def test_apply_if_absent_does_not_clobber_existing_gitconfig(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=ghp_new\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".gitconfig").write_text("[user]\n\tname = human\n")
+
+    result = provision_git_credentials(tmp_path)
+
+    assert result.provisioned is False
+    assert (home / ".gitconfig").read_text() == "[user]\n\tname = human\n"
+
+
+def test_force_overwrites_existing(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=ghp_new\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".git-credentials").write_text("PRE-EXISTING\n")
+
+    result = provision_git_credentials(tmp_path, force=True)
+
+    assert result.provisioned is True
+    assert "ghp_new" in (home / ".git-credentials").read_text()
+
+
+# ---------------------------------------------------------------------------
+# provision_all — HERMES_HOME root (default profile) + named profiles
+# ---------------------------------------------------------------------------
+
+
+def test_provision_all_does_root_and_each_named_profile(tmp_path):
+    # Default profile = HERMES_HOME root.
+    _write_env(tmp_path, "GITHUB_PAT=root_tok\n")
+    # Named profiles live under profiles/<name>/, each with its own .env.
+    _write_env(tmp_path / "profiles" / "cyborg", "GITHUB_PAT=cyborg_tok\n")
+    _write_env(tmp_path / "profiles" / "osint", "GH_TOKEN=osint_tok\n")
+
+    results = provision_all(tmp_path)
+
+    provisioned = {r.home: r for r in results if r.provisioned}
+    assert tmp_path in provisioned
+    assert (tmp_path / "profiles" / "cyborg") in provisioned
+    assert (tmp_path / "profiles" / "osint") in provisioned
+    assert "root_tok" in _cred_path(tmp_path).read_text()
+    assert "cyborg_tok" in _cred_path(tmp_path / "profiles" / "cyborg").read_text()
+    assert "osint_tok" in _cred_path(tmp_path / "profiles" / "osint").read_text()
+
+
+def test_provision_all_skips_profile_without_token(tmp_path):
+    _write_env(tmp_path / "profiles" / "notoken", "OPENAI_API_KEY=sk-x\n")
+    results = provision_all(tmp_path)
+    notoken = tmp_path / "profiles" / "notoken"
+    assert all(not r.provisioned for r in results if r.home == notoken)
+    assert not _cred_path(notoken).exists()
+
+
+def test_provision_all_handles_no_profiles_dir(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=root_tok\n")
+    results = provision_all(tmp_path)
+    assert any(r.provisioned and r.home == tmp_path for r in results)

--- a/tests/hermes_cli/test_git_credentials_boot.py
+++ b/tests/hermes_cli/test_git_credentials_boot.py
@@ -214,3 +214,30 @@ def test_provision_all_handles_no_profiles_dir(tmp_path):
     _write_env(tmp_path, "GITHUB_PAT=root_tok\n")
     results = provision_all(tmp_path)
     assert any(r.provisioned and r.home == tmp_path for r in results)
+
+
+def test_provision_all_uses_hermes_agent_name_for_root_identity(tmp_path, monkeypatch):
+    # The default profile (HERMES_HOME root) basename is "data" in production
+    # (/opt/data); HERMES_AGENT_NAME carries the real agent name, so commits
+    # are authored as the agent, not "data". (HSM parity.)
+    monkeypatch.setenv("HERMES_AGENT_NAME", "cryptids")
+    _write_env(tmp_path, "GITHUB_PAT=root_tok\n")
+
+    provision_all(tmp_path)
+
+    cfg = _cfg_path(tmp_path).read_text()
+    assert "name = cryptids" in cfg
+    assert "email = cryptids@users.noreply.github.com" in cfg
+
+
+def test_provision_all_profile_identity_uses_profile_name_not_env(tmp_path, monkeypatch):
+    # A named profile is its own agent — its identity is the profile name,
+    # never the container-level HERMES_AGENT_NAME.
+    monkeypatch.setenv("HERMES_AGENT_NAME", "rootname")
+    _write_env(tmp_path / "profiles" / "osint", "GITHUB_PAT=tok\n")
+
+    provision_all(tmp_path)
+
+    cfg = _cfg_path(tmp_path / "profiles" / "osint").read_text()
+    assert "name = osint" in cfg
+    assert "name = rootname" not in cfg


### PR DESCRIPTION
## What

Moves per-agent GitHub credential provisioning out of the swarm manager (HSM's `lib/services/git-credentials.ts`) and into the agent runtime, where the secret is actually reachable.

The tool subprocess that runs `git` deliberately can't see `GITHUB_TOKEN` (provider secrets are blocklisted from its env), and its `HOME` is redirected to `{HERMES_HOME}/home`. So a skill running *inside* the subprocess can neither read the token nor reliably find the agent's `.env`. HSM worked around this by reaching into `{dataDir}/home` from the outside — coupling HSM to a runtime-internal path and only ever handling GitHub.

This runs **in-process at container boot** (a `cont-init.d` step), where the `.env` is readable and `get_subprocess_home()` is known directly.

## Changes

- **`hermes_cli/git_credentials_boot.py`** — reads the agent's own `.env` token (`GITHUB_PAT > GITHUB_TOKEN > GH_TOKEN`), writes `{HERMES_HOME}/home/.git-credentials` (0600) + `.gitconfig` (0644) so git's `store` helper picks it up. Profile-aware (default profile = `HERMES_HOME` root, plus each `{HERMES_HOME}/profiles/<name>/`). Inert when no token; **apply-if-absent** so it never clobbers an existing git setup. 19 unit tests.
- **`docker/cont-init.d/03-provision-git-credentials`** + Dockerfile COPY — runs as the `hermes` user at boot, after `02-reconcile-profiles`.
- Root git identity uses **`HERMES_AGENT_NAME`** (avoids authoring commits as `data <data@…>`; HSM parity).
- **`skills/github/github-auth`** — fixed the auth-detection helper: it read `~/.hermes/.env`, which resolves wrong once HOME is redirected. Now `$HERMES_HOME`-aware and precedence-correct, with a note that the runtime auto-provisions.

Shared by hermes-agent and the multi-tenant fork (same `get_subprocess_home`), so no HSM dependence on a runtime-owned path. Lets HSM's provisioning later slim to a thin convenience instead of a second source of truth.

## Verification (real container, not just unit tests)

Built a throwaway image from this branch on the deploy host and booted it:
- s6 fires `03-provision-git-credentials` at boot → `exited 0` → provisioned as UID 10000
- `git credential fill` for github.com returns `username=x-access-token` + the token — **end-to-end HTTPS auth**
- apply-if-absent leaves a copy of a live agent's real data **byte-unchanged** (no clobber)
- hook file present `-rwxr-xr-x`, ordered after `02`; module imports under the image's Python 3.13

## Rollout

Live agents pick this up on their next `rebuild`. Until then HSM's provisioning keeps them working — both produce **byte-identical** files, so no flag day. Follow-ups (separate): slim HSM's provisioning once all forks boot the hook; add `gh` to the base image + a shallow-clone default; generalize beyond git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)