### PR TITLE
feat: surface model/aux fallback cascades to the home channel (WARNING)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5416,7 +5416,7 @@ def call_llm(
                 reason = "rate limit"
             else:
                 reason = "connection error"
-            logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
+            logger.warning("Auxiliary %s: %s on %s (%s), trying fallback",
                         task or "call", reason, resolved_provider, first_err)
 
             # Fallback order (#26882, #26803):
@@ -5840,7 +5840,7 @@ async def async_call_llm(
                 reason = "rate limit"
             else:
                 reason = "connection error"
-            logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",
+            logger.warning("Auxiliary %s (async): %s on %s (%s), trying fallback",
                         task or "call", reason, resolved_provider, first_err)
 
             # Fallback order (#26882, #26803):

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1251,7 +1251,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             f"🔄 Primary model failed — switching to fallback: "
             f"{fb_model} via {fb_provider}"
         )
-        logger.info(
+        logger.warning(
             "Fallback activated: %s → %s (%s)",
             old_model, fb_model, fb_provider,
         )

--- a/plugins/observability/home_log_router/registration.py
+++ b/plugins/observability/home_log_router/registration.py
@@ -39,6 +39,7 @@ DEFAULT_LOGGERS: Tuple[str, ...] = (
     "gateway.platforms.signal",
     "agent.conversation_loop",
     "model_tools",
+    "agent.auxiliary_client",
 )
 
 

--- a/tests/plugins/home_log_router/test_config.py
+++ b/tests/plugins/home_log_router/test_config.py
@@ -23,6 +23,9 @@ def test_defaults(monkeypatch):
     assert c.platform == "signal"
     assert c.level == logging.WARNING
     assert c.loggers == DEFAULT_LOGGERS
+    # cascade + provider fallbacks (incl. auxiliary client) forward by default
+    assert "agent.conversation_loop" in c.loggers
+    assert "agent.auxiliary_client" in c.loggers
     assert c.rate == 20 and c.window == 60 and c.dedup_window == 300
 
 


### PR DESCRIPTION
Follow-up to the home_log_router fixes: route the *cascade* events to the home channel (Signal "message bus").

These operational events were emitted at **INFO**, below the home_log_router WARNING floor, so they never reached home — even after the send-path fix. A fallback is a degraded state worth seeing, so bump to WARNING:

- **`agent/chat_completion_helpers.py`** — `"Fallback activated: <old> → <new>"` (the model cascade event).
- **`agent/auxiliary_client.py`** — auxiliary provider fallbacks (sync + async).
- **`plugins/observability/home_log_router/registration.py`** — add `agent.auxiliary_client` to the default allowlist so the aux fallbacks forward.

Left the `"clearing primary credential pool"` line at INFO on purpose — it fires alongside `"Fallback activated"` on every fallback and would just double-log the bus. The plugin's dedup + rate-cap keep frequent cascades from flooding.

The `_buffer_status` 🔄 chat notice is untouched — this only changes the *log* path (→ bus), not user-facing chat.

40 plugin tests green.

> Note: the two level bumps are core code (baked in the image), so they go live on an agent image rebuild; the allowlist change is in the hot-mounted plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)