### PR TITLE
feat(tools): add read_document tool for first-class PDF/document extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,6 +147,9 @@ RUN uv sync --frozen --no-install-project --extra all --extra messaging
 # Pre-install voice transcription (faster-whisper) so voice memos Just Work
 # in production gateway deployments without lazy-install latency.
 RUN uv pip install --no-cache-dir faster-whisper==1.2.1
+# Pre-install document reading (pymupdf) so PDFs Just Work in production
+# without lazy-install latency (read_document tool).
+RUN uv pip install --no-cache-dir pymupdf==1.27.2.3
 
 # ---------- Source code ----------
 # .dockerignore excludes node_modules, so the installs above survive.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,11 @@ youtube = [
 ]
 # `hermes dashboard` (localhost SPA + API).  Not in core to keep the default install lean.
 web = ["fastapi==0.133.1", "uvicorn[standard]==0.41.0"]
+# Document reading (read_document tool — PDF/EPUB/XPS text extraction).
+# pymupdf is a self-contained wheel (bundles mupdf, no Python transitive deps),
+# so it's cheap to lazy-install; kept out of [all] per the lazy-first policy and
+# eager-baked into the production image via the Dockerfile (mirrors `voice`).
+documents = ["pymupdf==1.27.2.3"]
 all = [
   # Policy (2026-05-12): `[all]` includes only extras that genuinely
   # CAN'T be lazy-installed via `tools/lazy_deps.py` — i.e. things every

--- a/tests/tools/test_document_tools.py
+++ b/tests/tools/test_document_tools.py
@@ -6,8 +6,11 @@ PDFs (and other pymupdf-supported formats) instead of hand-rolling
 2026-06-04-opinionated-hsm-base-package.
 """
 
-import fitz  # PyMuPDF — used here as test infra to build fixture PDFs
 import pytest
+
+# pymupdf is an optional ("documents") extra, not in the lean CI install
+# (`.[all,dev]`). Skip cleanly there; runs in the image where it ships eager.
+fitz = pytest.importorskip("fitz")
 
 from tools.document_tools import (
     READ_DOCUMENT_SCHEMA,

--- a/tests/tools/test_document_tools.py
+++ b/tests/tools/test_document_tools.py
@@ -1,0 +1,88 @@
+"""Tests for tools/document_tools.py — first-class document text extraction.
+
+The ``read_document`` tool gives the agent a reflexive, in-process way to read
+PDFs (and other pymupdf-supported formats) instead of hand-rolling
+``python3 -c`` / ``pip install`` in code-exec — see decision
+2026-06-04-opinionated-hsm-base-package.
+"""
+
+import fitz  # PyMuPDF — used here as test infra to build fixture PDFs
+import pytest
+
+from tools.document_tools import (
+    READ_DOCUMENT_SCHEMA,
+    _handle_read_document,
+    check_document_requirements,
+    read_document_tool,
+)
+
+
+def _make_pdf(path, pages_text):
+    """Write a PDF with one page per entry in ``pages_text`` (empty str = no text)."""
+    doc = fitz.open()
+    for text in pages_text:
+        page = doc.new_page()
+        if text:
+            page.insert_text((72, 72), text)
+    doc.save(str(path))
+    doc.close()
+
+
+class TestReadDocument:
+    @pytest.mark.asyncio
+    async def test_reads_text_from_pdf(self, tmp_path):
+        pdf = tmp_path / "hello.pdf"
+        _make_pdf(pdf, ["Hello from page one"])
+        result = await read_document_tool(str(pdf))
+        assert "Hello from page one" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_clear_error(self, tmp_path):
+        # Must not raise — the agent gets an actionable message instead.
+        result = await read_document_tool(str(tmp_path / "nope.pdf"))
+        assert "not found" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_page_range_limits_pages(self, tmp_path):
+        pdf = tmp_path / "two.pdf"
+        _make_pdf(pdf, ["AlphaPageOne", "BetaPageTwo"])
+        result = await read_document_tool(str(pdf), pages="1")
+        assert "AlphaPageOne" in result
+        assert "BetaPageTwo" not in result
+
+    @pytest.mark.asyncio
+    async def test_image_only_pdf_signals_needs_ocr(self, tmp_path):
+        # A page with no text layer should not look like a successful empty
+        # read — it should redirect the agent to the vision/OCR path.
+        pdf = tmp_path / "blank.pdf"
+        _make_pdf(pdf, [""])
+        result = await read_document_tool(str(pdf))
+        low = result.lower()
+        assert "ocr" in low or "vision" in low
+
+    @pytest.mark.asyncio
+    async def test_handler_reads_path_arg(self, tmp_path):
+        pdf = tmp_path / "h.pdf"
+        _make_pdf(pdf, ["HandlerSees"])
+        result = await _handle_read_document({"path": str(pdf)})
+        assert "HandlerSees" in result
+
+
+class TestSchemaAndRegistration:
+    def test_schema_name_and_required_path(self):
+        assert READ_DOCUMENT_SCHEMA["name"] == "read_document"
+        props = READ_DOCUMENT_SCHEMA["parameters"]["properties"]
+        assert "path" in props
+        assert "path" in READ_DOCUMENT_SCHEMA["parameters"]["required"]
+
+    def test_registered_in_registry(self):
+        import tools.document_tools  # noqa: F401  (self-registers on import)
+        from tools.registry import registry
+
+        assert registry.get_entry("read_document") is not None
+
+
+class TestRequirements:
+    def test_check_requirements_true_when_pymupdf_present(self):
+        # fitz imported at module top, so the dep is satisfied in this env.
+        assert check_document_requirements() is True

--- a/tools/document_tools.py
+++ b/tools/document_tools.py
@@ -1,0 +1,204 @@
+"""First-class document reading for the agent.
+
+The ``read_document`` tool extracts text from PDFs (and other pymupdf-supported
+formats) in-process, so the agent reaches for a real tool instead of
+hand-rolling ``python3 -c`` / ``pip install pymupdf`` in code-exec — the
+"make the right path the path of least resistance" lever from decision
+2026-06-04-opinionated-hsm-base-package.
+
+pymupdf (``fitz``) ships eagerly in the image (Dockerfile ``--extra
+documents``) and is also registered as a lazy feature (``documents.pymupdf``)
+so older images self-heal on first use.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+# Cap extracted text so a giant PDF can't blow up the context window. The
+# registry also enforces ``max_result_size_chars``; this is a friendly,
+# in-tool truncation with a clear marker.
+_MAX_TEXT_CHARS = 200_000
+
+
+def _import_fitz():
+    """Return the ``fitz`` (pymupdf) module, lazy-installing if needed.
+
+    Raises the original ImportError / FeatureUnavailable if it can't be made
+    importable so the caller can surface an actionable message.
+    """
+    try:
+        import fitz  # type: ignore
+        return fitz
+    except ImportError:
+        from tools.lazy_deps import ensure  # local import: avoid hard dep at module load
+        ensure("documents.pymupdf", prompt=False)
+        import fitz  # type: ignore
+        return fitz
+
+
+def _resolve_local_path(path: str) -> str:
+    """Strip a ``file://`` scheme and expand ``~`` so paths resolve locally."""
+    resolved = path.strip()
+    if resolved.startswith("file://"):
+        resolved = resolved[len("file://"):]
+    return os.path.expanduser(resolved)
+
+
+def _parse_pages(spec: Optional[str], page_count: int) -> List[int]:
+    """Parse a 1-indexed page spec into sorted 0-indexed page numbers.
+
+    ``"1"`` -> [0]; ``"1-3"`` -> [0,1,2]; ``"1,3,5"`` -> [0,2,4];
+    ``"2-3,5"`` -> [1,2,4]. Out-of-range pages are dropped. ``None`` or an
+    unparseable spec returns every page.
+    """
+    if not spec or not spec.strip():
+        return list(range(page_count))
+
+    wanted: set[int] = set()
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            if "-" in part:
+                lo_s, hi_s = part.split("-", 1)
+                lo, hi = int(lo_s), int(hi_s)
+                for p in range(lo, hi + 1):
+                    wanted.add(p - 1)
+            else:
+                wanted.add(int(part) - 1)
+        except ValueError:
+            continue
+
+    pages = sorted(p for p in wanted if 0 <= p < page_count)
+    return pages or list(range(page_count))
+
+
+def _read_document_sync(path: str, pages: Optional[str]) -> str:
+    """Blocking extraction — run via :func:`asyncio.to_thread`."""
+    local = _resolve_local_path(path)
+    if not os.path.isfile(local):
+        return f"❌ Document not found: {path}"
+
+    try:
+        fitz = _import_fitz()
+    except Exception as exc:  # ImportError / FeatureUnavailable
+        logger.warning("read_document: pymupdf unavailable: %s", exc)
+        return (
+            "❌ Document reading is unavailable: the pymupdf library could not "
+            f"be loaded ({exc})."
+        )
+
+    try:
+        doc = fitz.open(local)
+    except Exception as exc:
+        return f"❌ Could not open document {path!r}: {exc}"
+
+    try:
+        page_count = doc.page_count
+        selected = _parse_pages(pages, page_count)
+        chunks: List[str] = []
+        for idx in selected:
+            text = doc.load_page(idx).get_text().strip()
+            if text:
+                chunks.append(f"--- page {idx + 1} ---\n{text}")
+        body = "\n\n".join(chunks).strip()
+    finally:
+        doc.close()
+
+    if not body:
+        # A document with no extractable text layer (scanned page, Canva-style
+        # deck where text is drawn as vectors/images). Redirect to the OCR path
+        # rather than returning a misleading empty success.
+        return (
+            f"⚠️ No extractable text found in {path} ({page_count} page(s)). "
+            "This looks like an image-only / scanned document — its text lives "
+            "in the page images, not a text layer. Use the vision tool "
+            "(vision_analyze) on the rendered page image(s) to OCR it."
+        )
+
+    if len(body) > _MAX_TEXT_CHARS:
+        body = body[:_MAX_TEXT_CHARS] + "\n\n…[truncated]"
+    return body
+
+
+async def read_document_tool(path: str, pages: Optional[str] = None) -> str:
+    """Extract text from a local document (PDF, EPUB, XPS, …) via pymupdf.
+
+    ``path``: local file path or ``file://`` URI.
+    ``pages``: optional 1-indexed page spec (``"1"``, ``"1-3"``, ``"1,3,5"``).
+    Returns the extracted text, or an actionable message on error / image-only
+    documents. Never raises for the common failure cases.
+    """
+    return await asyncio.to_thread(_read_document_sync, path, pages)
+
+
+def check_document_requirements() -> bool:
+    """True when pymupdf is importable now, or lazy-installable on first use."""
+    try:
+        import fitz  # noqa: F401
+        return True
+    except ImportError:
+        pass
+    try:
+        from tools.lazy_deps import LAZY_DEPS, _allow_lazy_installs
+        return "documents.pymupdf" in LAZY_DEPS and _allow_lazy_installs()
+    except Exception:
+        return False
+
+
+READ_DOCUMENT_SCHEMA = {
+    "name": "read_document",
+    "description": (
+        "Extract the text of a document (PDF, EPUB, XPS, and similar) from a "
+        "local file path. Use this whenever the user sends or references a "
+        "document file (a PDF attachment, a .pdf path in their message, a file "
+        "saved by another tool). Prefer this over writing your own code to "
+        "parse the file. For image-only / scanned documents with no text "
+        "layer, this tells you to fall back to vision_analyze for OCR."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Local file path or file:// URI of the document to read.",
+            },
+            "pages": {
+                "type": "string",
+                "description": (
+                    "Optional 1-indexed page selection, e.g. '1', '1-3', or "
+                    "'1,3,5'. Omit to read the whole document."
+                ),
+            },
+        },
+        "required": ["path"],
+    },
+}
+
+
+async def _handle_read_document(args: Dict[str, Any], **kw: Any) -> str:
+    path = args.get("path") or args.get("document_url") or ""
+    pages = args.get("pages")
+    return await read_document_tool(path, pages)
+
+
+registry.register(
+    name="read_document",
+    toolset="documents",
+    schema=READ_DOCUMENT_SCHEMA,
+    handler=_handle_read_document,
+    check_fn=check_document_requirements,
+    is_async=True,
+    emoji="📄",
+    max_result_size_chars=_MAX_TEXT_CHARS,
+)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -163,6 +163,10 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "skill.youtube": ("youtube-transcript-api==1.2.4",),
 
     # ─── Tools ─────────────────────────────────────────────────────────────
