### PR TITLE
gardener_approvals: graceful empty-board guard (no freelancing on stray approve/merge)

### DIFF
--- a/plugins/gardener_approvals/decisions.py
+++ b/plugins/gardener_approvals/decisions.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 _OPEN_RE = re.compile(r"^## (D-\d{4}-\d{2}-\d{2}-\d+) .*status: open", re.MULTILINE)
+_RESOLVED_RE = re.compile(r"^## (D-\d{4}-\d{2}-\d{2}-\d+) .*status: resolved", re.MULTILINE)
+_RESOLVED_DATE_RE = re.compile(r"^\s*-\s+\*\*Resolved:\*\*\s+(\d{4}-\d{2}-\d{2})", re.MULTILINE)
 
 # Matches any of:
 #   PR #27   |  #27   |  pull/27   |  /pull/27
@@ -22,6 +24,12 @@ _PR_NUM_RE = re.compile(r"(?:PR\s+#|/pull/)(\d+)|#(\d+)|pull/(\d+)", re.IGNORECA
 class Decision:
     id: str
     pr_number: Optional[int]
+
+
+@dataclass
+class ResolvedDecision:
+    id: str
+    date: str   # ISO date string "YYYY-MM-DD", or "" if absent
 
 
 def read_open_decisions(decisions_path: str) -> List[Decision]:
@@ -58,3 +66,47 @@ def read_open_decisions(decisions_path: str) -> List[Decision]:
 
 def read_open_ids(decisions_path: str) -> List[str]:
     return [d.id for d in read_open_decisions(decisions_path)]
+
+
+def most_recent_resolved(path: str) -> Optional[ResolvedDecision]:
+    """Return the most recently resolved decision, or None if there are none.
+
+    "Most recent" is determined by the lexically-greatest ISO date found on a
+    ``- **Resolved:** YYYY-MM-DD`` line inside the block.  When dates tie or are
+    absent the decision appearing LAST in the file wins (decisions are appended
+    chronologically, so last = newest).
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError:
+        return None
+
+    matches = list(_RESOLVED_RE.finditer(text))
+    if not matches:
+        return None
+
+    best: Optional[ResolvedDecision] = None
+
+    for m in matches:
+        dec_id = m.group(1)
+        block_start = m.start()
+        next_header = re.search(r"^## ", text[block_start + 1:], re.MULTILINE)
+        block_end = (block_start + 1 + next_header.start()) if next_header else len(text)
+        block_text = text[block_start:block_end]
+
+        dm = _RESOLVED_DATE_RE.search(block_text)
+        date = dm.group(1) if dm else ""
+
+        candidate = ResolvedDecision(id=dec_id, date=date)
+        if best is None:
+            best = candidate
+        elif candidate.date > best.date:
+            # Strictly later date wins
+            best = candidate
+        elif candidate.date == best.date:
+            # Tie: prefer the one appearing later in the file (i.e. the current candidate,
+            # since we iterate forward through the file)
+            best = candidate
+
+    return best

--- a/plugins/gardener_approvals/handler.py
+++ b/plugins/gardener_approvals/handler.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 import logging
 
 from .config import load_config
-from .decisions import read_open_decisions
+from .decisions import most_recent_resolved, read_open_decisions
 from .gate import call_gate
-from .parser import parse_reply
+from .parser import has_approval_intent, parse_reply
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,7 @@ def _relay(msg: str) -> dict:
 def on_pre_llm_call(*, platform: str = "", user_message: str = "",
                     sender_id: str = "", sender_id_alt: str = "",
                     _config=None, _open_reader=None, _gate_caller=None,
+                    _recent_reader=None,
                     **_kwargs):
     try:
         cfg = _config or load_config()
@@ -44,6 +45,18 @@ def on_pre_llm_call(*, platform: str = "", user_message: str = "",
         open_reader = _open_reader or read_open_decisions
         decisions = open_reader(cfg.decisions_file)
         if not decisions:
+            # Nothing pending. If the user is replying with approval/merge intent,
+            # tell them it's already handled — and explicitly forbid the LLM from
+            # improvising an action (e.g. hunting for a branch to merge).
+            if has_approval_intent(user_message or ""):
+                recent = (_recent_reader or most_recent_resolved)(cfg.decisions_file)
+                note = "No gardener decisions are pending right now."
+                if recent:
+                    note += f" The most recently resolved was {recent.id} ({recent.date})."
+                note += (" If the user is replying to an approval or merge, tell them"
+                         " it's already handled and nothing is pending. Do NOT merge,"
+                         " approve, or act on anything else — there is nothing to act on.")
+                return {"context": "[gardener] " + note}
             return ""
         pr = parse_reply(user_message or "", decisions)
         if pr.ask:

--- a/plugins/gardener_approvals/parser.py
+++ b/plugins/gardener_approvals/parser.py
@@ -49,6 +49,24 @@ def _has_word(text: str, words) -> bool:
     return bool(toks & words)
 
 
+def has_approval_intent(text: str) -> bool:
+    """Return True if *text* contains any approve-, hold-, or merge-intent keyword
+    using the same word-boundary / phrase / emoji logic as parse_reply.  Conflicting
+    signals (approve + hold together) are still treated conservatively as False,
+    matching the no-op behaviour of parse_reply.
+    """
+    raw = text or ""
+    low = raw.lower()
+    approve = (_has_word(low, _APPROVE_WORDS)
+               or _has_phrase(low, _APPROVE_PHRASES)
+               or any(e in raw for e in _APPROVE_EMOJI))
+    hold = (_has_word(low, _HOLD_WORDS)
+            or _has_phrase(low, _HOLD_PHRASES))
+    if approve and hold:
+        return False   # conflicting → conservative no-op
+    return approve or hold
+
+
 def parse_reply(text: str, decisions: List[Decision]) -> ParseResult:
     if not decisions:
         return ParseResult(matched=False)

--- a/tests/plugins/gardener_approvals/test_decisions.py
+++ b/tests/plugins/gardener_approvals/test_decisions.py
@@ -101,3 +101,84 @@ def test_only_open_blocks_returned(tmp_path):
     assert "D-2026-06-09-02" not in ids   # resolved
     assert "D-2026-06-09-01" in ids
     assert "D-2026-06-09-03" in ids
+
+
+# --- most_recent_resolved tests ---
+
+from plugins.gardener_approvals.decisions import most_recent_resolved
+
+SAMPLE_RESOLVED_MULTI = """# Decisions
+
+## D-2026-06-07-01 · First — status: resolved
+- **Decision:** a
+- **Resolved:** 2026-06-07 by Juniper
+
+## D-2026-06-09-01 · Latest — status: resolved
+- **Decision:** b
+- **Resolved:** 2026-06-09 by Juniper
+
+## D-2026-06-08-01 · Middle — status: resolved
+- **Decision:** c
+- **Resolved:** 2026-06-08 by Juniper
+"""
+
+SAMPLE_NO_RESOLVED = """# Decisions
+
+## D-2026-06-09-01 · Open one — status: open
+- **Decision:** pending
+"""
+
+SAMPLE_RESOLVED_NO_DATE = """# Decisions
+
+## D-2026-06-09-01 · No date — status: resolved
+- **Decision:** a
+"""
+
+SAMPLE_RESOLVED_TIE = """# Decisions
+
+## D-2026-06-08-01 · First with same date — status: resolved
+- **Decision:** a
+- **Resolved:** 2026-06-08
+
+## D-2026-06-08-02 · Second with same date — status: resolved
+- **Decision:** b
+- **Resolved:** 2026-06-08
+"""
+
+
+def test_most_recent_resolved_returns_latest_by_date(tmp_path):
+    f = tmp_path / "decisions.md"
+    f.write_text(SAMPLE_RESOLVED_MULTI)
+    r = most_recent_resolved(str(f))
+    assert r is not None
+    assert r.id == "D-2026-06-09-01"
+    assert r.date == "2026-06-09"
+
+
+def test_most_recent_resolved_none_when_no_resolved(tmp_path):
+    f = tmp_path / "decisions.md"
+    f.write_text(SAMPLE_NO_RESOLVED)
+    assert most_recent_resolved(str(f)) is None
+
+
+def test_most_recent_resolved_none_when_missing_file(tmp_path):
+    assert most_recent_resolved(str(tmp_path / "nope.md")) is None
+
+
+def test_most_recent_resolved_no_date_still_returned(tmp_path):
+    # Single resolved block with no Resolved: date — still returns it (date="")
+    f = tmp_path / "decisions.md"
+    f.write_text(SAMPLE_RESOLVED_NO_DATE)
+    r = most_recent_resolved(str(f))
+    assert r is not None
+    assert r.id == "D-2026-06-09-01"
+    assert r.date == ""
+
+
+def test_most_recent_resolved_tie_prefers_last_in_file(tmp_path):
+    # Same date: last one in the file wins
+    f = tmp_path / "decisions.md"
+    f.write_text(SAMPLE_RESOLVED_TIE)
+    r = most_recent_resolved(str(f))
+    assert r is not None
+    assert r.id == "D-2026-06-08-02"

--- a/tests/plugins/gardener_approvals/test_handler.py
+++ b/tests/plugins/gardener_approvals/test_handler.py
@@ -29,8 +29,9 @@ def test_non_signal_platform_noop():
     assert _call(platform="cli") == ""
 
 
-def test_no_open_decisions_noop():
-    assert _call(_open_reader=lambda p: []) == ""
+def test_no_open_decisions_unrelated_message_noop():
+    # Empty board + no approval intent → still silent
+    assert _call(_open_reader=lambda p: [], user_message="what's the weather") == ""
 
 
 def test_prefers_uuid_alt_over_number():
@@ -120,3 +121,56 @@ def test_merge_decision_approve_calls_gate_with_merge_action():
     assert seen["decision_id"] == "D-2026-06-09-01"
     assert isinstance(out, dict)
     assert "merged PR #27" in out["context"]
+
+
+# --- empty-board guard tests ---
+
+from plugins.gardener_approvals.decisions import Decision
+# ResolvedDecision is defined in decisions.py (will exist after implementation)
+from plugins.gardener_approvals.decisions import ResolvedDecision
+
+
+def test_empty_board_merge_intent_injects_guard_with_recent_id():
+    """Empty board + merge/approve intent → guard dict with recent id mentioned."""
+    out = on_pre_llm_call(
+        platform="signal",
+        user_message="merge it",
+        sender_id_alt="U-ACI",
+        _config=CFG,
+        _open_reader=lambda p: [],
+        _recent_reader=lambda p: ResolvedDecision("D-2026-06-09-03", "2026-06-09"),
+    )
+    assert isinstance(out, dict)
+    ctx = out["context"]
+    # Must warn about nothing pending / already handled and forbid freelancing
+    assert any(phrase in ctx.lower() for phrase in ("already handled", "nothing", "do not"))
+    assert "D-2026-06-09-03" in ctx
+
+
+def test_empty_board_unrelated_chatter_still_silent():
+    """Empty board + non-approval chat → still returns '' (no injection)."""
+    out = on_pre_llm_call(
+        platform="signal",
+        user_message="hey what's up",
+        sender_id_alt="U-ACI",
+        _config=CFG,
+        _open_reader=lambda p: [],
+        _recent_reader=lambda p: ResolvedDecision("D-2026-06-09-03", "2026-06-09"),
+    )
+    assert out == ""
+
+
+def test_empty_board_approve_no_recent_still_injects_guard():
+    """Empty board + approve intent + no recent resolved → still injects guard (no id)."""
+    out = on_pre_llm_call(
+        platform="signal",
+        user_message="approve",
+        sender_id_alt="U-ACI",
+        _config=CFG,
+        _open_reader=lambda p: [],
+        _recent_reader=lambda p: None,
+    )
+    assert isinstance(out, dict)
+    ctx = out["context"]
+    # Must forbid freelancing even without a recent id
+    assert "do not" in ctx.lower() or "Do NOT" in ctx

--- a/tests/plugins/gardener_approvals/test_parser.py
+++ b/tests/plugins/gardener_approvals/test_parser.py
@@ -144,3 +144,71 @@ def test_explicit_id_picks_plain_decision_among_mixed_two():
     assert r.action == "resolve"
     assert r.value == "approve"
     assert r.decision_id == "D-2026-06-09-02"
+
+
+# --- has_approval_intent tests ---
+
+from plugins.gardener_approvals.parser import has_approval_intent
+
+
+def test_intent_approve():
+    assert has_approval_intent("approve") is True
+
+def test_intent_approved():
+    assert has_approval_intent("Approved!") is True
+
+def test_intent_yes():
+    assert has_approval_intent("yes") is True
+
+def test_intent_lgtm():
+    assert has_approval_intent("lgtm") is True
+
+def test_intent_merge():
+    assert has_approval_intent("merge") is True
+
+def test_intent_merge_it():
+    assert has_approval_intent("merge it") is True
+
+def test_intent_hold():
+    assert has_approval_intent("hold") is True
+
+def test_intent_emoji_thumbsup():
+    assert has_approval_intent("\U0001F44D") is True
+
+def test_intent_emoji_check():
+    assert has_approval_intent("✅") is True
+
+def test_intent_ship_it():
+    assert has_approval_intent("ship it") is True
+
+def test_intent_go_ahead():
+    assert has_approval_intent("go ahead") is True
+
+def test_no_intent_unrelated_chatter():
+    assert has_approval_intent("hey what's up") is False
+
+def test_no_intent_yesterday():
+    assert has_approval_intent("I saw it yesterday") is False
+
+def test_no_intent_disapprove():
+    # "disapprove" contains "approve" as substring but word-boundary check should block it
+    assert has_approval_intent("I disapprove") is False
+
+def test_no_intent_not_approved():
+    # approve + not = conflicting → False per conservative rules
+    # NOTE: has_approval_intent is intentionally True if ANY approve/hold/merge
+    # keyword is present WITHOUT conflict filtering — re-read spec: it should be
+    # conservative: "not approved" → False.
+    # The spec says same word-boundary/phrase logic; "not approved" → hold+approve → conflict → noop
+    # So has_approval_intent("not approved") → False (conflict logic applies).
+    assert has_approval_intent("not approved") is False
+
+def test_no_intent_uphold():
+    assert has_approval_intent("uphold the plan") is False
+
+def test_intent_nope():
+    # "nope" is in _HOLD_WORDS, so it counts as intent
+    assert has_approval_intent("nope") is True
+
+def test_no_intent_empty():
+    assert has_approval_intent("") is False


### PR DESCRIPTION
When there are no open gardener decisions, a bare 'approve'/'merge it' on Signal left the LLM with no context, so it improvised (it offered to merge an unrelated branch). Now: approval/merge intent + empty board → inject a guard ('already handled, nothing pending, do NOT act'), enriched with the most-recently-resolved decision (stateless, read from decisions.md). Unrelated chatter still injects nothing. 75 tests green. Follow-up to #33.