### PR TITLE
signal: persist invite-accepted groups across restarts

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -27,6 +27,12 @@ from urllib.parse import quote, unquote
 
 import httpx
 
+from hermes_constants import get_hermes_home
+try:
+    from utils import atomic_json_write as _atomic_json_write
+except Exception:
+    _atomic_json_write = None  # type: ignore[assignment]
+
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -58,6 +64,10 @@ logger = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 SIGNAL_MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100 MB
+
+# Persistence file for runtime-accepted group allowlist (relative to HERMES_HOME).
+# Groups added via invite acceptance are written here so they survive restarts.
+_APPROVED_GROUPS_FILE = "signal_approved_groups.json"
 MAX_MESSAGE_LENGTH = 8000  # Signal message size limit
 TYPING_INTERVAL = 8.0  # seconds between typing indicator refreshes
 SSE_RETRY_DELAY_INITIAL = 2.0
@@ -203,6 +213,27 @@ class SignalAdapter(BasePlatformAdapter):
         # Parse allowlists — group policy is derived from presence of group allowlist
         group_allowed_str = os.getenv("SIGNAL_GROUP_ALLOWED_USERS", "")
         self.group_allow_from = set(_parse_comma_list(group_allowed_str))
+
+        # Load runtime-accepted groups persisted from previous sessions.
+        # Corrupted or missing files are non-fatal — we just log and continue.
+        try:
+            _persisted_path = get_hermes_home() / _APPROVED_GROUPS_FILE
+            if _persisted_path.exists():
+                _persisted_data = json.loads(_persisted_path.read_text())
+                if isinstance(_persisted_data, dict):
+                    _loaded = set(_persisted_data.keys()) - self.group_allow_from
+                    self.group_allow_from.update(_loaded)
+                    if _loaded:
+                        logger.info(
+                            "Signal: loaded %d persisted approved group(s) from %s",
+                            len(_loaded), _APPROVED_GROUPS_FILE,
+                        )
+        except Exception:
+            logger.warning(
+                "Signal: failed to load persisted group allowlist from %s — continuing with env-var groups only",
+                _APPROVED_GROUPS_FILE,
+                exc_info=True,
+            )
 
         # Group invite policy — who can add the bot to new groups.
         # "approved-only" (default): only users in dm_allow_from can invite
@@ -492,6 +523,67 @@ class SignalAdapter(BasePlatformAdapter):
             self._sse_response = None
 
     # ------------------------------------------------------------------
+    # Group allowlist persistence
+    # ------------------------------------------------------------------
+
+    def _persist_approved_group(
+        self,
+        group_id: str,
+        sender: str,
+        sender_uuid: str,
+        sender_name: str,
+    ) -> None:
+        """Write a newly-approved group to the persistent JSON allowlist.
+
+        Read-modify-write so multiple groups accumulate correctly.
+        Uses atomic_json_write if available, otherwise tmp-file + os.replace.
+        Failures are logged as warnings and never propagated.
+        """
+        try:
+            path = get_hermes_home() / _APPROVED_GROUPS_FILE
+            existing: dict = {}
+            if path.exists():
+                try:
+                    existing = json.loads(path.read_text())
+                    if not isinstance(existing, dict):
+                        existing = {}
+                except Exception:
+                    existing = {}
+            existing[group_id] = {
+                "added_by": sender or "",
+                "added_by_uuid": sender_uuid or "",
+                "added_by_name": sender_name or "",
+                "approved_at": datetime.now(timezone.utc).isoformat(),
+            }
+            if _atomic_json_write is not None:
+                _atomic_json_write(path, existing)
+            else:
+                import tempfile
+                path.parent.mkdir(parents=True, exist_ok=True)
+                fd, tmp = tempfile.mkstemp(
+                    dir=str(path.parent),
+                    prefix=f".{path.stem}_",
+                    suffix=".tmp",
+                )
+                try:
+                    with os.fdopen(fd, "w") as fh:
+                        json.dump(existing, fh, indent=2)
+                    os.replace(tmp, str(path))
+                except Exception:
+                    try:
+                        os.unlink(tmp)
+                    except OSError:
+                        pass
+                    raise
+        except Exception:
+            logger.warning(
+                "Signal: failed to persist approved group %s to %s (non-fatal)",
+                group_id[:12] if group_id else "?",
+                _APPROVED_GROUPS_FILE,
+                exc_info=True,
+            )
+
+    # ------------------------------------------------------------------
     # Message Handling
     # ------------------------------------------------------------------
 
