### PR TITLE
glocal Phase 0: read floor (L1 read-deny + L2 terminal-guard)

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -168,7 +168,10 @@ _BLOCKED_PROJECT_ENV_BASENAMES: set[str] = {
 # approval, and L3 (secret not in the agent's mount) is the real boundary.
 # See glocal-scoping design, Read-floor section.
 _SECRET_READ_DENY_BASENAMES: frozenset[str] = frozenset({
-    "credentials",        # ~/.aws/credentials and similar cloud-CLI stores
+    # Bare "credentials" is broad (may block non-secret project files) but the
+    # DiD error is recoverable; cloud-CLI stores (~/.aws/credentials, gcloud)
+    # warrant the blanket block.
+    "credentials",
     ".git-credentials",
     ".netrc",
     ".pgpass",
@@ -180,7 +183,10 @@ _SECRET_READ_DENY_BASENAMES: frozenset[str] = frozenset({
     "id_dsa",
 })
 
-# Directory-name segments whose contents are credential stores.
+# Read-side credential dirs. Intentionally narrower than the write denylist
+# (build_write_denied_prefixes) — dirs like ~/.docker, ~/.azure, ~/.config/gh
+# are write-guarded but hold little plaintext-secret material the agent would
+# read, so they are omitted here.
 _SECRET_READ_DENY_DIR_SEGMENTS: tuple[str, ...] = (
     "/.aws/",
     "/.config/gcloud/",
@@ -201,7 +207,11 @@ def _looks_like_secret_read(resolved: Path) -> bool:
         return True
     if name.endswith(".pem"):
         return True
-    if name.endswith(".json") and "service-account" in name:
+    # Both hyphen (Google Cloud Console canonical) and underscore (Terraform,
+    # some SDKs) forms of service-account key filenames.
+    if name.endswith(".json") and (
+        "service-account" in name or "service_account" in name
+    ):
         return True
     full = str(resolved).lower()
     full_padded = full if full.endswith("/") else full + "/"

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -161,6 +161,52 @@ _BLOCKED_PROJECT_ENV_BASENAMES: set[str] = {
     ".envrc",
 }
 
+# Broadened secret-bearing credential material denied to the read-file tool
+# anywhere on disk: cloud service-account JSON, private keys, and cloud-CLI
+# credential dirs. Defense-in-depth only — the terminal tool can still cat
+# these; L2 (DANGEROUS_PATTERNS in tools/approval.py) routes that through
+# approval, and L3 (secret not in the agent's mount) is the real boundary.
+# See glocal-scoping design, Read-floor section.
+_SECRET_READ_DENY_BASENAMES: frozenset[str] = frozenset({
+    "credentials",        # ~/.aws/credentials and similar cloud-CLI stores
+    ".git-credentials",
+    ".netrc",
+    ".pgpass",
+    ".npmrc",
+    ".pypirc",
+    "id_rsa",
+    "id_ed25519",
+    "id_ecdsa",
+    "id_dsa",
+})
+
+# Directory-name segments whose contents are credential stores.
+_SECRET_READ_DENY_DIR_SEGMENTS: tuple[str, ...] = (
+    "/.aws/",
+    "/.config/gcloud/",
+    "/.kube/",
+    "/.gnupg/",
+    "/.ssh/",
+)
+
+
+def _looks_like_secret_read(resolved: Path) -> bool:
+    """True when *resolved* points at credential / key material the agent
+    should never read raw (cloud SA keys, private keys, credential dirs).
+
+    Defense-in-depth heuristic, not a boundary — see module docstring.
+    """
+    name = resolved.name.lower()
+    if name in _SECRET_READ_DENY_BASENAMES:
+        return True
+    if name.endswith(".pem"):
+        return True
+    if name.endswith(".json") and "service-account" in name:
+        return True
+    full = str(resolved).lower()
+    full_padded = full if full.endswith("/") else full + "/"
+    return any(seg in full_padded for seg in _SECRET_READ_DENY_DIR_SEGMENTS)
+
 
 def get_read_block_error(path: str) -> Optional[str]:
     """Return an error message when a read targets a denied Hermes path.
@@ -303,6 +349,16 @@ def get_read_block_error(path: str) -> Optional[str]:
             "and cannot be read to prevent credential leakage. "
             "If you need to check the file structure, read .env.example instead. "
             "(Defense-in-depth — not a security boundary; the terminal tool can still bypass.)"
+        )
+
+    # Broadened secret-bearing credential material anywhere on disk.
+    if _looks_like_secret_read(resolved):
+        return (
+            f"Access denied: {path} looks like secret-bearing credential "
+            "material and cannot be read directly to prevent credential "
+            "leakage. Provider tools consume credentials through internal "
+            "channels. (Defense-in-depth — not a security boundary; the "
+            "terminal tool can still bypass.)"
         )
 
     return None

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -337,3 +337,37 @@ def test_profile_mode_blocks_root_credentials(tmp_path, monkeypatch):
     root_tok.parent.mkdir(parents=True, exist_ok=True)
     root_tok.write_text("x")
     assert "MCP token" in (get_read_block_error(str(root_tok)) or "")
+
+
+class TestBroadenedSecretReadDeny:
+    """L1 read-floor: credential material beyond .env is denied to read_file."""
+
+    def test_gcloud_service_account_json_denied(self):
+        from agent.file_safety import get_read_block_error
+        err = get_read_block_error("~/.config/gcloud/my-app-service-account.json")
+        assert err is not None
+        assert "secret" in err.lower()
+
+    def test_aws_credentials_denied(self):
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("~/.aws/credentials") is not None
+
+    def test_ssh_private_key_denied(self):
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("~/.ssh/id_rsa") is not None
+
+    def test_pem_anywhere_denied(self):
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("/tmp/some/cert.pem") is not None
+
+    def test_mounted_service_account_denied(self):
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("/secrets/prod-service-account.json") is not None
+
+    def test_ordinary_json_allowed(self):
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("/tmp/project/data.json") is None
+
+    def test_env_example_still_allowed(self):
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("/tmp/project/.env.example") is None

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -371,3 +371,7 @@ class TestBroadenedSecretReadDeny:
     def test_env_example_still_allowed(self):
         from agent.file_safety import get_read_block_error
         assert get_read_block_error("/tmp/project/.env.example") is None
+
+    def test_underscore_service_account_denied(self):
+        from agent.file_safety import get_read_block_error
+        assert get_read_block_error("/secrets/foo_service_account.json") is not None

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1568,3 +1568,44 @@ class TestApprovalTimeoutIsNotConsent:
         assert last_post.get("choice") == "timeout", (
             f"hook choice should be 'timeout' on no-response, got {last_post.get('choice')!r}"
         )
+
+
+class TestSecretReadCommandGuard:
+    """L2 read-floor: reading credential material via the shell is flagged
+    dangerous so it routes through the approval flow instead of silently
+    succeeding (the terminal-tool bypass of get_read_block_error)."""
+
+    def test_cat_gcloud_service_account_flagged(self):
+        from tools.approval import detect_dangerous_command
+        is_dangerous, _key, desc = detect_dangerous_command(
+            "cat ~/.config/gcloud/app-service-account.json"
+        )
+        assert is_dangerous is True
+        assert "credential" in desc.lower() or "secret" in desc.lower()
+
+    def test_cat_aws_credentials_flagged(self):
+        from tools.approval import detect_dangerous_command
+        is_dangerous, _key, _desc = detect_dangerous_command("cat ~/.aws/credentials")
+        assert is_dangerous is True
+
+    def test_base64_ssh_key_flagged(self):
+        from tools.approval import detect_dangerous_command
+        is_dangerous, _key, _desc = detect_dangerous_command("base64 ~/.ssh/id_rsa")
+        assert is_dangerous is True
+
+    def test_cp_mounted_service_account_flagged(self):
+        from tools.approval import detect_dangerous_command
+        is_dangerous, _key, _desc = detect_dangerous_command(
+            "cp /secrets/prod-service-account.json /tmp/x"
+        )
+        assert is_dangerous is True
+
+    def test_cat_readme_not_flagged(self):
+        from tools.approval import detect_dangerous_command
+        is_dangerous, _key, _desc = detect_dangerous_command("cat README.md")
+        assert is_dangerous is False
+
+    def test_cat_ordinary_json_not_flagged(self):
+        from tools.approval import detect_dangerous_command
+        is_dangerous, _key, _desc = detect_dangerous_command("cat data.json")
+        assert is_dangerous is False

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -485,6 +485,20 @@ DANGEROUS_PATTERNS = [
     # into a single -X token. Catches the same threat class.
     (r'\bsudo\b[^;|&\n]*?\s+-[a-z]*[sa][a-z]*\b',
      "sudo with combined-flag privilege escalation"),
+    # Reading credential / secret material through the shell. The read-file
+    # tool already denies these (agent/file_safety.get_read_block_error);
+    # this routes the terminal-tool bypass (cat/cp/base64/… of a secret
+    # path) through the approval flow instead of silently succeeding.
+    # Defense-in-depth — a determined model can still obfuscate; L3 (keeping
+    # secrets out of the agent's mount) is the real fix. Patterns run against
+    # the normalized lowercased command. See glocal-scoping design, L2.
+    (r'\b(cat|less|more|head|tail|nl|xxd|od|strings|base64|cp|install)\b'
+     r'[^\n|]*'
+     r'(\.pem\b|\bid_rsa\b|\bid_ed25519\b|\bid_ecdsa\b|\bid_dsa\b|'
+     r'/\.aws/|/\.ssh/|/\.config/gcloud/|/\.gnupg/|/\.kube/|'
+     r'\.git-credentials\b|service-account[^\s]*\.json|'
+     r'service_account[^\s]*\.json)',
+     "read credential/secret file"),
 ]
 
 


### PR DESCRIPTION
## What

Phase 0 of the **glocal scoping** design — the **read-side secret floor**. Two additive, honestly-labeled defense-in-depth changes to existing image security modules.

**L1 — broaden read-file denylist** (`agent/file_safety.py`): `get_read_block_error` now also denies cloud service-account JSON (`service-account`/`service_account` *.json), private keys (`id_rsa`/`id_ed25519`/…), `.pem`, and cloud-CLI credential dirs (`~/.aws`, `~/.config/gcloud`, `~/.kube`, `~/.gnupg`, `~/.ssh`) — beyond the `.env` coverage it already had.

**L2 — terminal-guard** (`tools/approval.py`): one new `DANGEROUS_PATTERNS` entry flags shell reads of credential material (`cat`/`cp`/`base64`/… of a secret path) so they route through the **existing approval flow** — closing the terminal-tool bypass of L1.

## Why

Agents serving many chats have been observed trying to `cat` a Google service-account key into memory. `cat` is the terminal tool, which the existing `read_file` denylist never saw. This adds the terminal-side nudge (L2) and broadens the read-side deny (L1).

## Honesty / scope

Per `agent/file_safety.py`'s own docstring and `docs/architecture/image-vs-hsm-boundary.md`, an in-process read-deny is **NOT a hard boundary** — a same-user shell can always bypass it. These layers are defense-in-depth + approval routing. The **real** boundary (not mounting readable secrets into the agent namespace) is **Phase 0b** (HSM compose scaffolding), tracked separately. Cross-context confinement is **Phase 1**.

Design doc: `nimbleco-memory/specs/2026-06-09-glocal-scoping-design.md`. Plan: `nimbleco-memory/plans/2026-06-09-glocal-phase0-read-floor.md`.

## Tests

- `tests/agent/test_file_safety_credentials.py` — `TestBroadenedSecretReadDeny` (8 tests incl. underscore SA variant + allowed-path regressions).
- `tests/tools/test_approval.py` — `TestSecretReadCommandGuard` (6 tests, incl. benign negatives).
- Focused suites: **237 passed**. Reviewed for ReDoS (none — `[^\n|]*` can't overlap the alternation) and false positives (acceptable for DiD).
- Pre-existing/environmental failures in the full single-process run (`test_anthropic_adapter`, `test_voice_mode` AF_UNIX path length, `test_file_tools` macOS `/tmp`→`/private/tmp`) are unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)