### PR TITLE
Dual-publish image + deprecation notice (prep for hermes-agent-mt rename)

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -2,7 +2,7 @@ name: Publish Docker Image (Fork)
 
 # Fork-specific workflow. The upstream docker-publish.yml only runs on
 # github.repository == 'NousResearch/hermes-agent'; this workflow handles
-# publishing to GHCR for NimbleCoAI/hermes-agent.
+# publishing to GHCR for NimbleCoAI/hermes-agent-mt.
 
 on:
   push:
@@ -11,7 +11,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
@@ -34,7 +33,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Transitional DUAL-PUBLISH for the hermes-agent → hermes-agent-mt
+          # rename. The new path is canonical; the old path is a deprecated
+          # alias so existing pullers keep getting updates during the window.
+          # Remove the deprecated `…/hermes-agent` line after 2026-07-15.
+          images: |
+            ${{ env.REGISTRY }}/nimblecoai/hermes-agent-mt
+            ${{ env.REGISTRY }}/nimblecoai/hermes-agent
           tags: |
             type=raw,value=latest
             type=sha,prefix=

--- a/FORK-NOTICE.md
+++ b/FORK-NOTICE.md
@@ -1,5 +1,9 @@
 # Multi-Tenant Fork Notice
 
+> **⚠️ This repository was renamed: `NimbleCoAI/hermes-agent` → `NimbleCoAI/hermes-agent-mt`.**
+> - **Git URLs:** clone/remote URLs **auto-redirect** — existing checkouts keep working, no action needed.
+> - **Container image:** moved to **`ghcr.io/nimblecoai/hermes-agent-mt`**. The old path `ghcr.io/nimblecoai/hermes-agent` is a **deprecated alias**, still updated during a transition window but **frozen after 2026-07-15** — repoint to the new path before then.
+
 This is **hermes-agent-mt** — a thin fork of [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) patched for multi-tenant deployments managed by [Hermes Swarm Map](https://github.com/NimbleCoAI/hermes-swarm-map).
 
 ## What's Different
@@ -31,11 +35,11 @@ This fork adds **2 core patches** and **~8 adapter improvements** on top of upst
 
 ```bash
 # Docker (recommended)
-docker pull ghcr.io/nimblecoai/hermes-agent:latest
+docker pull ghcr.io/nimblecoai/hermes-agent-mt:latest
 
 # Or build from source
-git clone https://github.com/NimbleCoAI/hermes-agent.git
-cd hermes-agent
+git clone https://github.com/NimbleCoAI/hermes-agent-mt.git
+cd hermes-agent-mt
 pip install -e ".[all]"
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 > **🔀 Multi-Tenant Fork** — This is `hermes-agent-mt`, patched for multi-tenant deployments with per-context memory isolation, group policy enforcement, and [Hermes Swarm Map](https://github.com/NimbleCoAI/hermes-swarm-map) integration. See [FORK-NOTICE.md](FORK-NOTICE.md) for details.
 >
-> Upstream: [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) · Image: `ghcr.io/nimblecoai/hermes-agent:latest`
+> **⚠️ Repo renamed:** `NimbleCoAI/hermes-agent` → `NimbleCoAI/hermes-agent-mt`. Git clone/remote URLs auto-redirect (no action needed). The image moved to **`ghcr.io/nimblecoai/hermes-agent-mt`**; the old `ghcr.io/nimblecoai/hermes-agent` path is a **deprecated alias** that stops updating after **2026-07-15**.
+>
+> Upstream: [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) · Image: `ghcr.io/nimblecoai/hermes-agent-mt:latest`
 
 <p align="center">
   <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentation"></a>


### PR DESCRIPTION
Prep step 1/3 for renaming `NimbleCoAI/hermes-agent` → `NimbleCoAI/hermes-agent-mt` **without breaking external pullers**. Merge this **before** the rename.

## Changes
- **Dual-publish** (`ghcr-publish.yml`): the image now publishes to BOTH `ghcr.io/nimblecoai/hermes-agent-mt` (new/canonical) and `ghcr.io/nimblecoai/hermes-agent` (deprecated alias). Stops keying the path off `${{ github.repository }}` so publishing is stable across the rename. Existing pullers of the old path keep getting updates during the transition.
- **Deprecation banner** (README + FORK-NOTICE): git URLs auto-redirect (no action); image moved to the new path; old path frozen after **2026-07-15**; updated pull/clone commands.

## Sequence
1. **this PR** → merge → image publishes to both paths.
2. Rename the repo (git URLs redirect).
3. HSM PR: re-point its ~8 `ghcr.io/nimblecoai/hermes-agent` refs → `…-mt`.

Blast radius is tiny (repo has 3 stars / 0 forks), but this keeps it clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)