### PR TITLE
feat(plugins): home_log_router — forward suppressed logs to home channel

### DIFF
--- a/plugins/observability/home_log_router/README.md
+++ b/plugins/observability/home_log_router/README.md
@@ -46,7 +46,7 @@ The only setting anyone needs is the enable switch above. Advanced overrides
 
 | Env | Default | Meaning |
 |-----|---------|---------|
-| `HERMES_HOME_LOG_ENABLED` | (active) | Set to `0` to disable without un-enabling the plugin |
+| `HERMES_HOME_LOG_ENABLED` | (active) | Kill switch — any non-truthy value (`0`/`false`/`off`) disables without un-enabling the plugin. Non-positive numeric knobs below fall back to their defaults. |
 | `HERMES_HOME_LOG_PLATFORM` | `signal` | Platform whose home channel receives forwards |
 | `HERMES_HOME_LOG_LEVEL` | `WARNING` | Minimum level to forward |
 | `HERMES_HOME_LOG_LOGGERS` | (the three above) | Comma-separated logger-name prefixes |
@@ -67,4 +67,15 @@ Five small, independently testable units:
   sending (the platform adapter emits its own logs on another thread that a
   thread-local guard would miss)
 
+The handler and worker are process-lifetime; teardown is bound to `atexit`, not
+`on_session_end` (which fires every conversation turn). Installation is idempotent.
+
 Tests: `tests/plugins/home_log_router/`.
+
+### Known tradeoff
+
+The logger-name allowlist is coupled to internal module names, so an upstream
+rename of those loggers would silently stop forwarding. A deeper fix (a
+structured "operational alert" emit routed through `get_home_channel()`) would be
+rename-proof but requires core changes, which this thin-patch plugin deliberately
+avoids. The allowlist is env-overridable as a mitigation.

--- a/plugins/observability/home_log_router/README.md
+++ b/plugins/observability/home_log_router/README.md
@@ -1,0 +1,70 @@
+# home_log_router
+
+Forward the operational logs that actually matter to an agent's **home channel**.
+
+## Why
+
+Hermes agents suppress operational log records to keep chat clean — cascade
+fallbacks, provider errors, persistent reconnects. None of them reach the home
+channel: only shutdown/startup/cron resolve `get_home_channel()`. Suppression
+isn't routing, so operators are blind to agent health.
+
+This plugin closes that gap **without touching any emit site**. It installs a
+`logging.Handler` on the root logger and forwards a curated, throttled slice of
+records to the home channel through the existing `send_message` tool (a bare
+platform target resolves to the home channel). It survives upstream rebases.
+
+## Enable
+
+```
+hermes plugins enable observability/home_log_router
+```
+
+That's the opt-in. It activates immediately. If no home channel is configured
+(`SIGNAL_HOME_CHANNEL` / `/sethome`), forwarding is a silent no-op until one is.
+
+## What it forwards
+
+Records at **WARNING+** from these loggers (prefix-matched):
+
+- `gateway.platforms.signal` — reconnects / health (benign churn is DEBUG, so only real problems surface)
+- `agent.conversation_loop` — model cascade fallbacks
+- `model_tools` — provider errors during model calls
+
+## Storm safety
+
+Identical messages are deduplicated (re-surfacing once per window as a
+heartbeat), sends are rate-capped per window, and the first send after any
+suppression leads with a short "N suppressed" summary. The capture path is
+non-blocking (bounded queue, drop-on-full) and fully decoupled from delivery —
+logging is never blocked by a slow send.
+
+## Configuration
+
+The only setting anyone needs is the enable switch above. Advanced overrides
+(all optional, sensible defaults):
+
+| Env | Default | Meaning |
+|-----|---------|---------|
+| `HERMES_HOME_LOG_ENABLED` | (active) | Set to `0` to disable without un-enabling the plugin |
+| `HERMES_HOME_LOG_PLATFORM` | `signal` | Platform whose home channel receives forwards |
+| `HERMES_HOME_LOG_LEVEL` | `WARNING` | Minimum level to forward |
+| `HERMES_HOME_LOG_LOGGERS` | (the three above) | Comma-separated logger-name prefixes |
+| `HERMES_HOME_LOG_RATE` | `20` | Max sends per window |
+| `HERMES_HOME_LOG_WINDOW` | `60` | Rate window (seconds) |
+| `HERMES_HOME_LOG_DEDUP_WINDOW` | `300` | Identical-message dedup window (seconds) |
+| `HERMES_HOME_LOG_QUEUE` | `1000` | Bounded capture queue size |
+
+## Design
+
+Five small, independently testable units:
+
+- `RoutePolicy` — pure: does this record forward? (allowlist ∩ level floor)
+- `Throttle` — pure (injectable clock): dedup + rate-cap + suppression summary
+- `HomeLogHandler` — cheap `emit()`: policy-gate, format, non-blocking enqueue
+- `HomeLogWorker` — daemon thread: drain → throttle → guarded send
+- `ReentrancyGuard` — process-wide; suppresses capture while the worker is itself
+  sending (the platform adapter emits its own logs on another thread that a
+  thread-local guard would miss)
+
+Tests: `tests/plugins/home_log_router/`.

--- a/plugins/observability/home_log_router/__init__.py
+++ b/plugins/observability/home_log_router/__init__.py
@@ -7,8 +7,8 @@ This plugin installs a ``logging.Handler`` that forwards a curated, throttled
 slice of those records to the home channel via the ``send_message`` tool (a bare
 platform target resolves to home). Zero core emit-site edits.
 
