### PR TITLE
fix(signal): inline attachments as base64 in send_message tool

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -15,7 +15,6 @@ import asyncio
 import base64
 import json
 import logging
-import mimetypes
 import os
 import random
 import time
@@ -56,6 +55,7 @@ from gateway.platforms.signal_rate_limit import (
     _is_signal_rate_limit_error,
     _signal_send_timeout,
     get_scheduler,
+    signal_attachment_arg,
 )
 
 logger = logging.getLogger(__name__)
@@ -1169,30 +1169,11 @@ class SignalAdapter(BasePlatformAdapter):
     def _attachment_arg(self, path: str) -> str:
         """Build the signal-cli ``send`` attachment argument for a local file.
 
-        In HSM multi-container deployments signal-cli runs in its own
-        container and cannot see the agent's filesystem (``/opt/data``,
-        ``/tmp``), so a bare file path passed to the ``send`` RPC fails with
-        ``AttachmentInvalidException``. Rather than depend on a brittle web
-        of shared host mounts (one per agent, which doesn't scale and the
-        daemon compose never wired up), inline the file as a base64
-        ``data:`` URI — signal-cli 0.14+ accepts
-        ``data:<mime>;filename=<name>;base64,<data>`` for ``--attachment``.
-        This mirrors the inbound path, which already pulls attachments as
-        base64 via ``getAttachment``, and works for any source directory
-        with zero compose changes (single-container setups included).
-
-        Falls back to the raw path if the file can't be read, so a genuinely
-        missing file surfaces signal-cli's own error instead of being masked.
+        Thin wrapper over :func:`signal_attachment_arg` (shared with the
+        ``send_message`` tool) — see that function for the full rationale on
+        inlining files as base64 ``data:`` URIs in multi-container deployments.
         """
-        try:
-            data = Path(path).read_bytes()
-        except OSError as e:
-            logger.warning("Signal: could not read attachment %s: %s", path, e)
-            return path
-        mime = mimetypes.guess_type(path)[0] or "application/octet-stream"
-        name = Path(path).name
-        b64 = base64.b64encode(data).decode("ascii")
-        return f"data:{mime};filename={name};base64,{b64}"
+        return signal_attachment_arg(path)
 
     async def _rpc(
         self,

--- a/gateway/platforms/signal_rate_limit.py
+++ b/gateway/platforms/signal_rate_limit.py
@@ -16,13 +16,51 @@ daemon.
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
+import mimetypes
 import os
 import re
 import time
+from pathlib import Path
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def signal_attachment_arg(path: str) -> str:
+    """Build the signal-cli ``send`` attachment argument for a local file.
+
+    In HSM multi-container deployments signal-cli runs in its own container
+    and cannot see the agent's filesystem (``/opt/data``, ``/tmp``) — each
+    agent's data dir is bind-mounted only into its own container, not the
+    shared signal-cli daemon. A bare file path passed to the ``send`` RPC
+    therefore fails with ``AttachmentInvalidException`` / ``No such file``.
+
+    Rather than depend on a brittle web of shared host mounts (one per agent,
+    which doesn't scale and the daemon compose never wired up), inline the file
+    as a base64 ``data:`` URI — signal-cli 0.14+ accepts
+    ``data:<mime>;filename=<name>;base64,<data>`` for ``--attachment``. This
+    mirrors the inbound path (which pulls attachments as base64 via
+    ``getAttachment``) and works for any source directory with zero compose
+    changes, single-container setups included.
+
+    Falls back to the raw path if the file can't be read, so a genuinely
+    missing file surfaces signal-cli's own error instead of being masked.
+
+    Shared by the gateway adapter (``SignalAdapter._attachment_arg``) and the
+    ``send_message`` tool's Signal path so attachments inline identically for
+    every agent in the fleet.
+    """
+    try:
+        data = Path(path).read_bytes()
+    except OSError as e:
+        logger.warning("Signal: could not read attachment %s: %s", path, e)
+        return path
+    mime = mimetypes.guess_type(path)[0] or "application/octet-stream"
+    name = Path(path).name
+    b64 = base64.b64encode(data).decode("ascii")
+    return f"data:{mime};filename={name};base64,{b64}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_signal_send_resilience.py
+++ b/tests/tools/test_signal_send_resilience.py
@@ -403,3 +403,68 @@ class TestSignalConnectionRetry:
 def _send_signal_fn():
     from tools.send_message_tool import _send_signal
     return _send_signal
+
+
+# ---------------------------------------------------------------------------
+# Attachment inlining: the send_message tool must pass attachments to the
+# signal-cli daemon as base64 data: URIs, never as agent-container file paths.
+#
+# Regression: a video rendered at /opt/data/... failed with AttachmentInvalid
+# because the signal-cli daemon runs in a separate container that cannot see
+# the agent's filesystem. The gateway adapter already inlined as base64
+# (PR #18) but this tool path passed the raw path through.
+# ---------------------------------------------------------------------------
+
+class TestSignalAttachmentInlining:
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def _extra(self):
+        return {"http_url": "http://localhost:8080", "account": "+15551234567"}
+
+    def test_attachment_inlined_as_data_uri(self, monkeypatch, tmp_path):
+        """A local media file is inlined as data:<mime>;base64, not a raw path."""
+        _patch_conn_constants(monkeypatch)
+        _patch_tool_clock(monkeypatch)
+
+        # Simulate an agent-container path the daemon cannot resolve.
+        video = tmp_path / "render.mp4"
+        video.write_bytes(b"\x00\x01FAKEMP4DATA")
+
+        fake = _FakeSignalHttp([{"result": {"timestamp": 1}}])
+        _install_signal_http(monkeypatch, fake)
+
+        result = self._run(
+            _send_signal_fn()(
+                self._extra(), "group:abc", "here is the video",
+                media_files=[(str(video), False)],
+            )
+        )
+
+        assert result.get("success") is True
+        assert len(fake.calls) == 1
+        atts = fake.calls[0]["payload"]["params"]["attachments"]
+        assert len(atts) == 1
+        # The daemon must receive a self-contained data: URI, NOT the path.
+        assert atts[0].startswith("data:video/mp4;filename=render.mp4;base64,")
+        assert str(video) not in atts[0]
+
+    def test_missing_attachment_is_skipped(self, monkeypatch):
+        """A non-existent media path is skipped, not inlined."""
+        _patch_conn_constants(monkeypatch)
+        _patch_tool_clock(monkeypatch)
+
+        fake = _FakeSignalHttp([{"result": {"timestamp": 1}}])
+        _install_signal_http(monkeypatch, fake)
+
+        result = self._run(
+            _send_signal_fn()(
+                self._extra(), "group:abc", "text only",
+                media_files=[("/nope/missing.mp4", False)],
+            )
+        )
+
+        assert result.get("success") is True
+        # No attachments param when nothing was inlined.
+        params = fake.calls[0]["payload"]["params"]
+        assert "attachments" not in params or params["attachments"] == []

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1140,6 +1140,7 @@ async def _send_signal(extra, chat_id, message, media_files=None):
         _is_signal_rate_limit_error,
         _signal_send_timeout,
         get_scheduler,
+        signal_attachment_arg,
     )
 
     try:
