### PR TITLE
Ship gh CLI in the base image; default agents to shallow clones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,22 @@ RUN apt-get update && \
     build-essential curl nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
+# GitHub CLI (`gh`) — not in Debian's repos, so we add GitHub's own signed apt
+# repo. The github-* skills prefer `gh` and only fall back to git+curl when it's
+# absent; shipping it makes the richer paths (PRs, issues, releases) work out of
+# the box. Arch-aware via `dpkg --print-architecture` (image builds amd64+arm64).
+# Kept as its own layer so the larger base apt layer above stays cached when the
+# gh repo metadata changes. The keyring gives signature verification.
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
 # ---------- s6-overlay install ----------
 # s6-overlay provides supervision for the main hermes process, the dashboard,
 # and per-profile gateways. /init becomes PID 1 below — see ENTRYPOINT.

--- a/skills/github/github-repo-management/SKILL.md
+++ b/skills/github/github-repo-management/SKILL.md
@@ -27,9 +27,17 @@ if command -v gh &>/dev/null && gh auth status &>/dev/null; then
 else
   AUTH="git"
   if [ -z "$GITHUB_TOKEN" ]; then
-    if [ -f ~/.hermes/.env ] && grep -q "^GITHUB_TOKEN=" ~/.hermes/.env; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" ~/.hermes/.env | head -1 | cut -d= -f2 | tr -d '\n\r')
-    elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
+    # The agent's .env is at ${HERMES_HOME}/.env — NOT ~/.hermes/.env (HOME is
+    # redirected to ${HERMES_HOME}/home in the tool subprocess). Resolve via
+    # $HERMES_HOME, honoring precedence GITHUB_PAT > GITHUB_TOKEN > GH_TOKEN.
+    HERMES_ENV="${HERMES_HOME:-$HOME/.hermes}/.env"
+    if [ -f "$HERMES_ENV" ]; then
+      for _v in GITHUB_PAT GITHUB_TOKEN GH_TOKEN; do
+        _l=$(grep -E "^${_v}=" "$HERMES_ENV" | head -1)
+        [ -n "$_l" ] && { GITHUB_TOKEN=$(printf '%s' "$_l" | cut -d= -f2- | tr -d '\n\r' | sed 's/^["'\'']//;s/["'\'']$//'); break; }
+      done
+    fi
+    if [ -z "$GITHUB_TOKEN" ] && grep -q "github.com" ~/.git-credentials 2>/dev/null; then
       GITHUB_TOKEN=$(grep "github.com" ~/.git-credentials 2>/dev/null | head -1 | sed 's|https://[^:]*:\([^@]*\)@.*|\1|')
     fi
   fi
@@ -56,17 +64,27 @@ REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
 
 ## 1. Cloning Repositories
 
-Cloning is pure `git` — works identically either way:
+Cloning is pure `git` — works identically either way.
+
+**Default to a shallow clone (`--depth 1`).** A full clone of a large repo can take
+minutes (and time out in the tool sandbox); `--depth 1` is typically a couple of
+seconds and is all you need to read, edit, branch, and push. Only do a full clone
+when you genuinely need history (e.g. `git log`, `git blame`, `git bisect`, or
+rebasing onto an old base) — and you can deepen a shallow clone later with
+`git fetch --unshallow`.
 
 ```bash
-# Clone via HTTPS (works with credential helper or token-embedded URL)
+# Default: shallow clone (fast — prefer this)
+git clone --depth 1 https://github.com/owner/repo-name.git
+
+# Shallow clone into a specific directory
+git clone --depth 1 https://github.com/owner/repo-name.git ./my-local-dir
+
+# Full clone (only when you need history — slower, can time out on big repos)
 git clone https://github.com/owner/repo-name.git
 
-# Clone into a specific directory
-git clone https://github.com/owner/repo-name.git ./my-local-dir
-
-# Shallow clone (faster for large repos)
-git clone --depth 1 https://github.com/owner/repo-name.git
+# Need history after a shallow clone? Deepen it in place:
+#   git fetch --unshallow
 
 # Clone a specific branch
 git clone --branch develop https://github.com/owner/repo-name.git


### PR DESCRIPTION
Follow-up to #22 (runtime git-credential provisioning). Two base-package items from the plan.

## Changes

- **`gh` CLI in the base image** — installed via GitHub's signed apt repo, arch-aware (`dpkg --print-architecture`), in its own layer so the base apt layer stays cached. The `github-*` skills prefer `gh` and only fall back to git+curl when it's absent; shipping it makes the richer PR/issue/release flows work out of the box (previously `gh: not found`).
- **Shallow clone by default** (`github-repo-management`) — a full clone of a large repo can take minutes and time out in the tool sandbox; `--depth 1` is ~2s and enough to read/edit/branch/push. Full clone documented as the opt-in when history is genuinely needed (`git fetch --unshallow` to deepen later).
- **`.env` path fix** — same bug as #22's github-auth fix: this skill read `~/.hermes/.env`, which resolves wrong once HOME is redirected to `{HERMES_HOME}/home`. Now `$HERMES_HOME`-aware with `GITHUB_PAT > GITHUB_TOKEN > GH_TOKEN` precedence.

## Verification

Built the image from this branch on the deploy host (arm64): `gh version 2.93.0` present and runnable. Existing s6/Dockerfile structure unchanged otherwise.

## Note

Supply-chain: this adds GitHub's signed apt repo (keyring-verified) rather than a checksum-pinned binary like the s6-overlay tarballs. The apt repo auto-updates and is the documented install method; happy to switch to a pinned binary if the project prefers that trust model for third-party tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)