@@ -622,6 +714,17 @@ class SignalAdapter(BasePlatformAdapter):
                     "Signal: group %s added to runtime allowlist after invite acceptance",
                     group_v2_invite_id[:12] if group_v2_invite_id else "?",
                 )
+                # Persist so the group survives container restarts.
+                try:
+                    self._persist_approved_group(
+                        group_v2_invite_id, sender, sender_uuid, sender_name,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Signal: could not persist approved group %s (non-fatal)",
+                        group_v2_invite_id[:12] if group_v2_invite_id else "?",
+                        exc_info=True,
+                    )
                 return  # nothing else to process — no dataMessage
 
         # Get data message — also check editMessage (edited messages contain

--- a/tests/gateway/test_signal_group_persistence.py
+++ b/tests/gateway/test_signal_group_persistence.py
@@ -1,0 +1,320 @@
+"""Tests for Signal adapter group allowlist persistence across restarts.
+
+Covers:
+  - accepted invite writes the JSON file with correct groupId + metadata keys
+  - fresh adapter init loads persisted groups into group_allow_from
+  - persisted groups UNION with env-var groups (both sources present)
+  - corrupted JSON file → init still succeeds, group_allow_from = env groups only
+  - persistence write failure → invite acceptance still completes + group in runtime allowlist
+  - group already in env allowlist re-invited → no duplicate issues
+"""
+import asyncio
+import json
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.config import Platform, PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_signal_adapter(monkeypatch, tmp_path, account="+15551234567", **extra):
+    """Create a SignalAdapter with a tmp HERMES_HOME so tests never touch the real one."""
+    # Patch get_hermes_home at the source module AND in signal.py's own namespace
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    # Also patch via the signal module's import in case it imported directly
+    monkeypatch.setattr(
+        "gateway.platforms.signal.get_hermes_home", lambda: tmp_path, raising=False
+    )
+
+    monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", extra.pop("group_allowed", ""))
+    if "allowed_users" in extra:
+        monkeypatch.setenv("SIGNAL_ALLOWED_USERS", extra.pop("allowed_users"))
+    if "group_invite_policy" in extra:
+        monkeypatch.setenv("SIGNAL_GROUP_INVITE_POLICY", extra.pop("group_invite_policy"))
+
+    from gateway.platforms.signal import SignalAdapter
+    config = PlatformConfig()
+    config.enabled = True
+    config.extra = {
+        "http_url": "http://localhost:8080",
+        "account": account,
+        **extra,
+    }
+    return SignalAdapter(config)
+
+
+@pytest.fixture(autouse=True)
+def _reset_signal_scheduler():
+    from gateway.platforms.signal_rate_limit import _reset_scheduler
+    _reset_scheduler()
+    yield
+    _reset_scheduler()
+
+
+# ---------------------------------------------------------------------------
+# Helper: send an invite envelope and verify join was called
+# ---------------------------------------------------------------------------
+
+async def _send_invite_envelope(adapter, group_id, sender="+15559999999",
+                                sender_uuid="66666666-6666-6666-6666-666666666666",
+                                sender_name="Approved User"):
+    rpc_calls = []
+
+    async def mock_rpc(method, params, rpc_id=None, **kwargs):
+        rpc_calls.append(method)
+        return {"success": True}
+
+    adapter._rpc = mock_rpc
+    envelope = {
+        "envelope": {
+            "sourceNumber": sender,
+            "sourceUuid": sender_uuid,
+            "sourceName": sender_name,
+            "groupV2": {"groupId": group_id},
+        }
+    }
+    await adapter._handle_envelope(envelope)
+    return rpc_calls
+
+
+# ---------------------------------------------------------------------------
+# 1. Accepted invite writes the JSON file with the right groupId + metadata keys
+# ---------------------------------------------------------------------------
+
+class TestInviteWritesPersistenceFile:
+
+    @pytest.mark.asyncio
+    async def test_accepted_invite_creates_json_file(self, monkeypatch, tmp_path):
+        """Accepting a group invite must write signal_approved_groups.json."""
+        adapter = _make_signal_adapter(
+            monkeypatch, tmp_path, allowed_users="+15559999999"
+        )
+
+        await _send_invite_envelope(adapter, "group-aaa-111")
+
+        from gateway.platforms.signal import _APPROVED_GROUPS_FILE
+        persistence_file = tmp_path / _APPROVED_GROUPS_FILE
+        assert persistence_file.exists(), "Persistence file was not created after invite"
+
+    @pytest.mark.asyncio
+    async def test_accepted_invite_writes_correct_group_id(self, monkeypatch, tmp_path):
+        """The JSON file must contain the correct groupId as a top-level key."""
+        adapter = _make_signal_adapter(
+            monkeypatch, tmp_path, allowed_users="+15559999999"
+        )
+
+        await _send_invite_envelope(adapter, "group-bbb-222")
+
+        from gateway.platforms.signal import _APPROVED_GROUPS_FILE
+        data = json.loads((tmp_path / _APPROVED_GROUPS_FILE).read_text())
+        assert "group-bbb-222" in data
+
+    @pytest.mark.asyncio
+    async def test_accepted_invite_writes_metadata_keys(self, monkeypatch, tmp_path):
+        """Each entry must contain added_by, added_by_uuid, added_by_name, approved_at."""
+        adapter = _make_signal_adapter(
+            monkeypatch, tmp_path, allowed_users="+15559999999"
+        )
+
+        await _send_invite_envelope(
+            adapter, "group-ccc-333",
+            sender="+15559999999",
+            sender_uuid="66666666-6666-6666-6666-666666666666",
+            sender_name="Alice",
+        )
+
+        from gateway.platforms.signal import _APPROVED_GROUPS_FILE
+        data = json.loads((tmp_path / _APPROVED_GROUPS_FILE).read_text())
+        entry = data["group-ccc-333"]
+
+        assert "added_by" in entry
+        assert "added_by_uuid" in entry
+        assert "added_by_name" in entry
+        assert "approved_at" in entry
+
+        assert entry["added_by"] == "+15559999999"
+        assert entry["added_by_uuid"] == "66666666-6666-6666-6666-666666666666"
+        assert entry["added_by_name"] == "Alice"
+        # approved_at must be ISO-8601 formatted (contains 'T' separator)
+        assert "T" in entry["approved_at"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Fresh adapter loads persisted groups
+# ---------------------------------------------------------------------------
+
+class TestAdapterLoadsPersistedGroups:
+
+    def test_init_loads_persisted_groups_from_file(self, monkeypatch, tmp_path):
+        """A new adapter must load group IDs from the persistence file into group_allow_from."""
+        from gateway.platforms.signal import _APPROVED_GROUPS_FILE
+        existing = {
+            "group-persisted-001": {
+                "added_by": "+15559999999",
+                "added_by_uuid": "aaaa-bbbb",
+                "added_by_name": "Bob",
+                "approved_at": "2024-01-01T00:00:00+00:00",
+            }
+        }
+        (tmp_path / _APPROVED_GROUPS_FILE).write_text(json.dumps(existing))
+
+        # No env-var groups set
+        adapter = _make_signal_adapter(monkeypatch, tmp_path)
+
+        assert "group-persisted-001" in adapter.group_allow_from
+
+    def test_init_with_no_persistence_file_does_not_raise(self, monkeypatch, tmp_path):
+        """If the persistence file doesn't exist, init must succeed normally."""
+        adapter = _make_signal_adapter(monkeypatch, tmp_path)
+        assert isinstance(adapter.group_allow_from, set)
+
+
+# ---------------------------------------------------------------------------
+# 3. Persisted groups UNION with env-var groups
+# ---------------------------------------------------------------------------
+
+class TestPersistenceUnionWithEnvGroups:
+
+    def test_persisted_and_env_groups_both_present(self, monkeypatch, tmp_path):
+        """group_allow_from must contain groups from both the env var and the file."""
+        from gateway.platforms.signal import _APPROVED_GROUPS_FILE
+        existing = {
+            "group-from-file": {
+                "added_by": "+15558888888",
+                "added_by_uuid": "",
+                "added_by_name": "",
+                "approved_at": "2024-01-01T00:00:00+00:00",
+            }
+        }
+        (tmp_path / _APPROVED_GROUPS_FILE).write_text(json.dumps(existing))
+
+        adapter = _make_signal_adapter(
+            monkeypatch, tmp_path, group_allowed="group-from-env"
+        )
+
+        assert "group-from-env" in adapter.group_allow_from
+        assert "group-from-file" in adapter.group_allow_from
+
+
+# ---------------------------------------------------------------------------
+# 4. Corrupted JSON file → init still succeeds
+# ---------------------------------------------------------------------------
+
+class TestCorruptedFileHandling:
+
+    def test_corrupted_json_file_init_succeeds(self, monkeypatch, tmp_path):
+        """Corrupted persistence file must not crash init; env groups are preserved."""
+        from gateway.platforms.signal import _APPROVED_GROUPS_FILE
+        (tmp_path / _APPROVED_GROUPS_FILE).write_text("{invalid json!!!}")
+
+        adapter = _make_signal_adapter(
+            monkeypatch, tmp_path, group_allowed="env-group-safe"
+        )
+
+        # Init must succeed
+        assert isinstance(adapter.group_allow_from, set)
+        # Env-var group must still be present
+        assert "env-group-safe" in adapter.group_allow_from
+
+    def test_corrupted_json_file_does_not_load_bad_groups(self, monkeypatch, tmp_path):
+        """Corrupted persistence file must not add any groups (no partial state)."""
+        from gateway.platforms.signal import _APPROVED_GROUPS_FILE
+        (tmp_path / _APPROVED_GROUPS_FILE).write_text("{invalid json!!!")
+
+        adapter = _make_signal_adapter(monkeypatch, tmp_path)
+
+        # Only the empty set from the empty env var
+        assert len(adapter.group_allow_from) == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. Persistence write failure → invite acceptance still completes
+# ---------------------------------------------------------------------------
+
+class TestPersistenceWriteFailure:
+
+    @pytest.mark.asyncio
+    async def test_write_failure_does_not_break_invite_flow(self, monkeypatch, tmp_path):
+        """If persisting the group fails, the group must still be in the runtime allowlist."""
+        adapter = _make_signal_adapter(
+            monkeypatch, tmp_path, allowed_users="+15559999999"
+        )
+
+        # Make _persist_approved_group always raise
+        def _failing_persist(group_id, sender, sender_uuid, sender_name):
+            raise OSError("Disk full")
+
+        adapter._persist_approved_group = _failing_persist
+
+        await _send_invite_envelope(adapter, "group-write-fail-xyz")
+
+        # Group must be in runtime allowlist despite write failure
+        assert "group-write-fail-xyz" in adapter.group_allow_from
+
+    @pytest.mark.asyncio
+    async def test_write_failure_unwritable_dir(self, monkeypatch, tmp_path):
+        """Unwritable HERMES_HOME directory must not crash the invite flow."""
+        adapter = _make_signal_adapter(
+            monkeypatch, tmp_path, allowed_users="+15559999999"
+        )
+
+        # Make HERMES_HOME a file (not a dir) so writes will fail
+        hermes_home_fake = tmp_path / "blocked_home"
+        hermes_home_fake.write_text("not a directory")
+        monkeypatch.setattr(
+            "gateway.platforms.signal.get_hermes_home", lambda: hermes_home_fake
+        )
+
+        await _send_invite_envelope(adapter, "group-unwritable-dir")
+
+        # Still in runtime allowlist
+        assert "group-unwritable-dir" in adapter.group_allow_from
+
+
+# ---------------------------------------------------------------------------
+# 6. Group already in env allowlist re-invited → no duplicate issues
+# ---------------------------------------------------------------------------
+
+class TestReInviteNoduplicates:
+
+    @pytest.mark.asyncio
+    async def test_reinvite_of_env_group_no_duplicates(self, monkeypatch, tmp_path):
+        """Re-inviting a group already in env allowlist must not cause errors."""
+        adapter = _make_signal_adapter(
+            monkeypatch, tmp_path,
+            allowed_users="+15559999999",
+            group_allowed="already-in-env-group",
+        )
+
+        assert "already-in-env-group" in adapter.group_allow_from
+        original_count = len(adapter.group_allow_from)
+
+        # Invite for the same group
+        await _send_invite_envelope(adapter, "already-in-env-group")
+
+        # group_allow_from is a set — no duplicates possible
+        assert "already-in-env-group" in adapter.group_allow_from
+        # Set cardinality stays the same or smaller (add is idempotent)
+        assert len(adapter.group_allow_from) >= original_count
+
+    @pytest.mark.asyncio
+    async def test_reinvite_of_env_group_writes_file_without_error(self, monkeypatch, tmp_path):
+        """Re-invite of a group that's in the env allowlist should write to file cleanly."""
+        adapter = _make_signal_adapter(
+            monkeypatch, tmp_path,
+            allowed_users="+15559999999",
+            group_allowed="env-group-reinvited",
+        )
+
+        await _send_invite_envelope(adapter, "env-group-reinvited")
+
+        from gateway.platforms.signal import _APPROVED_GROUPS_FILE
+        persistence_file = tmp_path / _APPROVED_GROUPS_FILE
+        assert persistence_file.exists()
+        data = json.loads(persistence_file.read_text())
+        assert "env-group-reinvited" in data


### PR DESCRIPTION
## Problem

When an approved admin adds the bot to a Signal group, the invite handler accepts and adds the group to the runtime allowlist — but that set is in-memory only. The persistent allowlist is the `SIGNAL_GROUP_ALLOWED_USERS` env var, which only HSM writes. Any container restart or harness recreate silently drops runtime-approved groups and the bot goes deaf in them (hit in production on hermes-personal 2026-06-12: group message got no 👀, no response).

## Fix

- Accepted groups are persisted to `HERMES_HOME/signal_approved_groups.json` with audit metadata (`added_by`, `added_by_uuid`, `added_by_name`, `approved_at`).
- On adapter init, persisted groups are unioned into the allowlist alongside the env var.
- Both load and write are fault-tolerant: corrupted/unwritable file → warning log, never breaks init or the invite flow (atomic write via `atomic_json_write`, tmp+`os.replace` fallback).
- Security posture unchanged: persistence only happens after the existing `SIGNAL_GROUP_INVITE_POLICY` gate, so only admin-added (or allow-all, if configured) groups are ever persisted.

## Known limitation

HSM's `group-deregister` only edits the env var — a persisted group would survive it. Practical revocation today is removing the bot from the Signal group (it then receives nothing from that group anyway). If we want allowlist-level revocation while staying in the group, HSM needs a follow-up to delete entries from the state file.

## Tests

New `tests/gateway/test_signal_group_persistence.py` (12 tests): persist-on-accept with metadata, reload-on-init (with and without env groups), union semantics, corrupted file, unwritable dir, re-invite of already-allowed group. Full signal gateway suite: **236 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)