@@ -1152,7 +1153,11 @@ async def _send_signal(extra, chat_id, message, media_files=None):
         attachment_paths = []
         for media_path, _is_voice in valid_media:
             if os.path.exists(media_path):
-                attachment_paths.append(media_path)
+                # signal-cli runs in its own container and cannot see the
+                # agent's filesystem (/opt/data, /tmp). Inline the file as a
+                # base64 data: URI so the daemon never has to resolve the
+                # agent-side path — same helper the gateway adapter uses.
+                attachment_paths.append(signal_attachment_arg(media_path))
             else:
                 logger.warning("Signal media file not found, skipping: %s", media_path)
 


### PR DESCRIPTION
## Problem

Hermes agents can no longer **send** video/file attachments over Signal. The Mare agent rendered a video but every send failed:

```
Tool send_message returned error: Signal RPC error on batch 1/1:
{'code': -32603, 'message': 'Failed to send message: /opt/data/.../render.mp4: ... (AttachmentInvalid)'}
```

## Root cause (confirmed against the live Mac Mini fleet)

`signal-cli` runs as a **separate daemon container** (`signal-cli-daemon`). Each agent's data dir is bind-mounted **only into that agent's own container** at `/opt/data` — it is **not** mounted into the signal-cli daemon. (Verified via `docker inspect`: the daemon mounts `/Users/juni/.hermes-cryptids`, `.hermes-cyborg`, `.hermes-egregore`, etc. at their host paths, but not `.hermes-mare` at all, and never under `/opt/data`.)

So when the agent passes an attachment path that is valid *inside its own container* (`/opt/data/.../render.mp4`), the daemon — which receives that path verbatim over JSON-RPC `send` — has no such file in its filesystem view → `AttachmentInvalidException` / `No such file or directory`.

The gateway adapter (`gateway/platforms/signal.py`) was already fixed for exactly this in PR #18: it inlines files as base64 `data:` URIs via `_attachment_arg`, so the daemon never resolves an agent-side path. **But the `send_message` tool (`tools/send_message_tool.py`) — the path the agent's tool call actually takes — was never given the same fix.** It appended the raw `media_path` straight into the `attachments` RPC param. That's why media sends through the tool fail while the prior working session (which delivered via the gateway adapter's media flow) succeeded.

Note: the running Mare image (built 2026-06-12) already contains the adapter's base64 fix — confirming this is a *missing fix in the tool path*, not a stale image.

## Fix

- Extract the base64-inlining logic into a shared `signal_attachment_arg(path)` in `gateway/platforms/signal_rate_limit.py` — the module both call sites already import from.
- `SignalAdapter._attachment_arg` now delegates to it (single source of truth).
- `_send_signal` in the tool now inlines each media file via `signal_attachment_arg()` instead of passing the raw path.

This works **fleet-wide** for every agent regardless of which agent dir is or isn't mounted on the daemon, requires **no compose/mount changes**, and works for single-container setups too.

## Tests

New `TestSignalAttachmentInlining` in `tests/tools/test_signal_send_resilience.py`:
- a local media path is delivered to the daemon as `data:<mime>;filename=...;base64,...` and **never** as the raw path
- missing files are skipped (no attachments param)

Full signal suites pass (144 passed, 3 pre-existing env skips): `test_signal_send_resilience.py`, `tests/gateway/test_signal.py`, `tests/tools/test_signal_media.py`, `tests/gateway/test_signal_rate_limit.py`.

## Deployment requirements

- **App-only fix.** No compose/mount changes and no signal-cli config changes are required — that's the point of inlining as `data:` URIs.
- **Agents must be rebuilt** to pick up the change (runtime is baked into the image; the deployed agents are static until rebuilt). After merge, rebuild + redeploy the agent images via the normal HSM flow; no daemon restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)