### PR TITLE
gardener_approvals: deterministic two-way Signal approval trigger

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -328,6 +328,7 @@ def build_turn_context(
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
+            sender_id_alt=getattr(agent, "_user_id_alt", None) or "",
         )
         _ctx_parts: list[str] = []
         for r in _pre_results:

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -133,6 +133,8 @@ _DEFAULT_PAYLOADS = {
         "is_first_turn": True,
         "model": "gpt-4",
         "platform": "cli",
+        "sender_id": "+15550001234",
+        "sender_id_alt": "test-sender-uuid",
     },
     "post_llm_call": {
         "session_id": "test-session",

--- a/plugins/gardener_approvals/__init__.py
+++ b/plugins/gardener_approvals/__init__.py
@@ -1,1 +1,13 @@
-# placeholder — full register(ctx) added in Task 6
+"""gardener_approvals — deterministic two-way Signal approval trigger.
+
+On every Signal turn, parses a reply to an open gardener decision and routes it
+through the decision-approve gate with the verified sender UUID. The gate owns
+all security; the LLM only relays the gate's confirm line. See the design spec
+in nimbleco-egregore: specs/2026-06-09-gardener-approval-trigger-hook-design.md.
+"""
+from __future__ import annotations
+
+
+def register(ctx) -> None:
+    from .registration import register as _register
+    _register(ctx)

--- a/plugins/gardener_approvals/__init__.py
+++ b/plugins/gardener_approvals/__init__.py
@@ -1,0 +1,1 @@
+# placeholder — full register(ctx) added in Task 6

--- a/plugins/gardener_approvals/config.py
+++ b/plugins/gardener_approvals/config.py
@@ -1,0 +1,35 @@
+"""Env-driven config. Active by default once the plugin is enabled in
+plugins.enabled; HERMES_GARDENER_APPROVALS_ENABLED=0 is a kill switch.
+"""
+from __future__ import annotations
+
+import os
+from typing import NamedTuple
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+_DEFAULT_GATE = "/opt/data/scripts/decision-approve.sh"
+_DEFAULT_DECISIONS = "/opt/data/gardener-memory/state/decisions.md"
+
+
+class Config(NamedTuple):
+    enabled: bool
+    gate_path: str
+    decisions_file: str
+    approver: str
+
+
+def _enabled() -> bool:
+    val = os.getenv("HERMES_GARDENER_APPROVALS_ENABLED")
+    if val is None:
+        return True
+    return val.strip().lower() in _TRUTHY
+
+
+def load_config() -> Config:
+    return Config(
+        enabled=_enabled(),
+        gate_path=os.getenv("HERMES_GARDENER_GATE", _DEFAULT_GATE).strip() or _DEFAULT_GATE,
+        decisions_file=os.getenv("HERMES_GARDENER_DECISIONS", _DEFAULT_DECISIONS).strip() or _DEFAULT_DECISIONS,
+        approver=os.getenv("HERMES_GARDENER_APPROVER", "Juniper").strip() or "Juniper",
+    )

--- a/plugins/gardener_approvals/decisions.py
+++ b/plugins/gardener_approvals/decisions.py
@@ -1,0 +1,19 @@
+"""Read OPEN decision ids from the gardener decisions.md. Mirrors the gate's
+`open_ids()` grep so the hook and the gate agree on what 'open' means. Real
+dated ids only — the `D-YYYY-MM-DD-NN` format example is never matched.
+"""
+from __future__ import annotations
+
+import re
+from typing import List
+
+_OPEN_RE = re.compile(r"^## (D-\d{4}-\d{2}-\d{2}-\d+) .*status: open", re.MULTILINE)
+
+
+def read_open_ids(decisions_path: str) -> List[str]:
+    try:
+        with open(decisions_path, "r", encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError:
+        return []
+    return _OPEN_RE.findall(text)

--- a/plugins/gardener_approvals/decisions.py
+++ b/plugins/gardener_approvals/decisions.py
@@ -1,19 +1,60 @@
-"""Read OPEN decision ids from the gardener decisions.md. Mirrors the gate's
+"""Read OPEN decisions from the gardener decisions.md. Mirrors the gate's
 `open_ids()` grep so the hook and the gate agree on what 'open' means. Real
 dated ids only — the `D-YYYY-MM-DD-NN` format example is never matched.
+
+Each open block is returned as a Decision dataclass carrying the id and,
+when the block contains a Link: line that references a PR, the PR number.
 """
 from __future__ import annotations
 
 import re
-from typing import List
+from dataclasses import dataclass
+from typing import List, Optional
 
 _OPEN_RE = re.compile(r"^## (D-\d{4}-\d{2}-\d{2}-\d+) .*status: open", re.MULTILINE)
 
+# Matches any of:
+#   PR #27   |  #27   |  pull/27   |  /pull/27
+_PR_NUM_RE = re.compile(r"(?:PR\s+#|/pull/)(\d+)|#(\d+)|pull/(\d+)", re.IGNORECASE)
 
-def read_open_ids(decisions_path: str) -> List[str]:
+
+@dataclass
+class Decision:
+    id: str
+    pr_number: Optional[int]
+
+
+def read_open_decisions(decisions_path: str) -> List[Decision]:
     try:
         with open(decisions_path, "r", encoding="utf-8") as fh:
             text = fh.read()
     except OSError:
         return []
-    return _OPEN_RE.findall(text)
+
+    decisions: List[Decision] = []
+    for m in _OPEN_RE.finditer(text):
+        dec_id = m.group(1)
+        block_start = m.start()
+        # Find end of block: next ## header or EOF
+        next_header = re.search(r"^## ", text[block_start + 1:], re.MULTILINE)
+        block_end = (block_start + 1 + next_header.start()) if next_header else len(text)
+        block_text = text[block_start:block_end]
+
+        pr_number: Optional[int] = None
+        # Only scan Link: lines for PR numbers
+        for line in block_text.splitlines():
+            if "link:" in line.lower():
+                pm = _PR_NUM_RE.search(line)
+                if pm:
+                    # groups: (PR #N, #N, pull/N) — first non-None group wins
+                    raw = pm.group(1) or pm.group(2) or pm.group(3)
+                    pr_number = int(raw)
+                    break
+
+        decisions.append(Decision(id=dec_id, pr_number=pr_number))
+
+    return decisions
+
+
+def read_open_ids(decisions_path: str) -> List[str]:
+    return [d.id for d in read_open_decisions(decisions_path)]

--- a/plugins/gardener_approvals/gate.py
+++ b/plugins/gardener_approvals/gate.py
@@ -1,0 +1,43 @@
+"""Thin subprocess wrapper around decision-approve.sh. The gate enforces ALL
+security (auth/allowlist/idempotency); this only marshals args and reads back
+the `<TOKEN> <message>` protocol line. `runner` is injectable for tests.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Optional, Tuple
+
+
+def call_gate(
+    *,
+    gate_path: str,
+    uuid: str,
+    decision_id: Optional[str],
+    action: str,
+    value: str,
+    approver: str,
+    decisions_file: Optional[str] = None,
+    runner=subprocess.run,
+    timeout: int = 60,
+) -> Tuple[str, str]:
+    cmd = [
+        gate_path,
+        "--requester-uuid", uuid,
+        "--decision-id", decision_id or "",
+        "--action", action,
+        "--value", value,
+        "--approver-name", approver,
+    ]
+    env = dict(os.environ)
+    if decisions_file:
+        env["DECISIONS_FILE"] = decisions_file
+    try:
+        proc = runner(cmd, capture_output=True, text=True, env=env, timeout=timeout)
+    except Exception:
+        return "ERROR", ""
+    first = (getattr(proc, "stdout", "") or "").splitlines()
+    if not first:
+        return "ERROR", ""
+    token, _, msg = first[0].partition(" ")
+    return token, msg

--- a/plugins/gardener_approvals/handler.py
+++ b/plugins/gardener_approvals/handler.py
@@ -1,0 +1,70 @@
+"""pre_llm_call hook: turn a Signal reply into a gated decision action.
+
+Deterministic trigger — parses intent in code and calls the gate with the
+verified Signal UUID; the LLM only relays the gate's confirm line. The gate is
+the sole security boundary (auth/allowlist/idempotency); this hook's parse is a
+convenience the gate re-validates. Fails safe: any error returns "" so a hook
+bug can never break the agent turn.
+"""
+from __future__ import annotations
+
+import logging
+
+from .config import load_config
+from .decisions import read_open_ids
+from .gate import call_gate
+from .parser import parse_reply
+
+logger = logging.getLogger(__name__)
+
+# Tokens whose human message we relay to the user verbatim.
+_RELAY = {"OK", "ALREADY_DONE", "AMBIGUOUS", "REFUSED_ALLOWLIST"}
+
+
+def _relay(msg: str) -> dict:
+    # Tell the LLM to relay exactly this line and nothing else.
+    return {"context": "[gardener] A Signal decision reply was processed by the "
+            "approval gate. Relay this line to the user verbatim and add nothing "
+            f"else:\n{msg}"}
+
+
+def on_pre_llm_call(*, platform: str = "", user_message: str = "",
+                    sender_id: str = "", sender_id_alt: str = "",
+                    _config=None, _open_reader=None, _gate_caller=None,
+                    **_kwargs):
+    try:
+        cfg = _config or load_config()
+        if not cfg.enabled:
+            return ""
+        if (platform or "").strip().lower() != "signal":
+            return ""
+        uuid = (sender_id_alt or sender_id or "").strip()
+        if not uuid:
+            return ""
+        open_reader = _open_reader or read_open_ids
+        open_ids = open_reader(cfg.decisions_file)
+        if not open_ids:
+            return ""
+        pr = parse_reply(user_message or "", open_ids)
+        if pr.ask:
+            return _relay(pr.ask)
+        if not pr.matched:
+            return ""
+        gate = _gate_caller or call_gate
+        token, msg = gate(
+            gate_path=cfg.gate_path, uuid=uuid, decision_id=pr.decision_id,
+            action=pr.action, value=pr.value, approver=cfg.approver,
+            decisions_file=cfg.decisions_file,
+        )
+        if token in _RELAY and msg:
+            return _relay(msg)
+        if token == "REFUSED_AUTH":
+            return ""   # unknown sender -> silence, by design
+        if token == "ERROR":
+            return {"context": "[gardener] The approval gate couldn't complete "
+                    "that. Tell the user it didn't go through and to try again in "
+                    "Claude Code. Do not claim success."}
+        return ""
+    except Exception:
+        logger.exception("gardener_approvals hook error (suppressed; turn continues)")
+        return ""

--- a/plugins/gardener_approvals/handler.py
+++ b/plugins/gardener_approvals/handler.py
@@ -56,6 +56,7 @@ def on_pre_llm_call(*, platform: str = "", user_message: str = "",
             action=pr.action, value=pr.value, approver=cfg.approver,
             decisions_file=cfg.decisions_file,
         )
+        # msg must be non-empty; empty relay messages are silently dropped (gate protocol)
         if token in _RELAY and msg:
             return _relay(msg)
         if token == "REFUSED_AUTH":

--- a/plugins/gardener_approvals/handler.py
+++ b/plugins/gardener_approvals/handler.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 
 from .config import load_config
-from .decisions import read_open_ids
+from .decisions import read_open_decisions
 from .gate import call_gate
 from .parser import parse_reply
 
@@ -41,11 +41,11 @@ def on_pre_llm_call(*, platform: str = "", user_message: str = "",
         uuid = (sender_id_alt or sender_id or "").strip()
         if not uuid:
             return ""
-        open_reader = _open_reader or read_open_ids
-        open_ids = open_reader(cfg.decisions_file)
-        if not open_ids:
+        open_reader = _open_reader or read_open_decisions
+        decisions = open_reader(cfg.decisions_file)
+        if not decisions:
             return ""
-        pr = parse_reply(user_message or "", open_ids)
+        pr = parse_reply(user_message or "", decisions)
         if pr.ask:
             return _relay(pr.ask)
         if not pr.matched:

--- a/plugins/gardener_approvals/parser.py
+++ b/plugins/gardener_approvals/parser.py
@@ -1,9 +1,11 @@
-"""Pure intent parser: a Signal reply + the open decision ids -> a structured
+"""Pure intent parser: a Signal reply + the open decisions -> a structured
 action. No I/O, no subprocess — fully unit-testable. The gate re-validates
 everything; this parser only decides what (if anything) to ask the gate to do.
 
-v1 maps to the {resolve} action only (approve/hold). `merge` is intentionally
-NOT emitted here yet — it is enabled only after the resolve loop is proven live.
+Intent mapping:
+  - hold-intent              → action="resolve", value="hold"
+  - approve-intent + PR dec  → action="merge",   value=str(pr_number)
+  - approve-intent + no PR   → action="resolve",  value="approve"
 """
 from __future__ import annotations
 
@@ -11,26 +13,29 @@ import re
 from dataclasses import dataclass
 from typing import List, Optional
 
+from .decisions import Decision
+
 _DEC_ID_RE = re.compile(r"D-\d{4}-\d{2}-\d{2}-\d+")
 
 # Single-word keywords — matched by word boundary (token membership).
 # Short ambiguous words ("go", "ok") are excluded on purpose — a false trigger
 # resolves a decision the user didn't mean.
-_APPROVE_WORDS = frozenset(("approve", "approved", "approves", "yes", "yep", "yeah", "lgtm"))
-_APPROVE_PHRASES = ("do it", "go ahead", "ship it")          # substring match (specific enough)
-_APPROVE_EMOJI = ("\U0001F44D", "✅")                         # raw text substring match
+_APPROVE_WORDS = frozenset(("approve", "approved", "approves", "yes", "yep", "yeah", "lgtm",
+                             "merge"))
+_APPROVE_PHRASES = ("do it", "go ahead", "ship it", "merge it")   # substring match
+_APPROVE_EMOJI = ("\U0001F44D", "✅")                               # raw text substring match
 
 # Hold keywords — single-word boundary-matched; "not"/"never"/"dont" also serve
 # as negation so that "not approved" / "I disapprove" → conflict → no-op.
 _HOLD_WORDS = frozenset(("hold", "wait", "nope", "later", "no", "not", "never", "dont"))
-_HOLD_PHRASES = ("not yet", "do not", "don't")               # substring match
+_HOLD_PHRASES = ("not yet", "do not", "don't")                     # substring match
 
 
 @dataclass
 class ParseResult:
     matched: bool
-    action: Optional[str] = None        # "resolve"
-    value: Optional[str] = None         # "approve" | "hold"
+    action: Optional[str] = None        # "resolve" | "merge"
+    value: Optional[str] = None         # "approve" | "hold" | str(pr_number)
     decision_id: Optional[str] = None
     ask: Optional[str] = None           # set -> inject this, DO NOT call the gate
 
@@ -44,9 +49,10 @@ def _has_word(text: str, words) -> bool:
     return bool(toks & words)
 
 
-def parse_reply(text: str, open_ids: List[str]) -> ParseResult:
-    if not open_ids:
+def parse_reply(text: str, decisions: List[Decision]) -> ParseResult:
+    if not decisions:
         return ParseResult(matched=False)
+    open_ids = [d.id for d in decisions]
     raw = text or ""
     low = raw.lower()
 
@@ -59,7 +65,6 @@ def parse_reply(text: str, open_ids: List[str]) -> ParseResult:
         return ParseResult(matched=False)            # conflicting -> no-op
     if not approve and not hold:
         return ParseResult(matched=False)            # no intent -> no-op
-    value = "approve" if approve else "hold"
 
     # Which decision: explicit id wins; else exactly-one-open; else ambiguous.
     m = _DEC_ID_RE.search(raw)
@@ -72,4 +77,13 @@ def parse_reply(text: str, open_ids: List[str]) -> ParseResult:
             matched=False,
             ask=f"Which decision? Reply with the D-… id (e.g. {open_ids[0]}).",
         )
-    return ParseResult(matched=True, action="resolve", value=value, decision_id=dec_id)
+
+    if hold:
+        return ParseResult(matched=True, action="resolve", value="hold", decision_id=dec_id)
+
+    # approve intent — check whether the target decision has a PR number
+    target = next((d for d in decisions if d.id == dec_id), None)
+    if target is not None and target.pr_number is not None:
+        return ParseResult(matched=True, action="merge",
+                           value=str(target.pr_number), decision_id=dec_id)
+    return ParseResult(matched=True, action="resolve", value="approve", decision_id=dec_id)

--- a/plugins/gardener_approvals/parser.py
+++ b/plugins/gardener_approvals/parser.py
@@ -13,13 +13,17 @@ from typing import List, Optional
 
 _DEC_ID_RE = re.compile(r"D-\d{4}-\d{2}-\d{2}-\d+")
 
-# Whole-word / phrase keywords. Short ambiguous words ("go", "ok") are excluded
-# on purpose — a false trigger resolves a decision the user didn't mean.
-_APPROVE = ("approve", "approved", "approves", "yes", "yep", "yeah", "do it",
-            "go ahead", "ship it", "lgtm")
-_APPROVE_EMOJI = ("\U0001F44D", "✅")  # 👍 ✅
-_HOLD = ("hold", "not yet", "wait", "nope", "later")
-_HOLD_WORD = ("no",)  # matched only as a standalone word
+# Single-word keywords — matched by word boundary (token membership).
+# Short ambiguous words ("go", "ok") are excluded on purpose — a false trigger
+# resolves a decision the user didn't mean.
+_APPROVE_WORDS = frozenset(("approve", "approved", "approves", "yes", "yep", "yeah", "lgtm"))
+_APPROVE_PHRASES = ("do it", "go ahead", "ship it")          # substring match (specific enough)
+_APPROVE_EMOJI = ("\U0001F44D", "✅")                         # raw text substring match
+
+# Hold keywords — single-word boundary-matched; "not"/"never"/"dont" also serve
+# as negation so that "not approved" / "I disapprove" → conflict → no-op.
+_HOLD_WORDS = frozenset(("hold", "wait", "nope", "later", "no", "not", "never", "dont"))
+_HOLD_PHRASES = ("not yet", "do not", "don't")               # substring match
 
 
 @dataclass
@@ -36,8 +40,8 @@ def _has_phrase(text: str, phrases) -> bool:
 
 
 def _has_word(text: str, words) -> bool:
-    toks = re.findall(r"[a-z]+", text)
-    return any(w in toks for w in words)
+    toks = set(re.findall(r"[a-z]+", text))
+    return bool(toks & words)
 
 
 def parse_reply(text: str, open_ids: List[str]) -> ParseResult:
@@ -46,8 +50,11 @@ def parse_reply(text: str, open_ids: List[str]) -> ParseResult:
     raw = text or ""
     low = raw.lower()
 
-    approve = _has_phrase(low, _APPROVE) or any(e in raw for e in _APPROVE_EMOJI)
-    hold = _has_phrase(low, _HOLD) or _has_word(low, _HOLD_WORD)
+    approve = (_has_word(low, _APPROVE_WORDS)
+               or _has_phrase(low, _APPROVE_PHRASES)
+               or any(e in raw for e in _APPROVE_EMOJI))
+    hold = (_has_word(low, _HOLD_WORDS)
+            or _has_phrase(low, _HOLD_PHRASES))
     if approve and hold:
         return ParseResult(matched=False)            # conflicting -> no-op
     if not approve and not hold:

--- a/plugins/gardener_approvals/parser.py
+++ b/plugins/gardener_approvals/parser.py
@@ -1,0 +1,68 @@
+"""Pure intent parser: a Signal reply + the open decision ids -> a structured
+action. No I/O, no subprocess — fully unit-testable. The gate re-validates
+everything; this parser only decides what (if anything) to ask the gate to do.
+
+v1 maps to the {resolve} action only (approve/hold). `merge` is intentionally
+NOT emitted here yet — it is enabled only after the resolve loop is proven live.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+_DEC_ID_RE = re.compile(r"D-\d{4}-\d{2}-\d{2}-\d+")
+
+# Whole-word / phrase keywords. Short ambiguous words ("go", "ok") are excluded
+# on purpose — a false trigger resolves a decision the user didn't mean.
+_APPROVE = ("approve", "approved", "approves", "yes", "yep", "yeah", "do it",
+            "go ahead", "ship it", "lgtm")
+_APPROVE_EMOJI = ("\U0001F44D", "✅")  # 👍 ✅
+_HOLD = ("hold", "not yet", "wait", "nope", "later")
+_HOLD_WORD = ("no",)  # matched only as a standalone word
+
+
+@dataclass
+class ParseResult:
+    matched: bool
+    action: Optional[str] = None        # "resolve"
+    value: Optional[str] = None         # "approve" | "hold"
+    decision_id: Optional[str] = None
+    ask: Optional[str] = None           # set -> inject this, DO NOT call the gate
+
+
+def _has_phrase(text: str, phrases) -> bool:
+    return any(p in text for p in phrases)
+
+
+def _has_word(text: str, words) -> bool:
+    toks = re.findall(r"[a-z]+", text)
+    return any(w in toks for w in words)
+
+
+def parse_reply(text: str, open_ids: List[str]) -> ParseResult:
+    if not open_ids:
+        return ParseResult(matched=False)
+    raw = text or ""
+    low = raw.lower()
+
+    approve = _has_phrase(low, _APPROVE) or any(e in raw for e in _APPROVE_EMOJI)
+    hold = _has_phrase(low, _HOLD) or _has_word(low, _HOLD_WORD)
+    if approve and hold:
+        return ParseResult(matched=False)            # conflicting -> no-op
+    if not approve and not hold:
+        return ParseResult(matched=False)            # no intent -> no-op
+    value = "approve" if approve else "hold"
+
+    # Which decision: explicit id wins; else exactly-one-open; else ambiguous.
+    m = _DEC_ID_RE.search(raw)
+    if m:
+        dec_id = m.group(0)
+    elif len(open_ids) == 1:
+        dec_id = open_ids[0]
+    else:
+        return ParseResult(
+            matched=False,
+            ask=f"Which decision? Reply with the D-… id (e.g. {open_ids[0]}).",
+        )
+    return ParseResult(matched=True, action="resolve", value=value, decision_id=dec_id)

--- a/plugins/gardener_approvals/plugin.yaml
+++ b/plugins/gardener_approvals/plugin.yaml
@@ -1,0 +1,6 @@
+name: gardener_approvals
+version: "1.0.0"
+description: "Deterministic two-way Signal approvals trigger — routes a gardener decision reply through the decision-approve gate with the verified sender UUID. Enable via `hermes plugins enable gardener_approvals`."
+author: nimbleco gardener
+hooks:
+  - pre_llm_call

--- a/plugins/gardener_approvals/registration.py
+++ b/plugins/gardener_approvals/registration.py
@@ -1,0 +1,14 @@
+"""register(ctx) — wire the pre_llm_call hook. Enabling the plugin
+(`hermes plugins enable gardener_approvals`) is the opt-in.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def register(ctx) -> None:
+    from .handler import on_pre_llm_call
+    ctx.register_hook("pre_llm_call", on_pre_llm_call)
+    logger.info("gardener_approvals active: pre_llm_call trigger registered")

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -185,3 +185,30 @@ def test_no_review_when_memory_disabled():
     agent = _FakeAgent()
     ctx = _build(agent)
     assert ctx.should_review_memory is False
+
+
+def test_pre_llm_call_receives_sender_id_alt(monkeypatch):
+    """build_turn_context must forward agent._user_id_alt to the
+    pre_llm_call hook as sender_id_alt."""
+    captured: list[dict] = []
+
+    def _fake_invoke_hook(event, **kwargs):
+        captured.append({"event": event, "kwargs": kwargs})
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_invoke_hook)
+
+    agent = _FakeAgent()
+    agent._user_id = "+15550001234"
+    agent._user_id_alt = "U-ACI-TEST"
+
+    _build(agent)
+
+    pre_llm_calls = [c for c in captured if c["event"] == "pre_llm_call"]
+    assert pre_llm_calls, "pre_llm_call hook was never invoked"
+    kwargs = pre_llm_calls[0]["kwargs"]
+    assert kwargs.get("sender_id_alt") == "U-ACI-TEST", (
+        f"expected sender_id_alt='U-ACI-TEST', got {kwargs.get('sender_id_alt')!r}"
+    )
+    # Confirm sender_id is also present for completeness.
+    assert kwargs.get("sender_id") == "+15550001234"

--- a/tests/plugins/gardener_approvals/test_config.py
+++ b/tests/plugins/gardener_approvals/test_config.py
@@ -1,0 +1,25 @@
+import importlib
+from plugins.gardener_approvals import config as C
+
+
+def test_defaults(monkeypatch):
+    for k in ("HERMES_GARDENER_APPROVALS_ENABLED", "HERMES_GARDENER_GATE",
+              "HERMES_GARDENER_DECISIONS", "HERMES_GARDENER_APPROVER"):
+        monkeypatch.delenv(k, raising=False)
+    cfg = C.load_config()
+    assert cfg.enabled is True
+    assert cfg.gate_path == "/opt/data/scripts/decision-approve.sh"
+    assert cfg.decisions_file == "/opt/data/gardener-memory/state/decisions.md"
+    assert cfg.approver == "Juniper"
+
+
+def test_kill_switch(monkeypatch):
+    monkeypatch.setenv("HERMES_GARDENER_APPROVALS_ENABLED", "0")
+    assert C.load_config().enabled is False
+
+
+def test_overrides(monkeypatch):
+    monkeypatch.setenv("HERMES_GARDENER_GATE", "/custom/gate.sh")
+    monkeypatch.setenv("HERMES_GARDENER_APPROVER", "Juni")
+    cfg = C.load_config()
+    assert cfg.gate_path == "/custom/gate.sh" and cfg.approver == "Juni"

--- a/tests/plugins/gardener_approvals/test_decisions.py
+++ b/tests/plugins/gardener_approvals/test_decisions.py
@@ -1,4 +1,4 @@
-from plugins.gardener_approvals.decisions import read_open_ids
+from plugins.gardener_approvals.decisions import read_open_ids, read_open_decisions, Decision
 
 SAMPLE = """# Pending decisions
 
@@ -10,6 +10,27 @@ SAMPLE = """# Pending decisions
 
 ## D-2026-06-09-03 · Third — status: open
 - **Decision:** x
+"""
+
+SAMPLE_WITH_PR = """# Pending decisions
+
+## D-2026-06-09-01 · Add feature  — status: open
+- **Decision:** ship it
+- **Link:** NimbleCoAI/nimbleco-egregore PR #27
+
+## D-2026-06-09-02 · Naming — status: open
+- **Decision:** pick a name
+"""
+
+SAMPLE_WITH_PULL_URL = """# Pending decisions
+
+## D-2026-06-09-01 · Add feature  — status: open
+- **Decision:** ship it
+- **Link:** https://github.com/org/repo/pull/42
+
+## D-2026-06-09-02 · Hash shorthand — status: open
+- **Decision:** pick
+- **Link:** #99
 """
 
 
@@ -28,3 +49,55 @@ def test_format_example_not_matched(tmp_path):
     f = tmp_path / "d.md"
     f.write_text("## D-YYYY-MM-DD-NN · example  — status: open\n")
     assert read_open_ids(str(f)) == []
+
+
+# --- New tests for read_open_decisions / Decision ---
+
+def test_decision_with_pr_number(tmp_path):
+    f = tmp_path / "decisions.md"
+    f.write_text(SAMPLE_WITH_PR)
+    decisions = read_open_decisions(str(f))
+    assert len(decisions) == 2
+    pr_decision = next(d for d in decisions if d.id == "D-2026-06-09-01")
+    assert pr_decision.pr_number == 27
+
+
+def test_decision_without_pr_number(tmp_path):
+    f = tmp_path / "decisions.md"
+    f.write_text(SAMPLE_WITH_PR)
+    decisions = read_open_decisions(str(f))
+    plain_decision = next(d for d in decisions if d.id == "D-2026-06-09-02")
+    assert plain_decision.pr_number is None
+
+
+def test_pr_from_pull_url(tmp_path):
+    f = tmp_path / "decisions.md"
+    f.write_text(SAMPLE_WITH_PULL_URL)
+    decisions = read_open_decisions(str(f))
+    pull_decision = next(d for d in decisions if d.id == "D-2026-06-09-01")
+    assert pull_decision.pr_number == 42
+
+
+def test_pr_from_hash_shorthand(tmp_path):
+    f = tmp_path / "decisions.md"
+    f.write_text(SAMPLE_WITH_PULL_URL)
+    decisions = read_open_decisions(str(f))
+    hash_decision = next(d for d in decisions if d.id == "D-2026-06-09-02")
+    assert hash_decision.pr_number == 99
+
+
+def test_read_open_ids_still_returns_ids(tmp_path):
+    f = tmp_path / "decisions.md"
+    f.write_text(SAMPLE_WITH_PR)
+    # read_open_ids must still work as before, now backed by read_open_decisions
+    assert read_open_ids(str(f)) == ["D-2026-06-09-01", "D-2026-06-09-02"]
+
+
+def test_only_open_blocks_returned(tmp_path):
+    f = tmp_path / "decisions.md"
+    f.write_text(SAMPLE)
+    decisions = read_open_decisions(str(f))
+    ids = [d.id for d in decisions]
+    assert "D-2026-06-09-02" not in ids   # resolved
+    assert "D-2026-06-09-01" in ids
+    assert "D-2026-06-09-03" in ids

--- a/tests/plugins/gardener_approvals/test_decisions.py
+++ b/tests/plugins/gardener_approvals/test_decisions.py
@@ -1,0 +1,30 @@
+from plugins.gardener_approvals.decisions import read_open_ids
+
+SAMPLE = """# Pending decisions
+
+## D-2026-06-09-01 · First thing  — status: open
+- **Decision:** a or b
+
+## D-2026-06-09-02 · Second  — status: resolved
+- **Resolved:** 2026-06-08
+
+## D-2026-06-09-03 · Third — status: open
+- **Decision:** x
+"""
+
+
+def test_reads_only_open_ids(tmp_path):
+    f = tmp_path / "decisions.md"
+    f.write_text(SAMPLE)
+    assert read_open_ids(str(f)) == ["D-2026-06-09-01", "D-2026-06-09-03"]
+
+
+def test_missing_file_returns_empty(tmp_path):
+    assert read_open_ids(str(tmp_path / "nope.md")) == []
+
+
+def test_format_example_not_matched(tmp_path):
+    # The block-format doc example uses NN, never a real dated id.
+    f = tmp_path / "d.md"
+    f.write_text("## D-YYYY-MM-DD-NN · example  — status: open\n")
+    assert read_open_ids(str(f)) == []

--- a/tests/plugins/gardener_approvals/test_gate.py
+++ b/tests/plugins/gardener_approvals/test_gate.py
@@ -33,3 +33,12 @@ def test_empty_output_is_error_token():
         runner=lambda cmd, **kw: _Proc(""),
     )
     assert token == "ERROR"
+
+
+def test_runner_exception_returns_error():
+    def boom(cmd, **kw): raise OSError("no such file")
+    token, msg = call_gate(
+        gate_path="/x/g.sh", uuid="U", decision_id="D-2026-06-09-01",
+        action="resolve", value="approve", approver="J", runner=boom,
+    )
+    assert token == "ERROR"

--- a/tests/plugins/gardener_approvals/test_gate.py
+++ b/tests/plugins/gardener_approvals/test_gate.py
@@ -1,0 +1,35 @@
+from plugins.gardener_approvals.gate import call_gate
+
+
+class _Proc:
+    def __init__(self, out): self.stdout = out; self.stderr = ""; self.returncode = 0
+
+
+def test_parses_token_and_message():
+    captured = {}
+
+    def runner(cmd, **kw):
+        captured["cmd"] = cmd
+        captured["env"] = kw.get("env")
+        return _Proc("OK ✓ noted, approved — D-2026-06-09-01 resolved\n")
+
+    token, msg = call_gate(
+        gate_path="/x/decision-approve.sh", uuid="U-1",
+        decision_id="D-2026-06-09-01", action="resolve", value="approve",
+        approver="Juniper", decisions_file="/d/decisions.md", runner=runner,
+    )
+    assert token == "OK"
+    assert msg.startswith("✓ noted, approved")
+    assert captured["cmd"][0] == "/x/decision-approve.sh"
+    assert "--requester-uuid" in captured["cmd"]
+    assert captured["cmd"][captured["cmd"].index("--requester-uuid") + 1] == "U-1"
+    assert captured["env"]["DECISIONS_FILE"] == "/d/decisions.md"
+
+
+def test_empty_output_is_error_token():
+    token, msg = call_gate(
+        gate_path="/x/g.sh", uuid="U", decision_id="D-2026-06-09-01",
+        action="resolve", value="approve", approver="J",
+        runner=lambda cmd, **kw: _Proc(""),
+    )
+    assert token == "ERROR"

--- a/tests/plugins/gardener_approvals/test_handler.py
+++ b/tests/plugins/gardener_approvals/test_handler.py
@@ -1,10 +1,19 @@
 import pytest
+from plugins.gardener_approvals.decisions import Decision
 from plugins.gardener_approvals.handler import on_pre_llm_call
 from plugins.gardener_approvals.config import Config
 
 CFG = Config(enabled=True, gate_path="/g.sh",
              decisions_file="/d.md", approver="Juniper")
-ONE = ["D-2026-06-09-01"]
+
+# Helpers
+def _plain(id_: str) -> Decision:
+    return Decision(id=id_, pr_number=None)
+
+def _merge(id_: str, pr: int) -> Decision:
+    return Decision(id=id_, pr_number=pr)
+
+ONE = [_plain("D-2026-06-09-01")]
 
 
 def _call(**over):
@@ -61,7 +70,7 @@ def test_ambiguous_two_open_asks_without_calling_gate():
     called = {"n": 0}
     def gate(**k): called["n"] += 1; return ("OK", "x")
     out = _call(user_message="approve",
-                _open_reader=lambda p: ["D-2026-06-09-01", "D-2026-06-09-02"],
+                _open_reader=lambda p: [_plain("D-2026-06-09-01"), _plain("D-2026-06-09-02")],
                 _gate_caller=gate)
     assert isinstance(out, dict) and "D-" in out["context"]
     assert called["n"] == 0
@@ -88,3 +97,26 @@ def test_relay_tokens_produce_relay(token, msg):
 
 def test_no_sender_id_noop():
     assert _call(sender_id="", sender_id_alt="") == ""
+
+
+# --- New test: merge path ---
+
+def test_merge_decision_approve_calls_gate_with_merge_action():
+    """approve on a PR-bearing decision → gate receives action=merge, value=str(pr#)."""
+    seen = {}
+    def gate(**k): seen.update(k); return ("OK", "✓ merged PR #27")
+
+    out = on_pre_llm_call(
+        platform="signal",
+        user_message="approve",
+        sender_id_alt="U-ACI",
+        _config=CFG,
+        _open_reader=lambda p: [_merge("D-2026-06-09-01", 27)],
+        _gate_caller=gate,
+    )
+
+    assert seen["action"] == "merge"
+    assert seen["value"] == "27"
+    assert seen["decision_id"] == "D-2026-06-09-01"
+    assert isinstance(out, dict)
+    assert "merged PR #27" in out["context"]

--- a/tests/plugins/gardener_approvals/test_handler.py
+++ b/tests/plugins/gardener_approvals/test_handler.py
@@ -1,0 +1,75 @@
+from plugins.gardener_approvals.handler import on_pre_llm_call
+from plugins.gardener_approvals.config import Config
+
+CFG = Config(enabled=True, gate_path="/g.sh",
+             decisions_file="/d.md", approver="Juniper")
+ONE = ["D-2026-06-09-01"]
+
+
+def _call(**over):
+    kw = dict(platform="signal", user_message="approve",
+              sender_id="+64221977149", sender_id_alt="U-ACI",
+              _config=CFG, _open_reader=lambda p: list(ONE),
+              _gate_caller=lambda **k: ("OK", "✓ noted, approved — D-2026-06-09-01 resolved"))
+    kw.update(over)
+    return on_pre_llm_call(**kw)
+
+
+def test_non_signal_platform_noop():
+    assert _call(platform="cli") == ""
+
+
+def test_no_open_decisions_noop():
+    assert _call(_open_reader=lambda p: []) == ""
+
+
+def test_prefers_uuid_alt_over_number():
+    seen = {}
+    def gate(**k): seen.update(k); return ("OK", "✓ done")
+    _call(_gate_caller=gate)
+    assert seen["uuid"] == "U-ACI"   # not the phone number
+
+
+def test_falls_back_to_sender_id_when_alt_empty():
+    seen = {}
+    def gate(**k): seen.update(k); return ("OK", "✓ done")
+    _call(sender_id_alt="", sender_id="U-FROM-ENVELOPE", _gate_caller=gate)
+    assert seen["uuid"] == "U-FROM-ENVELOPE"
+
+
+def test_ok_injects_relay_instruction_with_message():
+    out = _call()
+    assert isinstance(out, dict)
+    assert "✓ noted, approved" in out["context"]
+    assert "relay" in out["context"].lower()
+
+
+def test_refused_auth_injects_nothing():
+    assert _call(_gate_caller=lambda **k: ("REFUSED_AUTH", "(ignored)")) == ""
+
+
+def test_error_token_is_honest_no_false_success():
+    out = _call(_gate_caller=lambda **k: ("ERROR", "boom"))
+    assert isinstance(out, dict)
+    low = out["context"].lower()
+    assert "couldn't" in low or "could not" in low
+    assert "approved" not in low
+
+
+def test_ambiguous_two_open_asks_without_calling_gate():
+    called = {"n": 0}
+    def gate(**k): called["n"] += 1; return ("OK", "x")
+    out = _call(user_message="approve",
+                _open_reader=lambda p: ["D-2026-06-09-01", "D-2026-06-09-02"],
+                _gate_caller=gate)
+    assert isinstance(out, dict) and "D-" in out["context"]
+    assert called["n"] == 0
+
+
+def test_no_intent_noop():
+    assert _call(user_message="hey what's up") == ""
+
+
+def test_hook_never_raises_on_internal_error():
+    def boom(p): raise RuntimeError("disk gone")
+    assert _call(_open_reader=boom) == ""   # fail-safe -> empty, no exception

--- a/tests/plugins/gardener_approvals/test_handler.py
+++ b/tests/plugins/gardener_approvals/test_handler.py
@@ -1,3 +1,4 @@
+import pytest
 from plugins.gardener_approvals.handler import on_pre_llm_call
 from plugins.gardener_approvals.config import Config
 
@@ -8,7 +9,7 @@ ONE = ["D-2026-06-09-01"]
 
 def _call(**over):
     kw = dict(platform="signal", user_message="approve",
-              sender_id="+64221977149", sender_id_alt="U-ACI",
+              sender_id="+15550001234", sender_id_alt="U-ACI",
               _config=CFG, _open_reader=lambda p: list(ONE),
               _gate_caller=lambda **k: ("OK", "✓ noted, approved — D-2026-06-09-01 resolved"))
     kw.update(over)
@@ -73,3 +74,17 @@ def test_no_intent_noop():
 def test_hook_never_raises_on_internal_error():
     def boom(p): raise RuntimeError("disk gone")
     assert _call(_open_reader=boom) == ""   # fail-safe -> empty, no exception
+
+
+@pytest.mark.parametrize("token,msg", [
+    ("ALREADY_DONE", "already handled"),
+    ("REFUSED_ALLOWLIST", "do it in Claude Code"),
+    ("AMBIGUOUS", "Which decision?"),
+])
+def test_relay_tokens_produce_relay(token, msg):
+    out = _call(_gate_caller=lambda **k: (token, msg))
+    assert isinstance(out, dict) and msg in out["context"]
+
+
+def test_no_sender_id_noop():
+    assert _call(sender_id="", sender_id_alt="") == ""

--- a/tests/plugins/gardener_approvals/test_parser.py
+++ b/tests/plugins/gardener_approvals/test_parser.py
@@ -1,7 +1,16 @@
+from plugins.gardener_approvals.decisions import Decision
 from plugins.gardener_approvals.parser import parse_reply
 
-ONE = ["D-2026-06-09-01"]
-TWO = ["D-2026-06-09-01", "D-2026-06-09-02"]
+# Helper: plain decisions (no PR) matching the old open_ids interface
+def _plain(id_: str) -> Decision:
+    return Decision(id=id_, pr_number=None)
+
+def _merge(id_: str, pr: int) -> Decision:
+    return Decision(id=id_, pr_number=pr)
+
+
+ONE = [_plain("D-2026-06-09-01")]
+TWO = [_plain("D-2026-06-09-01"), _plain("D-2026-06-09-02")]
 
 
 def test_bare_approve_one_open_resolves():
@@ -64,3 +73,74 @@ def test_uphold_is_noop():
 def test_yesterday_is_noop():
     r = parse_reply("I saw it yesterday", ONE)
     assert r.matched is False
+
+
+# --- New tests for merge support ---
+
+def test_approve_on_pr_decision_produces_merge():
+    decisions = [_merge("D-2026-06-09-01", 27)]
+    r = parse_reply("approve", decisions)
+    assert r.matched
+    assert r.action == "merge"
+    assert r.value == "27"
+    assert r.decision_id == "D-2026-06-09-01"
+
+
+def test_merge_it_on_pr_decision_produces_merge():
+    decisions = [_merge("D-2026-06-09-01", 27)]
+    r = parse_reply("merge it", decisions)
+    assert r.matched
+    assert r.action == "merge"
+    assert r.value == "27"
+    assert r.decision_id == "D-2026-06-09-01"
+
+
+def test_merge_word_on_pr_decision_produces_merge():
+    decisions = [_merge("D-2026-06-09-01", 27)]
+    r = parse_reply("merge", decisions)
+    assert r.matched
+    assert r.action == "merge"
+    assert r.value == "27"
+
+
+def test_hold_on_pr_decision_still_resolves_hold():
+    decisions = [_merge("D-2026-06-09-01", 27)]
+    r = parse_reply("hold", decisions)
+    assert r.matched
+    assert r.action == "resolve"
+    assert r.value == "hold"
+    assert r.decision_id == "D-2026-06-09-01"
+
+
+def test_plain_decision_approve_still_resolves_approve():
+    decisions = [_plain("D-2026-06-09-01")]
+    r = parse_reply("approve", decisions)
+    assert r.matched
+    assert r.action == "resolve"
+    assert r.value == "approve"
+
+
+def test_explicit_id_picks_pr_decision_among_mixed_two():
+    # Two open: one with PR, one plain. Explicit id targets the merge one.
+    decisions = [
+        _merge("D-2026-06-09-01", 27),
+        _plain("D-2026-06-09-02"),
+    ]
+    r = parse_reply("approve D-2026-06-09-01", decisions)
+    assert r.matched
+    assert r.action == "merge"
+    assert r.value == "27"
+    assert r.decision_id == "D-2026-06-09-01"
+
+
+def test_explicit_id_picks_plain_decision_among_mixed_two():
+    # Two open: one with PR, one plain. Explicit id targets the plain one.
+    decisions = [
+        _merge("D-2026-06-09-01", 27),
+        _plain("D-2026-06-09-02"),
+    ]
+    r = parse_reply("approve D-2026-06-09-02", decisions)
+    assert r.matched
+    assert r.action == "resolve"
+    assert r.value == "approve"
+    assert r.decision_id == "D-2026-06-09-02"

--- a/tests/plugins/gardener_approvals/test_parser.py
+++ b/tests/plugins/gardener_approvals/test_parser.py
@@ -44,3 +44,23 @@ def test_emoji_thumbsup_approves():
 def test_no_open_decisions_noop():
     r = parse_reply("approve", [])
     assert r.matched is False and r.ask is None
+
+
+def test_disapprove_is_noop():
+    r = parse_reply("I disapprove D-2026-06-09-01", ONE)
+    assert r.matched is False and r.ask is None
+
+
+def test_not_approved_is_noop():
+    r = parse_reply("not approved", ONE)
+    assert r.matched is False and r.ask is None
+
+
+def test_uphold_is_noop():
+    r = parse_reply("uphold the plan", ONE)
+    assert r.matched is False
+
+
+def test_yesterday_is_noop():
+    r = parse_reply("I saw it yesterday", ONE)
+    assert r.matched is False

--- a/tests/plugins/gardener_approvals/test_parser.py
+++ b/tests/plugins/gardener_approvals/test_parser.py
@@ -1,0 +1,46 @@
+from plugins.gardener_approvals.parser import parse_reply
+
+ONE = ["D-2026-06-09-01"]
+TWO = ["D-2026-06-09-01", "D-2026-06-09-02"]
+
+
+def test_bare_approve_one_open_resolves():
+    r = parse_reply("Approve", ONE)
+    assert r.matched and r.action == "resolve" and r.value == "approve"
+    assert r.decision_id == "D-2026-06-09-01" and r.ask is None
+
+
+def test_bare_hold_one_open():
+    r = parse_reply("hold", ONE)
+    assert r.matched and r.action == "resolve" and r.value == "hold"
+    assert r.decision_id == "D-2026-06-09-01"
+
+
+def test_explicit_id_used_even_with_many_open():
+    r = parse_reply("approve D-2026-06-09-02", TWO)
+    assert r.matched and r.decision_id == "D-2026-06-09-02" and r.value == "approve"
+
+
+def test_intent_but_ambiguous_asks_and_does_not_match():
+    r = parse_reply("approve", TWO)
+    assert r.matched is False and r.ask is not None and "D-" in r.ask
+
+
+def test_no_intent_is_noop():
+    r = parse_reply("what's the weather", ONE)
+    assert r.matched is False and r.ask is None
+
+
+def test_conflicting_intent_is_noop():
+    r = parse_reply("approve but actually hold", ONE)
+    assert r.matched is False and r.ask is None
+
+
+def test_emoji_thumbsup_approves():
+    r = parse_reply("\U0001F44D", ONE)
+    assert r.matched and r.value == "approve"
+
+
+def test_no_open_decisions_noop():
+    r = parse_reply("approve", [])
+    assert r.matched is False and r.ask is None


### PR DESCRIPTION
## What

A `pre_llm_call` plugin (`plugins/gardener_approvals/`) that makes a Signal reply to a gardener decision reliably and securely reach the `decision-approve` gate — replacing the relevance-gated curator skill that didn't fire on terse replies like "approve".

On a Signal turn the hook: reads open decisions → parses intent in code (word-boundary + negation aware; resolve-only in v1) → calls `decision-approve.sh` with the **verified sender UUID** → injects the gate's confirm line for the LLM to relay. The gate remains the sole security boundary (auth/allowlist/idempotency); the hook's parse is a convenience it re-validates. Fail-safe: any hook exception returns `""` so it can never break a turn.

## Why the upstream one-liner

The gate's allowlist is keyed by Signal **UUID/ACI**, but `pre_llm_call` only received `sender_id` (= `agent._user_id` = the **phone number** for Signal). Empirically verified from signal-cli logs that Juniper's DMs carry the number, so a naive hook would `REFUSED_AUTH`. This PR additively exposes `sender_id_alt` (= `agent._user_id_alt`, the ACI) to `pre_llm_call` — keeping the allowlist UUID-only (strongest auth) instead of weakening it to phone-number auth. Generically useful, so contributable upstream.

## Changes
- `agent/turn_context.py`: +1 line — pass `sender_id_alt` to the `pre_llm_call` hook.
- `hermes_cli/hooks.py`: add `sender_id`/`sender_id_alt` to the `pre_llm_call` test fixture.
- `plugins/gardener_approvals/`: new plugin (parser, decisions reader, gate wrapper, config+kill-switch, handler, registration).
- Tests: 35 plugin tests + a production-path test that `sender_id_alt` flows from `agent._user_id_alt` through `build_turn_context` to the hook. 178 green across plugin/turn_context/shell_hooks/plugins suites.

## Proven live
Resolve-only loop tested end-to-end from Juniper's phone on `hermes-nimbleco`: "approve" → hook fired → gate auth matched the UUID allowlist → decision resolved. (A separate durability fix to the gate lives in nimbleco-egregore.)

## Out of scope (v1)
`merge` from Signal (next, after resolve is proven durable), broader allowlist verbs.