+    # Document reading (read_document tool — PDF/EPUB/XPS text extraction).
+    # Ships eagerly in the image (Dockerfile `--extra documents`); listed here
+    # so older images / non-image installs self-heal on first use.
+    "documents.pymupdf": ("pymupdf==1.27.2.3",),
     # ACP adapter (VS Code / Zed / JetBrains integration)
     "tool.acp": ("agent-client-protocol==0.9.0",),
     # Dashboard (`hermes dashboard`)

--- a/uv.lock
+++ b/uv.lock
@@ -1666,6 +1666,9 @@ dingtalk = [
     { name = "dingtalk-stream" },
     { name = "qrcode" },
 ]
+documents = [
+    { name = "pymupdf" },
+]
 edge-tts = [
     { name = "edge-tts" },
 ]
@@ -1848,6 +1851,7 @@ requires-dist = [
     { name = "ptyprocess", marker = "sys_platform != 'win32' and extra == 'pty'", specifier = "==0.7.0" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.12.1" },
+    { name = "pymupdf", marker = "extra == 'documents'", specifier = "==1.27.2.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = "==2.4.0" },
@@ -1876,7 +1880,7 @@ requires-dist = [
     { name = "vercel", marker = "extra == 'vercel'", specifier = "==0.5.7" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "documents", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -3398,6 +3402,22 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.27.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/32/708bedc9dde7b328d45abbc076091769d44f2f24ad151ad92d56a6ec142b/pymupdf-1.27.2.3.tar.gz", hash = "sha256:7a92faa25129e8bbec5e50eeb9214f187665428c31b05c4ef6e36c58c0b1c6d2", size = 85759618, upload-time = "2026-04-24T14:13:14.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/09/ddbdfa7ee91fbabd6f63d7d744884cbdfe3e7ff9b8604749fb38bddf5c5d/pymupdf-1.27.2.3-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc1bc3cae6e9e150b0dbb0a9221bdfd411d65f0db2fe359eaa22467d7cc2a05f", size = 24002636, upload-time = "2026-04-24T14:09:17.459Z" },
+    { url = "https://files.pythonhosted.org/packages/01/89/3f8edd6c4f50ca370e2a2f2a3011face36f3760728ffe76dffec91c0fca0/pymupdf-1.27.2.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:660d93cb6da5bbddf11d3982ae27745dd3a9902d9f24cdb69adab83962294b5a", size = 23278238, upload-time = "2026-04-24T14:09:32.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/26/b7e5a70eb83bd189f8b5df87ec442746b992f2f632662839b288170d357d/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1dd460a3ae4597a755f00a3bd9771f5ebf1531dc111f6a36bf05dd00a6b84425", size = 24333923, upload-time = "2026-04-24T14:09:47.341Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/aa1ee2240f29481a04a827c313333b4ecd8a14d6ac3e15d3f41a30574781/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:857842b4888827bd6155a1131341b2822a7ebe9a8c15a975fd7d490d7a64a30c", size = 24963198, upload-time = "2026-04-24T14:10:07.408Z" },
+    { url = "https://files.pythonhosted.org/packages/69/49/4f742451f980840829fc00ba158bebb25d389c846d8f4f8c65936ee55de8/pymupdf-1.27.2.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:580983849c64a08d08344ca3d1580e87c01f046a8392421797bc850efd72a5b6", size = 25184609, upload-time = "2026-04-24T14:10:22.911Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/3f/3853d6608f394faf6eec2bd4e8ea9f6a00beea329b071abdb29f4164cc3d/pymupdf-1.27.2.3-cp310-abi3-win32.whl", hash = "sha256:a5c1088a87189891a4946ab314a14b7934ac4c5b6077f7e74ebee956f8906d0e", size = 18019286, upload-time = "2026-04-24T14:10:34.239Z" },
+    { url = "https://files.pythonhosted.org/packages/44/47/5fb10fe73f96b31253a41647c362ea9e0380920bddf16028414a051247fc/pymupdf-1.27.2.3-cp310-abi3-win_amd64.whl", hash = "sha256:d20f68ef15195e073071dbc4ae7455257c7889af7584e39df490c0a92728526e", size = 19249102, upload-time = "2026-04-24T14:10:46.72Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/b9e91aac82293f9c954654c85581ee8212b5b05efadc534b581141241e6f/pymupdf-1.27.2.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:77691604c5d1d0233827139bbcdea61fd57879c84712b8e49b1f45520f7ab9c2", size = 25000393, upload-time = "2026-04-24T14:11:01.669Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds a first-class **`read_document`** tool so the agent can read PDFs (and other pymupdf-supported formats) by calling a tool instead of hand-rolling `python3 -c` / `pip install pymupdf` in code-exec.

## Why

Today an agent that's handed a PDF has no real path to read it:
- code-exec runs on the **system `python3`** (`/usr/bin/python3`) which has **no pip and no pymupdf**, so `import fitz` / `pip install` both fail;
- the security gate correctly flags the `curl|sh` / `pip install --break-system-packages` improvisation that follows.

The fix is to provision the capability as a first-class tool that runs in the venv process — *make the right path the path of least resistance*. (Part of the opinionated HSM base-package work, decision `2026-06-04-opinionated-hsm-base-package`.)

## Changes

- **`tools/document_tools.py`** — async `read_document` tool (pymupdf/`fitz`). Local paths + `file://` URIs, 1-indexed page selection (`"1"`, `"1-3"`, `"1,3,5"`), soft text cap. Image-only / scanned PDFs (no text layer) are detected and redirected to the vision OCR path rather than returning a misleading empty success. Runs extraction via `asyncio.to_thread`.
- **`pyproject.toml`** — `documents` extra (`pymupdf`), kept out of `[all]` per the lazy-first policy.
- **`tools/lazy_deps.py`** — `documents.pymupdf` entry so non-image installs self-heal on first use.
- **`Dockerfile`** — eager `uv pip install pymupdf` so PDFs Just Work in the production image with no first-use lazy-install latency (mirrors the `voice`/faster-whisper line).
- **`uv.lock`** — adds pymupdf (self-contained wheel, no Python transitive deps).
- **`tests/tools/test_document_tools.py`** — 8 tests.

## Testing

Ran in a container built from the agent image (`FROM <agent-image>` + pymupdf), with the changed files bind-mounted over `/opt/hermes`:

- `test_document_tools.py` + `test_lazy_deps.py` + `test_package_json_lazy_deps.py` → **72 passed**.
- Integration probe: tool **discovers** under toolset `documents`, `check_fn` passes, real-PDF extraction returns the expected text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