-Opt-in: inert unless ``HERMES_HOME_LOG_ENABLED`` is set. With no home channel
-configured the forward is a silent no-op.
+Enabling the plugin activates it; ``HERMES_HOME_LOG_ENABLED=0`` is a kill switch.
+With no home channel configured the forward is a silent no-op.
 
 Activation is handled by the Hermes plugin system — standalone plugins only load
 when listed in ``plugins.enabled`` (``hermes plugins enable

--- a/plugins/observability/home_log_router/__init__.py
+++ b/plugins/observability/home_log_router/__init__.py
@@ -1,0 +1,25 @@
+"""home_log_router — forward selected suppressed logs to the Signal home channel.
+
+Hermes agents suppress operational log records (cascade fallbacks, provider
+errors, persistent reconnects) to keep chat clean. None of them reach the
+agent's home channel — only shutdown/startup/cron resolve ``get_home_channel()``.
+This plugin installs a ``logging.Handler`` that forwards a curated, throttled
+slice of those records to the home channel via the ``send_message`` tool (a bare
+platform target resolves to home). Zero core emit-site edits.
+
+Opt-in: inert unless ``HERMES_HOME_LOG_ENABLED`` is set. With no home channel
+configured the forward is a silent no-op.
+
+Activation is handled by the Hermes plugin system — standalone plugins only load
+when listed in ``plugins.enabled`` (``hermes plugins enable
+observability/home_log_router``).
+"""
+from __future__ import annotations
+
+
+def register(ctx) -> None:
+    # Lazy import: keeps unit submodules independently importable for testing
+    # without pulling the whole plugin graph at import time.
+    from .registration import register as _register
+
+    _register(ctx)

--- a/plugins/observability/home_log_router/guard.py
+++ b/plugins/observability/home_log_router/guard.py
@@ -18,7 +18,11 @@ class ReentrancyGuard:
 
     @property
     def active(self) -> bool:
-        return self._depth > 0
+        # Read under the lock too: the guard's job is cross-thread visibility
+        # (worker thread vs. the adapter's _run_async send thread), which a
+        # lock-free read does not guarantee on free-threaded interpreters.
+        with self._lock:
+            return self._depth > 0
 
     def __enter__(self) -> "ReentrancyGuard":
         with self._lock:

--- a/plugins/observability/home_log_router/guard.py
+++ b/plugins/observability/home_log_router/guard.py
@@ -1,0 +1,30 @@
+"""ReentrancyGuard — process-wide suppression while the worker is sending.
+
+The worker forwards via ``send_message``, which (through ``_run_async``) performs
+the actual platform send on a *separate* thread, and the platform adapter emits
+its own log records during that send. Those records match the allowlist and would
+feed back into the queue. A thread-local guard would miss the adapter's thread,
+so this guard is process-wide: while active, the handler drops every record.
+"""
+from __future__ import annotations
+
+import threading
+
+
+class ReentrancyGuard:
+    def __init__(self) -> None:
+        self._depth = 0
+        self._lock = threading.Lock()
+
+    @property
+    def active(self) -> bool:
+        return self._depth > 0
+
+    def __enter__(self) -> "ReentrancyGuard":
+        with self._lock:
+            self._depth += 1
+        return self
+
+    def __exit__(self, *exc) -> None:
+        with self._lock:
+            self._depth -= 1

--- a/plugins/observability/home_log_router/handler.py
+++ b/plugins/observability/home_log_router/handler.py
@@ -1,0 +1,42 @@
+"""HomeLogHandler — a logging.Handler that enqueues forwardable records.
+
+emit() is deliberately cheap and non-blocking: it gates on the policy and the
+re-entrancy guard, formats the record, and does a single ``put_nowait``,
+dropping silently if the queue is full. All network I/O happens later, on the
+worker thread — so logging is never blocked by a slow send.
+"""
+from __future__ import annotations
+
+import logging
+import queue
+
+from .guard import ReentrancyGuard
+from .policy import RoutePolicy
+
+_DEFAULT_FORMAT = "%(levelname)s %(name)s: %(message)s"
+
+
+class HomeLogHandler(logging.Handler):
+    def __init__(
+        self,
+        policy: RoutePolicy,
+        out_queue: "queue.Queue[str]",
+        guard: ReentrancyGuard,
+    ) -> None:
+        super().__init__()
+        self.policy = policy
+        self.out_queue = out_queue
+        self.guard = guard
+        self.setFormatter(logging.Formatter(_DEFAULT_FORMAT))
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if self.guard.active:
+            return
+        if not self.policy.should_forward(record):
+            return
+        try:
+            self.out_queue.put_nowait(self.format(record))
+        except queue.Full:
+            pass  # storm: drop rather than block the logging thread
+        except Exception:  # pragma: no cover - never let logging raise
+            self.handleError(record)

--- a/plugins/observability/home_log_router/plugin.yaml
+++ b/plugins/observability/home_log_router/plugin.yaml
@@ -1,0 +1,6 @@
+name: home_log_router
+version: "1.0.0"
+description: "Forward selected suppressed logs (cascade fallbacks, provider errors, persistent reconnects) to the agent's home channel via send_message. Opt-in via `hermes plugins enable observability/home_log_router`. Inert when no home channel is set; disable with HERMES_HOME_LOG_ENABLED=0."
+author: NimbleCo
+hooks:
+  - on_session_end

--- a/plugins/observability/home_log_router/policy.py
+++ b/plugins/observability/home_log_router/policy.py
@@ -1,0 +1,21 @@
+"""RoutePolicy — decides whether a LogRecord should be forwarded to home.
+
+Pure decision unit: a record forwards iff its logger name starts with one of
+the allowlisted prefixes AND its level is at or above the floor.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+
+class RoutePolicy:
+    def __init__(self, logger_prefixes: Iterable[str], level: int) -> None:
+        # tuple so str.startswith can test all prefixes in one call
+        self.prefixes = tuple(logger_prefixes)
+        self.level = level
+
+    def should_forward(self, record: logging.LogRecord) -> bool:
+        if record.levelno < self.level:
+            return False
+        return bool(self.prefixes) and record.name.startswith(self.prefixes)

--- a/plugins/observability/home_log_router/registration.py
+++ b/plugins/observability/home_log_router/registration.py
@@ -1,0 +1,107 @@
+"""register(ctx) — wire the plugin into the running agent.
+
+Enabling the plugin (``hermes plugins enable observability/home_log_router``) is
+the opt-in; this then attaches a ``HomeLogHandler`` to the root logger and starts
+a ``HomeLogWorker`` that forwards throttled records to the home channel through the
+``send_message`` tool. A bare platform target (e.g. ``"signal"``) resolves to
+``get_home_channel()``; if no home is configured the tool returns an error which
+the worker silently ignores.
+
+``HERMES_HOME_LOG_ENABLED=0`` is an optional kill switch — disable forwarding
+without un-enabling the plugin. Everything else defaults sensibly; no knobs needed.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import queue
+import time
+
+from .guard import ReentrancyGuard
+from .handler import HomeLogHandler
+from .policy import RoutePolicy
+from .throttle import Throttle
+from .worker import HomeLogWorker
+
+logger = logging.getLogger(__name__)
+
+# Loggers whose suppressed records are worth surfacing to home, grounded in the
+# real module logger names: Signal reconnect/health, model cascade fallbacks, and
+# provider errors during model calls. Prefix-matched, so submodules are covered.
+DEFAULT_LOGGERS = (
+    "gateway.platforms.signal",
+    "agent.conversation_loop",
+    "model_tools",
+)
+
+
+def _truthy(value: str | None) -> bool:
+    return bool(value) and value.strip().lower() not in ("0", "false", "no", "off", "")
+
+
+def _level(name: str) -> int:
+    resolved = logging.getLevelName(name.strip().upper())
+    return resolved if isinstance(resolved, int) else logging.WARNING
+
+
+def _enabled() -> bool:
+    # Active by default once the plugin is enabled; only an explicit falsey
+    # value disables it (kill switch).
+    val = os.getenv("HERMES_HOME_LOG_ENABLED")
+    return True if val is None else _truthy(val)
+
+
+def register(ctx) -> None:
+    if not _enabled():
+        return  # kill switch engaged
+
+    platform = os.getenv("HERMES_HOME_LOG_PLATFORM", "signal").strip() or "signal"
+    level = _level(os.getenv("HERMES_HOME_LOG_LEVEL", "WARNING"))
+    raw_loggers = os.getenv("HERMES_HOME_LOG_LOGGERS", "")
+    loggers = tuple(s.strip() for s in raw_loggers.split(",") if s.strip()) or DEFAULT_LOGGERS
+    rate = _int("HERMES_HOME_LOG_RATE", 20)
+    window = _float("HERMES_HOME_LOG_WINDOW", 60.0)
+    dedup_window = _float("HERMES_HOME_LOG_DEDUP_WINDOW", 300.0)
+    queue_max = _int("HERMES_HOME_LOG_QUEUE", 1000)
+
+    guard = ReentrancyGuard()
+    out_queue: "queue.Queue[str]" = queue.Queue(maxsize=queue_max)
+    handler = HomeLogHandler(RoutePolicy(loggers, level), out_queue, guard)
+    throttle = Throttle(rate=rate, window=window, dedup_window=dedup_window, clock=time.monotonic)
+    worker = HomeLogWorker(out_queue, throttle, _make_sender(ctx, platform), guard)
+
+    logging.getLogger().addHandler(handler)
+    worker.start()
+    logger.info(
+        "home_log_router active: platform=%s level=%s loggers=%s",
+        platform, logging.getLevelName(level), ",".join(loggers),
+    )
+
+    def _teardown(**_kwargs):
+        logging.getLogger().removeHandler(handler)
+        worker.stop()
+
+    ctx.register_hook("on_session_end", _teardown)
+
+
+def _make_sender(ctx, platform: str):
+    def sender(message: str) -> None:
+        # Bare platform target -> home channel. Return value (incl. "no home"
+        # errors) is intentionally ignored: forwarding is best-effort.
+        ctx.dispatch_tool("send_message", {"target": platform, "message": message})
+
+    return sender
+
+
+def _int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, "").strip() or default)
+    except ValueError:
+        return default
+
+
+def _float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, "").strip() or default)
+    except ValueError:
+        return default

