### PR TITLE
fix(home_log_router): send via send_message_tool() directly (was Unknown tool)

### DIFF
--- a/plugins/observability/home_log_router/registration.py
+++ b/plugins/observability/home_log_router/registration.py
@@ -123,7 +123,7 @@ def register(ctx) -> None:
     out_queue: "queue.Queue[str]" = queue.Queue(maxsize=cfg.queue_max)
     handler = HomeLogHandler(RoutePolicy(cfg.loggers, cfg.level), out_queue, guard)
     throttle = Throttle(cfg.rate, cfg.window, cfg.dedup_window, time.monotonic)
-    worker = HomeLogWorker(out_queue, throttle, _make_sender(ctx, cfg.platform), guard)
+    worker = HomeLogWorker(out_queue, throttle, _make_sender(cfg.platform), guard)
 
     logging.getLogger().addHandler(handler)
     worker.start()
@@ -149,10 +149,19 @@ def _teardown() -> None:
         _worker = None
 
 
-def _make_sender(ctx, platform: str):
+def _send_to_home(platform: str, message: str) -> None:
+    # Invoke the send_message tool FUNCTION directly. In the gateway plugin/worker
+    # context the tool is NOT in the dispatchable registry (ctx.dispatch_tool
+    # returns ``{"error": "Unknown tool: send_message"}``), so we call the function.
+    # A bare platform target resolves to get_home_channel(); return value (incl.
+    # "no home" errors) is intentionally ignored — forwarding is best-effort.
+    from tools.send_message_tool import send_message_tool
+
+    send_message_tool({"target": platform, "message": message})
+
+
+def _make_sender(platform: str):
     def sender(message: str) -> None:
-        # Bare platform target -> home channel. Return value (incl. "no home"
-        # errors) is intentionally ignored: forwarding is best-effort.
-        ctx.dispatch_tool("send_message", {"target": platform, "message": message})
+        _send_to_home(platform, message)
 
     return sender

--- a/tests/plugins/home_log_router/test_registration.py
+++ b/tests/plugins/home_log_router/test_registration.py
@@ -63,19 +63,35 @@ def test_register_is_idempotent(monkeypatch):
         registration._teardown()
 
 
+def _capture_sends(monkeypatch):
+    """Patch _send_to_home (the real sink) and capture (platform, message) calls.
+
+    The sink calls the send_message tool FUNCTION directly — NOT ctx.dispatch_tool,
+    which returns "Unknown tool: send_message" in the gateway worker context.
+    """
+    sent = []
+    evt = threading.Event()
+
+    def fake(platform, message):
+        sent.append((platform, message))
+        evt.set()
+
+    monkeypatch.setattr(registration, "_send_to_home", fake)
+    return sent, evt
+
+
 def test_forwards_record_to_send_message_home(monkeypatch):
     monkeypatch.delenv("HERMES_HOME_LOG_ENABLED", raising=False)
-    ctx = FakeCtx()
+    sent, evt = _capture_sends(monkeypatch)
     try:
-        registration.register(ctx)
+        registration.register(FakeCtx())
         log = logging.getLogger("gateway.platforms.signal")
         log.setLevel(logging.DEBUG)
         log.warning("disk full on %s", "agent-7")
-        assert ctx.tool_event.wait(timeout=2.0), "send_message was never dispatched"
-        name, args = ctx.dispatched[0]
-        assert name == "send_message"
-        assert args["target"] == "signal"
-        assert "disk full on agent-7" in args["message"]
+        assert evt.wait(timeout=2.0), "log was never forwarded to home"
+        platform, message = sent[0]
+        assert platform == "signal"
+        assert "disk full on agent-7" in message
     finally:
         registration._teardown()
 
@@ -83,14 +99,13 @@ def test_forwards_record_to_send_message_home(monkeypatch):
 def test_respects_platform_env(monkeypatch):
     monkeypatch.delenv("HERMES_HOME_LOG_ENABLED", raising=False)
     monkeypatch.setenv("HERMES_HOME_LOG_PLATFORM", "telegram")
-    ctx = FakeCtx()
+    sent, evt = _capture_sends(monkeypatch)
     try:
-        registration.register(ctx)
+        registration.register(FakeCtx())
         log = logging.getLogger("model_tools")
         log.setLevel(logging.DEBUG)
         log.error("provider down")
-        assert ctx.tool_event.wait(timeout=2.0)
-        _, args = ctx.dispatched[0]
-        assert args["target"] == "telegram"
+        assert evt.wait(timeout=2.0)
+        assert sent[0][0] == "telegram"
     finally:
         registration._teardown()


### PR DESCRIPTION
## The bug
`home_log_router` (PR #27) forwarded logs via `ctx.dispatch_tool("send_message", …)`. In the gateway plugin/worker context **`send_message` is not in the dispatchable registry** — every forward returned `{"error": "Unknown tool: send_message"}` and was swallowed by the worker's best-effort catch. So since it shipped, the plugin captured records correctly but **nothing ever reached any home channel.** (Found while debugging why a Signal "message bus" had received no logs since June 1.)

## The fix
Call the `send_message` tool **function** directly via a `_send_to_home(platform, message)` sink (`tools.send_message_tool`). Bare platform target still resolves to `get_home_channel()`.

Verified live on a deployed agent — a `model_tools` WARNING now returns:
`{"success": true, "platform": "signal", ... "note": "Sent to signal home channel"}` and lands on the agent's Signal home.

## Tests
`test_registration.py` now patches `_send_to_home` (the real sink) instead of `ctx.dispatch_tool`. 40 plugin tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)