--- a/plugins/observability/home_log_router/registration.py
+++ b/plugins/observability/home_log_router/registration.py
@@ -7,15 +7,22 @@ a ``HomeLogWorker`` that forwards throttled records to the home channel through 
 ``get_home_channel()``; if no home is configured the tool returns an error which
 the worker silently ignores.
 
-``HERMES_HOME_LOG_ENABLED=0`` is an optional kill switch — disable forwarding
-without un-enabling the plugin. Everything else defaults sensibly; no knobs needed.
+The handler and worker are *process-lifetime* resources, so teardown is bound to
+``atexit`` — NOT to ``on_session_end``, which fires at the end of every
+conversation turn and would tear the plugin down after the first message.
+Installation is idempotent so repeated registration never stacks handlers.
+
+``HERMES_HOME_LOG_ENABLED=0`` (or any non-truthy value) is a kill switch.
+Everything else defaults sensibly; no knobs needed.
 """
 from __future__ import annotations
 
+import atexit
 import logging
 import os
 import queue
 import time
+from typing import NamedTuple, Tuple
 
 from .guard import ReentrancyGuard
 from .handler import HomeLogHandler
@@ -28,60 +35,118 @@ logger = logging.getLogger(__name__)
 # Loggers whose suppressed records are worth surfacing to home, grounded in the
 # real module logger names: Signal reconnect/health, model cascade fallbacks, and
 # provider errors during model calls. Prefix-matched, so submodules are covered.
-DEFAULT_LOGGERS = (
+DEFAULT_LOGGERS: Tuple[str, ...] = (
     "gateway.platforms.signal",
     "agent.conversation_loop",
     "model_tools",
 )
 
 
-def _truthy(value: str | None) -> bool:
-    return bool(value) and value.strip().lower() not in ("0", "false", "no", "off", "")
+class Config(NamedTuple):
+    enabled: bool
+    platform: str
+    level: int
+    loggers: Tuple[str, ...]
+    rate: int
+    window: int
+    dedup_window: int
+    queue_max: int
 
 
-def _level(name: str) -> int:
-    resolved = logging.getLevelName(name.strip().upper())
-    return resolved if isinstance(resolved, int) else logging.WARNING
+# Matches the project's shared truthy set (utils.TRUTHY_STRINGS). Kept local so
+# this thin-patch plugin stays self-contained and doesn't couple to a core file
+# that churns on upstream rebases (utils.py also uses 3.11-only syntax).
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
 
 
 def _enabled() -> bool:
-    # Active by default once the plugin is enabled; only an explicit falsey
-    # value disables it (kill switch).
+    # Active by default once the plugin is enabled; any non-truthy value is a
+    # kill switch. Unset (None) stays on; empty/"0"/"false"/"off" turn it off.
     val = os.getenv("HERMES_HOME_LOG_ENABLED")
-    return True if val is None else _truthy(val)
+    if val is None:
+        return True
+    return val.strip().lower() in _TRUTHY
+
+
+def _level(raw: str) -> int:
+    raw = (raw or "").strip()
+    if raw.isdigit():  # numeric levels like "10"/"30" must be honored
+        return int(raw)
+    resolved = logging.getLevelName(raw.upper())
+    return resolved if isinstance(resolved, int) else logging.WARNING
+
+
+def _positive(key: str, default: int) -> int:
+    # A non-positive rate/window/dedup silently breaks throttling (mutes
+    # everything, or disables the rate cap). Fall back to the default instead.
+    raw = os.getenv(key, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _read_config() -> Config:
+    raw_loggers = os.getenv("HERMES_HOME_LOG_LOGGERS", "")
+    loggers = tuple(s.strip() for s in raw_loggers.split(",") if s.strip()) or DEFAULT_LOGGERS
+    return Config(
+        enabled=_enabled(),
+        platform=os.getenv("HERMES_HOME_LOG_PLATFORM", "signal").strip() or "signal",
+        level=_level(os.getenv("HERMES_HOME_LOG_LEVEL", "WARNING")),
+        loggers=loggers,
+        rate=_positive("HERMES_HOME_LOG_RATE", 20),
+        window=_positive("HERMES_HOME_LOG_WINDOW", 60),
+        dedup_window=_positive("HERMES_HOME_LOG_DEDUP_WINDOW", 300),
+        queue_max=_positive("HERMES_HOME_LOG_QUEUE", 1000),
+    )
+
+
+# Process-lifetime singletons. register() is idempotent against these.
+_handler: HomeLogHandler | None = None
+_worker: HomeLogWorker | None = None
+_atexit_registered = False
 
 
 def register(ctx) -> None:
-    if not _enabled():
+    global _handler, _worker, _atexit_registered
+    if _handler is not None:
+        return  # already installed — don't stack handlers
+
+    cfg = _read_config()
+    if not cfg.enabled:
         return  # kill switch engaged
 
-    platform = os.getenv("HERMES_HOME_LOG_PLATFORM", "signal").strip() or "signal"
-    level = _level(os.getenv("HERMES_HOME_LOG_LEVEL", "WARNING"))
-    raw_loggers = os.getenv("HERMES_HOME_LOG_LOGGERS", "")
-    loggers = tuple(s.strip() for s in raw_loggers.split(",") if s.strip()) or DEFAULT_LOGGERS
-    rate = _int("HERMES_HOME_LOG_RATE", 20)
-    window = _float("HERMES_HOME_LOG_WINDOW", 60.0)
-    dedup_window = _float("HERMES_HOME_LOG_DEDUP_WINDOW", 300.0)
-    queue_max = _int("HERMES_HOME_LOG_QUEUE", 1000)
-
     guard = ReentrancyGuard()
-    out_queue: "queue.Queue[str]" = queue.Queue(maxsize=queue_max)
-    handler = HomeLogHandler(RoutePolicy(loggers, level), out_queue, guard)
-    throttle = Throttle(rate=rate, window=window, dedup_window=dedup_window, clock=time.monotonic)
-    worker = HomeLogWorker(out_queue, throttle, _make_sender(ctx, platform), guard)
+    out_queue: "queue.Queue[str]" = queue.Queue(maxsize=cfg.queue_max)
+    handler = HomeLogHandler(RoutePolicy(cfg.loggers, cfg.level), out_queue, guard)
+    throttle = Throttle(cfg.rate, cfg.window, cfg.dedup_window, time.monotonic)
+    worker = HomeLogWorker(out_queue, throttle, _make_sender(ctx, cfg.platform), guard)
 
     logging.getLogger().addHandler(handler)
     worker.start()
+    _handler, _worker = handler, worker
+
+    if not _atexit_registered:
+        atexit.register(_teardown)
+        _atexit_registered = True
+
     logger.info(
         "home_log_router active: platform=%s level=%s loggers=%s",
-        platform, logging.getLevelName(level), ",".join(loggers),
+        cfg.platform, logging.getLevelName(cfg.level), ",".join(cfg.loggers),
     )
 
-    def _teardown(**_kwargs):
-        logging.getLogger().removeHandler(handler)
-        worker.stop()
 
-    ctx.register_hook("on_session_end", _teardown)
+def _teardown() -> None:
+    global _handler, _worker
+    if _handler is not None:
+        logging.getLogger().removeHandler(_handler)
+        _handler = None
+    if _worker is not None:
+        _worker.stop()
+        _worker = None
 
 
 def _make_sender(ctx, platform: str):
@@ -91,17 +156,3 @@ def _make_sender(ctx, platform: str):
         ctx.dispatch_tool("send_message", {"target": platform, "message": message})
 
     return sender
-
-
-def _int(name: str, default: int) -> int:
-    try:
-        return int(os.getenv(name, "").strip() or default)
-    except ValueError:
-        return default
-
-
-def _float(name: str, default: float) -> float:
-    try:
-        return float(os.getenv(name, "").strip() or default)
-    except ValueError:
-        return default

--- a/plugins/observability/home_log_router/throttle.py
+++ b/plugins/observability/home_log_router/throttle.py
@@ -31,6 +31,7 @@ class Throttle:
         self._window_start = clock()
         self._count = 0  # admits in the current rate window
         self._last_seen: dict[str, float] = {}  # message -> last admit time
+        self._last_prune = self._window_start
         self._suppressed = 0  # suppressions since last summary
 
     def admit(self, message: str) -> List[str]:
@@ -64,12 +65,31 @@ class Throttle:
         out.append(message)
         return out
 
+    def flush_summary(self) -> List[str]:
+        """Emit a pending "N suppressed" summary outside the admit path.
+
+        A burst that ends with suppression (no following admit) would otherwise
+        never report its count. The worker calls this on idle so the tail of a
+        storm is still surfaced.
+        """
+        if self._suppressed <= 0:
+            return []
+        out = [self._summary(self._suppressed)]
+        self._suppressed = 0
+        return out
+
     def _summary(self, n: int) -> str:
         noun = "message" if n == 1 else "messages"
         return f"… {n} more log {noun} suppressed"
 
     def _prune(self, now: float) -> None:
         # Drop dedup entries past their window so the map can't grow unbounded.
+        # Runs at most once per dedup_window, not on every admit: an expired
+        # entry is harmless (admit re-admits it), so eager pruning only wastes
+        # an O(n) scan on the hot path during high-cardinality storms.
+        if now - self._last_prune < self.dedup_window:
+            return
+        self._last_prune = now
         expired = [m for m, ts in self._last_seen.items() if now - ts >= self.dedup_window]
         for m in expired:
             del self._last_seen[m]

--- a/plugins/observability/home_log_router/throttle.py
+++ b/plugins/observability/home_log_router/throttle.py
@@ -1,0 +1,75 @@
+"""Throttle — storm control for home-channel forwarding.
+
+Pure logic with an injectable clock so it is fully testable without sleeping.
+
+Policy:
+  * dedup     — an identical message is admitted at most once per dedup_window
+                (a persistent error still resurfaces each window as a heartbeat,
+                rather than flooding or vanishing forever).
+  * rate-cap  — at most ``rate`` admits per ``window`` seconds; excess suppressed.
+  * summary   — the first admit following any suppression leads with a short
+                "N suppressed" line so operators know they aren't seeing all.
+"""
+from __future__ import annotations
+
+from typing import Callable, List
+
+
+class Throttle:
+    def __init__(
+        self,
+        rate: int,
+        window: float,
+        dedup_window: float,
+        clock: Callable[[], float],
+    ) -> None:
+        self.rate = rate
+        self.window = window
+        self.dedup_window = dedup_window
+        self._clock = clock
+
+        self._window_start = clock()
+        self._count = 0  # admits in the current rate window
+        self._last_seen: dict[str, float] = {}  # message -> last admit time
+        self._suppressed = 0  # suppressions since last summary
+
+    def admit(self, message: str) -> List[str]:
+        now = self._clock()
+
+        # Roll the rate window if it has elapsed.
+        if now - self._window_start >= self.window:
+            self._window_start = now
+            self._count = 0
+
+        # Dedup: identical message admitted at most once per dedup_window.
+        last = self._last_seen.get(message)
+        if last is not None and now - last < self.dedup_window:
+            self._suppressed += 1
+            return []
+
+        # Rate-cap: cap admits per window.
+        if self._count >= self.rate:
+            self._suppressed += 1
+            return []
+
+        # Admit.
+        self._count += 1
+        self._last_seen[message] = now
+        self._prune(now)
+
+        out: List[str] = []
+        if self._suppressed > 0:
+            out.append(self._summary(self._suppressed))
+            self._suppressed = 0
+        out.append(message)
+        return out
+
+    def _summary(self, n: int) -> str:
+        noun = "message" if n == 1 else "messages"
+        return f"… {n} more log {noun} suppressed"
+
+    def _prune(self, now: float) -> None:
+        # Drop dedup entries past their window so the map can't grow unbounded.
+        expired = [m for m, ts in self._last_seen.items() if now - ts >= self.dedup_window]
+        for m in expired:
+            del self._last_seen[m]

--- a/plugins/observability/home_log_router/worker.py
+++ b/plugins/observability/home_log_router/worker.py
@@ -1,0 +1,68 @@
+"""HomeLogWorker — background daemon that turns queued records into home sends.
+
+The handler only enqueues; this worker owns all the slow/fallible work: it drains
+the queue, runs each message through the Throttle, and calls ``sender`` under the
+re-entrancy guard so the send's own log output never feeds back. A send failure is
+swallowed — losing a forwarded log must never crash the agent.
+"""
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+from typing import Callable
+
+from .guard import ReentrancyGuard
+from .throttle import Throttle
+
+logger = logging.getLogger(__name__)
+
+
+class HomeLogWorker:
+    def __init__(
+        self,
+        out_queue: "queue.Queue[str]",
+        throttle: Throttle,
+        sender: Callable[[str], None],
+        guard: ReentrancyGuard,
+        poll_timeout: float = 0.5,
+    ) -> None:
+        self.out_queue = out_queue
+        self.throttle = throttle
+        self.sender = sender
+        self.guard = guard
+        self.poll_timeout = poll_timeout
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def process(self, message: str) -> None:
+        """Throttle one message and send what survives. Synchronous, testable."""
+        for out in self.throttle.admit(message):
+            with self.guard:
+                try:
+                    self.sender(out)
+                except Exception as exc:  # never let a bad send escape
+                    logger.debug("home_log_router send failed: %s", exc)
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._run, name="home-log-router", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self, join_timeout: float = 2.0) -> None:
+        self._stop.set()
+        thread, self._thread = self._thread, None
+        if thread is not None:
+            thread.join(timeout=join_timeout)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                message = self.out_queue.get(timeout=self.poll_timeout)
+            except queue.Empty:
+                continue
+            self.process(message)

--- a/plugins/observability/home_log_router/worker.py
+++ b/plugins/observability/home_log_router/worker.py
@@ -37,7 +37,14 @@ class HomeLogWorker:
 
     def process(self, message: str) -> None:
         """Throttle one message and send what survives. Synchronous, testable."""
-        for out in self.throttle.admit(message):
+        self._send_all(self.throttle.admit(message))
+
+    def idle_flush(self) -> None:
+        """Deliver any pending suppression summary when the queue goes quiet."""
+        self._send_all(self.throttle.flush_summary())
+
+    def _send_all(self, messages) -> None:
+        for out in messages:
             with self.guard:
                 try:
                     self.sender(out)
@@ -64,5 +71,6 @@ class HomeLogWorker:
             try:
                 message = self.out_queue.get(timeout=self.poll_timeout)
             except queue.Empty:
+                self.idle_flush()
                 continue
             self.process(message)

--- a/tests/plugins/home_log_router/test_config.py
+++ b/tests/plugins/home_log_router/test_config.py
@@ -1,0 +1,67 @@
+"""_read_config — env parsing with guards against silently-broken values."""
+import logging
+
+from plugins.observability.home_log_router import registration
+from plugins.observability.home_log_router.registration import DEFAULT_LOGGERS
+
+
+def _cfg(monkeypatch, **env):
+    for k in (
+        "HERMES_HOME_LOG_ENABLED", "HERMES_HOME_LOG_PLATFORM", "HERMES_HOME_LOG_LEVEL",
+        "HERMES_HOME_LOG_LOGGERS", "HERMES_HOME_LOG_RATE", "HERMES_HOME_LOG_WINDOW",
+        "HERMES_HOME_LOG_DEDUP_WINDOW", "HERMES_HOME_LOG_QUEUE",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    return registration._read_config()
+
+
+def test_defaults(monkeypatch):
+    c = _cfg(monkeypatch)
+    assert c.enabled is True
+    assert c.platform == "signal"
+    assert c.level == logging.WARNING
+    assert c.loggers == DEFAULT_LOGGERS
+    assert c.rate == 20 and c.window == 60 and c.dedup_window == 300
+
+
+def test_enabled_unset_is_active(monkeypatch):
+    assert _cfg(monkeypatch).enabled is True
+
+
+def test_kill_switch_values_disable(monkeypatch):
+    assert _cfg(monkeypatch, HERMES_HOME_LOG_ENABLED="0").enabled is False
+    assert _cfg(monkeypatch, HERMES_HOME_LOG_ENABLED="false").enabled is False
+    assert _cfg(monkeypatch, HERMES_HOME_LOG_ENABLED="1").enabled is True
+
+
+def test_nonpositive_rate_falls_back_to_default(monkeypatch):
+    assert _cfg(monkeypatch, HERMES_HOME_LOG_RATE="0").rate == 20
+    assert _cfg(monkeypatch, HERMES_HOME_LOG_RATE="-5").rate == 20
+
+
+def test_nonpositive_window_falls_back_to_default(monkeypatch):
+    assert _cfg(monkeypatch, HERMES_HOME_LOG_WINDOW="0").window == 60
+
+
+def test_nonpositive_dedup_falls_back_to_default(monkeypatch):
+    assert _cfg(monkeypatch, HERMES_HOME_LOG_DEDUP_WINDOW="0").dedup_window == 300
+
+
+def test_named_level(monkeypatch):
+    assert _cfg(monkeypatch, HERMES_HOME_LOG_LEVEL="ERROR").level == logging.ERROR
+
+
+def test_numeric_level_string(monkeypatch):
+    # "10" must mean DEBUG, not silently fall back to WARNING.
+    assert _cfg(monkeypatch, HERMES_HOME_LOG_LEVEL="10").level == logging.DEBUG
+
+
+def test_bogus_level_falls_back_to_warning(monkeypatch):
+    assert _cfg(monkeypatch, HERMES_HOME_LOG_LEVEL="nonsense").level == logging.WARNING
+
+
+def test_logger_allowlist_override(monkeypatch):
+    c = _cfg(monkeypatch, HERMES_HOME_LOG_LOGGERS="a.b, c.d ,e")
+    assert c.loggers == ("a.b", "c.d", "e")

--- a/tests/plugins/home_log_router/test_handler.py
+++ b/tests/plugins/home_log_router/test_handler.py
@@ -1,0 +1,54 @@
+"""HomeLogHandler — cheap emit(): policy-gate, format, non-blocking enqueue.
+
+emit() must never touch the network and never block: it only filters and does a
+``put_nowait`` (dropping on a full queue). A process-wide re-entrancy guard lets
+the worker suppress capture while it is itself sending (which emits adapter logs
+that would otherwise feed back).
+"""
+import logging
+import queue
+
+from plugins.observability.home_log_router.handler import HomeLogHandler
+from plugins.observability.home_log_router.guard import ReentrancyGuard
+from plugins.observability.home_log_router.policy import RoutePolicy
+
+
+def _record(name="gateway.platforms.signal", level=logging.WARNING, msg="boom"):
+    return logging.LogRecord(name, level, __file__, 1, msg, (), None)
+
+
+def _handler(maxsize=10, guard=None):
+    policy = RoutePolicy(["gateway.platforms.signal"], logging.WARNING)
+    q = queue.Queue(maxsize=maxsize)
+    h = HomeLogHandler(policy=policy, out_queue=q, guard=guard or ReentrancyGuard())
+    return h, q
+
+
+def test_forwards_matching_record_to_queue():
+    h, q = _handler()
+    h.emit(_record(msg="hello"))
+    item = q.get_nowait()
+    assert "hello" in item
+    assert "WARNING" in item
+
+
+def test_drops_record_policy_rejects():
+    h, q = _handler()
+    h.emit(_record(name="some.other.logger", level=logging.ERROR))
+    assert q.empty()
+
+
+def test_drops_silently_when_queue_full():
+    h, q = _handler(maxsize=1)
+    h.emit(_record(msg="first"))   # fills the queue
+    h.emit(_record(msg="second"))  # must not raise, must be dropped
+    assert q.qsize() == 1
+    assert "first" in q.get_nowait()
+
+
+def test_drops_record_while_guard_active():
+    guard = ReentrancyGuard()
+    h, q = _handler(guard=guard)
+    with guard:
+        h.emit(_record(msg="during-send"))
+    assert q.empty()

--- a/tests/plugins/home_log_router/test_policy.py
+++ b/tests/plugins/home_log_router/test_policy.py
@@ -1,0 +1,31 @@
+"""RoutePolicy — decides whether a LogRecord should be forwarded to home."""
+import logging
+
+from plugins.observability.home_log_router.policy import RoutePolicy
+
+
+def _record(name: str, level: int) -> logging.LogRecord:
+    return logging.LogRecord(
+        name=name, level=level, pathname=__file__, lineno=1,
+        msg="hello", args=(), exc_info=None,
+    )
+
+
+def test_forwards_allowed_logger_at_or_above_floor():
+    policy = RoutePolicy(logger_prefixes=["gateway.platforms.signal"], level=logging.WARNING)
+    assert policy.should_forward(_record("gateway.platforms.signal", logging.WARNING)) is True
+
+
+def test_drops_allowed_logger_below_floor():
+    policy = RoutePolicy(logger_prefixes=["gateway.platforms.signal"], level=logging.WARNING)
+    assert policy.should_forward(_record("gateway.platforms.signal", logging.INFO)) is False
+
+
+def test_drops_logger_not_in_allowlist():
+    policy = RoutePolicy(logger_prefixes=["gateway.platforms.signal"], level=logging.WARNING)
+    assert policy.should_forward(_record("some.other.module", logging.ERROR)) is False
+
+
+def test_forwards_submodule_of_allowed_prefix():
+    policy = RoutePolicy(logger_prefixes=["agent.conversation_loop"], level=logging.WARNING)
+    assert policy.should_forward(_record("agent.conversation_loop.cascade", logging.ERROR)) is True

--- a/tests/plugins/home_log_router/test_registration.py
+++ b/tests/plugins/home_log_router/test_registration.py
@@ -1,0 +1,98 @@
+"""registration.register(ctx) — wiring: env gate, root handler, sender, teardown."""
+import logging
+import threading
+
+from plugins.observability.home_log_router import registration
+from plugins.observability.home_log_router.handler import HomeLogHandler
+
+
+class FakeCtx:
+    def __init__(self):
+        self.dispatched = []
+        self.hooks = {}
+        self.tool_event = threading.Event()
+
+    def dispatch_tool(self, name, args, **kw):
+        self.dispatched.append((name, args))
+        self.tool_event.set()
+        return "{}"
+
+    def register_hook(self, name, cb):
+        self.hooks.setdefault(name, []).append(cb)
+
+
+def _our_handlers():
+    return [h for h in logging.getLogger().handlers if isinstance(h, HomeLogHandler)]
+
+
+def _teardown(ctx):
+    for cb in ctx.hooks.get("on_session_end", []):
+        cb()
+
+
+def test_active_when_plugin_enabled_by_default(monkeypatch):
+    # No env switch needed: enabling the plugin is the opt-in. register() activates.
+    monkeypatch.delenv("HERMES_HOME_LOG_ENABLED", raising=False)
+    ctx = FakeCtx()
+    try:
+        registration.register(ctx)
+        assert len(_our_handlers()) == 1
+        assert "on_session_end" in ctx.hooks
+    finally:
+        _teardown(ctx)
+    assert _our_handlers() == []
+
+
+def test_kill_switch_disables(monkeypatch):
+    # Optional escape hatch: disable without un-enabling the plugin.
+    monkeypatch.setenv("HERMES_HOME_LOG_ENABLED", "0")
+    before = len(_our_handlers())
+    ctx = FakeCtx()
+    registration.register(ctx)
+    assert len(_our_handlers()) == before
+    assert ctx.hooks == {}
+
+
+def test_enabled_attaches_handler_and_teardown_hook(monkeypatch):
+    monkeypatch.delenv("HERMES_HOME_LOG_ENABLED", raising=False)
+    ctx = FakeCtx()
+    try:
+        registration.register(ctx)
+        assert len(_our_handlers()) == 1
+        assert "on_session_end" in ctx.hooks
+    finally:
+        _teardown(ctx)
+    assert _our_handlers() == []  # teardown detached it
+
+
+def test_forwards_record_to_send_message_home(monkeypatch):
+    monkeypatch.setenv("HERMES_HOME_LOG_ENABLED", "1")
+    ctx = FakeCtx()
+    try:
+        registration.register(ctx)
+        log = logging.getLogger("gateway.platforms.signal")
+        log.setLevel(logging.DEBUG)
+        log.warning("disk full on %s", "agent-7")
+        assert ctx.tool_event.wait(timeout=2.0), "send_message was never dispatched"
+        name, args = ctx.dispatched[0]
+        assert name == "send_message"
+        assert args["target"] == "signal"      # bare platform -> home channel
+        assert "disk full on agent-7" in args["message"]
+    finally:
+        _teardown(ctx)
+
+
+def test_respects_platform_env(monkeypatch):
+    monkeypatch.setenv("HERMES_HOME_LOG_ENABLED", "1")
+    monkeypatch.setenv("HERMES_HOME_LOG_PLATFORM", "telegram")
+    ctx = FakeCtx()
+    try:
+        registration.register(ctx)
+        log = logging.getLogger("model_tools")
+        log.setLevel(logging.DEBUG)
+        log.error("provider down")
+        assert ctx.tool_event.wait(timeout=2.0)
+        _, args = ctx.dispatched[0]
+        assert args["target"] == "telegram"
+    finally:
+        _teardown(ctx)

--- a/tests/plugins/home_log_router/test_registration.py
+++ b/tests/plugins/home_log_router/test_registration.py
@@ -1,4 +1,9 @@
-"""registration.register(ctx) — wiring: env gate, root handler, sender, teardown."""
+"""registration.register(ctx) — wiring: enable gate, root handler, sender, lifecycle.
+
+Teardown is a process-lifetime concern (atexit), NOT on_session_end: that hook
+fires at the end of every conversation turn, which would tear the plugin down
+after the first message.
+"""
 import logging
 import threading
 
@@ -25,48 +30,41 @@ def _our_handlers():
     return [h for h in logging.getLogger().handlers if isinstance(h, HomeLogHandler)]
 
 
-def _teardown(ctx):
-    for cb in ctx.hooks.get("on_session_end", []):
-        cb()
-
-
 def test_active_when_plugin_enabled_by_default(monkeypatch):
-    # No env switch needed: enabling the plugin is the opt-in. register() activates.
     monkeypatch.delenv("HERMES_HOME_LOG_ENABLED", raising=False)
     ctx = FakeCtx()
     try:
         registration.register(ctx)
         assert len(_our_handlers()) == 1
-        assert "on_session_end" in ctx.hooks
+        # Must NOT use on_session_end (fires per turn -> self-destruct).
+        assert "on_session_end" not in ctx.hooks
     finally:
-        _teardown(ctx)
+        registration._teardown()
     assert _our_handlers() == []
 
 
 def test_kill_switch_disables(monkeypatch):
-    # Optional escape hatch: disable without un-enabling the plugin.
-    monkeypatch.setenv("HERMES_HOME_LOG_ENABLED", "0")
-    before = len(_our_handlers())
-    ctx = FakeCtx()
-    registration.register(ctx)
-    assert len(_our_handlers()) == before
-    assert ctx.hooks == {}
-
-
-def test_enabled_attaches_handler_and_teardown_hook(monkeypatch):
-    monkeypatch.delenv("HERMES_HOME_LOG_ENABLED", raising=False)
-    ctx = FakeCtx()
-    try:
+    for value in ("0", "false", "off"):
+        monkeypatch.setenv("HERMES_HOME_LOG_ENABLED", value)
+        before = len(_our_handlers())
+        ctx = FakeCtx()
         registration.register(ctx)
+        assert len(_our_handlers()) == before, value
+        registration._teardown()
+
+
+def test_register_is_idempotent(monkeypatch):
+    monkeypatch.delenv("HERMES_HOME_LOG_ENABLED", raising=False)
+    try:
+        registration.register(FakeCtx())
+        registration.register(FakeCtx())  # second call must not stack a handler
         assert len(_our_handlers()) == 1
-        assert "on_session_end" in ctx.hooks
     finally:
-        _teardown(ctx)
-    assert _our_handlers() == []  # teardown detached it
+        registration._teardown()
 
 
 def test_forwards_record_to_send_message_home(monkeypatch):
-    monkeypatch.setenv("HERMES_HOME_LOG_ENABLED", "1")
+    monkeypatch.delenv("HERMES_HOME_LOG_ENABLED", raising=False)
     ctx = FakeCtx()
     try:
         registration.register(ctx)
@@ -76,14 +74,14 @@ def test_forwards_record_to_send_message_home(monkeypatch):
         assert ctx.tool_event.wait(timeout=2.0), "send_message was never dispatched"
         name, args = ctx.dispatched[0]
         assert name == "send_message"
-        assert args["target"] == "signal"      # bare platform -> home channel
+        assert args["target"] == "signal"
         assert "disk full on agent-7" in args["message"]
     finally:
-        _teardown(ctx)
+        registration._teardown()
 
 
 def test_respects_platform_env(monkeypatch):
-    monkeypatch.setenv("HERMES_HOME_LOG_ENABLED", "1")
+    monkeypatch.delenv("HERMES_HOME_LOG_ENABLED", raising=False)
     monkeypatch.setenv("HERMES_HOME_LOG_PLATFORM", "telegram")
     ctx = FakeCtx()
     try:
@@ -95,4 +93,4 @@ def test_respects_platform_env(monkeypatch):
         _, args = ctx.dispatched[0]
         assert args["target"] == "telegram"
     finally:
-        _teardown(ctx)
+        registration._teardown()

--- a/tests/plugins/home_log_router/test_throttle.py
+++ b/tests/plugins/home_log_router/test_throttle.py
@@ -1,0 +1,77 @@
+"""Throttle — dedup identical messages, rate-cap a window, summarize suppressions.
+
+``admit(msg)`` returns the list of strings that should actually be sent: usually
+``[msg]``; ``[]`` when suppressed; and a leading summary line on the first admit
+following any suppression.
+"""
+from plugins.observability.home_log_router.throttle import Throttle
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 0.0
+
+    def __call__(self):
+        return self.t
+
+
+def _make(rate=100, window=60.0, dedup_window=300.0):
+    clock = FakeClock()
+    return Throttle(rate=rate, window=window, dedup_window=dedup_window, clock=clock), clock
+
+
+def test_admits_distinct_messages():
+    t, _ = _make()
+    assert t.admit("A") == ["A"]
+    assert t.admit("B") == ["B"]
+
+
+def test_suppresses_identical_within_dedup_window():
+    t, clock = _make(dedup_window=300.0)
+    assert t.admit("A") == ["A"]
+    clock.t = 1.0
+    assert t.admit("A") == []
+
+
+def test_readmits_identical_after_dedup_window():
+    t, clock = _make(dedup_window=300.0)
+    t.admit("A")
+    clock.t = 301.0
+    assert "A" in t.admit("A")
+
+
+def test_rate_cap_suppresses_excess_within_window():
+    t, _ = _make(rate=2, window=60.0)
+    assert t.admit("X") == ["X"]
+    assert t.admit("Y") == ["Y"]
+    assert t.admit("Z") == []  # third distinct message in the window is over the cap
+
+
+def test_rate_resets_after_window():
+    t, clock = _make(rate=1, window=10.0)
+    assert t.admit("X") == ["X"]
+    assert t.admit("Y") == []
+    clock.t = 11.0
+    assert "Z" in t.admit("Z")
+
+
+def test_summary_emitted_after_suppression():
+    t, clock = _make(rate=1, window=10.0)
+    t.admit("A")          # admitted
+    t.admit("B")          # rate-suppressed (count=1)
+    clock.t = 11.0
+    out = t.admit("C")    # new window: should lead with a summary, then "C"
+    assert out[-1] == "C"
+    assert len(out) == 2
+    assert "1" in out[0]
+    assert "suppress" in out[0].lower()
+
+
+def test_summary_counter_resets_after_emit():
+    t, clock = _make(rate=1, window=10.0)
+    t.admit("A")
+    t.admit("B")          # suppressed (count=1)
+    clock.t = 11.0
+    t.admit("C")          # emits summary, resets counter
+    clock.t = 22.0
+    assert t.admit("D") == ["D"]  # no lingering summary

--- a/tests/plugins/home_log_router/test_throttle.py
+++ b/tests/plugins/home_log_router/test_throttle.py
@@ -75,3 +75,21 @@ def test_summary_counter_resets_after_emit():
     t.admit("C")          # emits summary, resets counter
     clock.t = 22.0
     assert t.admit("D") == ["D"]  # no lingering summary
+
+
+def test_flush_summary_returns_pending_and_resets():
+    # A burst that ends with suppression (no following admit) must still be
+    # reportable via flush_summary, not lost.
+    t, _ = _make(rate=1, window=10.0)
+    t.admit("A")
+    t.admit("B")  # suppressed
+    out = t.flush_summary()
+    assert len(out) == 1
+    assert "1" in out[0] and "suppress" in out[0].lower()
+    assert t.flush_summary() == []  # counter cleared
+
+
+def test_flush_summary_empty_when_nothing_suppressed():
+    t, _ = _make()
+    t.admit("A")
+    assert t.flush_summary() == []

--- a/tests/plugins/home_log_router/test_worker.py
+++ b/tests/plugins/home_log_router/test_worker.py
@@ -1,0 +1,82 @@
+"""HomeLogWorker — drains the queue, applies Throttle, sends under the guard."""
+import queue
+import threading
+
+from plugins.observability.home_log_router.guard import ReentrancyGuard
+from plugins.observability.home_log_router.throttle import Throttle
+from plugins.observability.home_log_router.worker import HomeLogWorker
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 0.0
+
+    def __call__(self):
+        return self.t
+
+
+def _worker(rate=100, window=60.0, dedup_window=300.0, sender=None, guard=None):
+    clock = FakeClock()
+    q: "queue.Queue[str]" = queue.Queue(maxsize=100)
+    throttle = Throttle(rate=rate, window=window, dedup_window=dedup_window, clock=clock)
+    guard = guard or ReentrancyGuard()
+    w = HomeLogWorker(out_queue=q, throttle=throttle, sender=sender or (lambda m: None), guard=guard)
+    return w, q, clock, guard
+
+
+def test_process_sends_admitted_message():
+    sent = []
+    w, *_ = _worker(sender=sent.append)
+    w.process("hello")
+    assert sent == ["hello"]
+
+
+def test_process_applies_throttle_dedup():
+    sent = []
+    w, _, clock, _ = _worker(sender=sent.append)
+    w.process("dup")
+    clock.t = 1.0
+    w.process("dup")  # within dedup window -> suppressed
+    assert sent == ["dup"]
+
+
+def test_send_runs_under_guard():
+    seen = []
+    guard = ReentrancyGuard()
+    w, *_ = _worker(sender=lambda m: seen.append(guard.active), guard=guard)
+    w.process("x")
+    assert seen == [True]            # guard active during the send
+    assert guard.active is False     # released afterward
+
+
+def test_sender_exception_is_swallowed():
+    def boom(_):
+        raise RuntimeError("send failed")
+
+    w, *_ = _worker(sender=boom)
+    w.process("x")  # must not raise
+
+
+def test_thread_drains_queue():
+    received = []
+    done = threading.Event()
+
+    def sender(m):
+        received.append(m)
+        done.set()
+
+    w, q, *_ = _worker(sender=sender)
+    w.start()
+    try:
+        q.put("from-thread")
+        assert done.wait(timeout=2.0), "worker thread did not drain the queue"
+    finally:
+        w.stop()
+    assert received == ["from-thread"]
+
+
+def test_stop_is_idempotent_and_joins():
+    w, *_ = _worker()
+    w.start()
+    w.stop()
+    w.stop()  # second stop must not raise

--- a/tests/plugins/home_log_router/test_worker.py
+++ b/tests/plugins/home_log_router/test_worker.py
@@ -80,3 +80,25 @@ def test_stop_is_idempotent_and_joins():
     w.start()
     w.stop()
     w.stop()  # second stop must not raise
+
+
+def test_idle_flush_sends_pending_summary():
+    sent = []
+    w, _, clock, _ = _worker(rate=1, window=10.0, sender=sent.append)
+    w.process("A")          # admitted
+    w.process("B")          # suppressed (rate)
+    sent.clear()
+    w.idle_flush()          # should drain the pending suppression summary
+    assert len(sent) == 1
+    assert "suppress" in sent[0].lower()
+
+
+def test_idle_flush_sends_under_guard():
+    seen = []
+    guard = ReentrancyGuard()
+    w, *_ = _worker(rate=1, window=10.0, sender=lambda m: seen.append(guard.active), guard=guard)
+    w.process("A")
+    w.process("B")  # suppressed
+    seen.clear()
+    w.idle_flush()
+    assert seen == [True]


### PR DESCRIPTION
## What

A new opt-in plugin (`plugins/observability/home_log_router/`) that forwards the operational logs that matter — cascade fallbacks, provider errors, persistent reconnects — to an agent's **home channel**.

## Why

Agents suppress these records to keep chat clean, but none reach the home channel: only shutdown/startup/cron resolve `get_home_channel()`. Suppression isn't routing, so operators are blind to agent health. (Root-caused in a prior investigation handoff.)

## How

Installs a `logging.Handler` on the root logger and forwards a curated, throttled slice of records to home via the existing `send_message` tool (a bare platform target resolves to the home channel). **Zero core emit-site edits** — survives upstream rebases, honoring the thin-patch fork constraint.

Five small, independently-tested units:
- **RoutePolicy** — pure: allowlist-prefix ∩ level-floor decision
- **Throttle** — pure (injectable clock): dedup + rate-cap + "N suppressed" summary
- **HomeLogHandler** — cheap non-blocking `emit()` (policy-gate, format, `put_nowait`, drop-on-full)
- **HomeLogWorker** — daemon thread: drain queue → throttle → guarded send
- **ReentrancyGuard** — process-wide loop-breaker: `send_message` → `_run_async` runs the send on a *separate* thread where the Signal adapter emits allowlisted logs; a thread-local guard would miss it and feed back

## Policy

- Default allowlist (grounded in real logger names): `gateway.platforms.signal`, `agent.conversation_loop`, `model_tools` at WARNING+. Benign Signal reconnect churn is already DEBUG, so the floor skips noise.
- **Opt-in** by enabling the plugin; `HERMES_HOME_LOG_ENABLED=0` is a kill switch.
- **Silent no-op** when no home channel is set.
- Storm-safe: bounded queue (drop-on-full), dedup, rate-cap.

## Tests

26 tests in `tests/plugins/home_log_router/`, all green. Each unit tested in isolation (fake ctx / fake sender / fake clock) plus an end-to-end through `register()`.

> Note: tested locally on Python 3.9 (only interpreter available here; units are pure stdlib and 3.9-safe). CI on 3.11 should confirm against the full suite. Change is purely additive — no core files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)