### PR TITLE
fix(gateway): admins can clear another participant's pending approval in groups

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2441,6 +2441,22 @@ class GatewayRunner:
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         )
 
+    def _chat_scope_session_key(self, source: SessionSource) -> str:
+        """The per-chat session key with NO per-user suffix.
+
+        Used to find sibling per-user sessions in the same group/chat: every
+        ``group_sessions_per_user`` key for this chat is either equal to this
+        scope or nested under ``scope + ':'``.  Returns "" if it can't be built.
+        """
+        try:
+            return build_session_key(
+                source,
+                group_sessions_per_user=False,
+                thread_sessions_per_user=False,
+            )
+        except Exception:
+            return ""
+
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
         """Return whether Telegram DM topic mode is active for this chat."""
         if source.platform != Platform.TELEGRAM or source.chat_type != "dm":
@@ -15110,24 +15126,20 @@ class GatewayRunner:
         session_key = self._session_key_for_source(source)
 
         from tools.approval import (
-            resolve_gateway_approval, has_blocking_approval,
-            _get_approval_config,
+            resolve_gateway_approval, resolve_gateway_approval_in_scope,
+            has_blocking_approval, _get_approval_config,
         )
 
         # Admin-only gating: when admin_only is set (default True),
         # only admin users may approve dangerous commands.
         approval_cfg = _get_approval_config()
+        is_admin_approver = True
         if approval_cfg.get("admin_only", True):
             from gateway.slash_access import policy_for_source as _policy_for_source
             _policy = _policy_for_source(self.config, source)
             if _policy.enabled and not _policy.is_admin(source.user_id):
                 return "⛔ Not authorized — only admin users can approve/deny dangerous commands."
-
-        if not has_blocking_approval(session_key):
-            if session_key in self._pending_approvals:
-                self._pending_approvals.pop(session_key)
-                return t("gateway.approval_expired")
-            return t("gateway.approve.no_pending")
+            is_admin_approver = (not _policy.enabled) or _policy.is_admin(source.user_id)
 
         # Parse args: support "all", "all session", "all always", "session", "always"
         args = event.get_command_args().strip().lower().split()
@@ -15141,8 +15153,25 @@ class GatewayRunner:
         else:
             choice = "once"
 
-        count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
+        if has_blocking_approval(session_key):
+            count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
+        else:
+            # group_sessions_per_user keys the pending approval to the
+            # *triggering* participant's session, not the approver's. Let an
+            # admin clear a sibling per-user session's approval in the same chat
+            # — otherwise a non-admin can trigger a command nobody can approve.
+            count = 0
+            if is_admin_approver:
+                scope = self._chat_scope_session_key(source)
+                if scope:
+                    count = resolve_gateway_approval_in_scope(
+                        scope, choice, resolve_all=resolve_all, exclude=session_key,
+                    )
+
         if not count:
+            if session_key in self._pending_approvals:
+                self._pending_approvals.pop(session_key)
+                return t("gateway.approval_expired")
             return t("gateway.approve.no_pending")
 
         # Resume typing indicator — agent is about to continue processing.
@@ -15166,30 +15195,43 @@ class GatewayRunner:
         session_key = self._session_key_for_source(source)
 
         from tools.approval import (
-            resolve_gateway_approval, has_blocking_approval,
-            _get_approval_config,
+            resolve_gateway_approval, resolve_gateway_approval_in_scope,
+            has_blocking_approval, _get_approval_config,
         )
 
         # Admin-only gating: when admin_only is set (default True),
         # only admin users may deny dangerous commands.
         approval_cfg = _get_approval_config()
+        is_admin_approver = True
         if approval_cfg.get("admin_only", True):
             from gateway.slash_access import policy_for_source as _policy_for_source
             _policy = _policy_for_source(self.config, source)
             if _policy.enabled and not _policy.is_admin(source.user_id):
                 return "⛔ Not authorized — only admin users can approve/deny dangerous commands."
-
-        if not has_blocking_approval(session_key):
-            if session_key in self._pending_approvals:
-                self._pending_approvals.pop(session_key)
-                return t("gateway.deny.stale")
-            return t("gateway.deny.no_pending")
+            is_admin_approver = (not _policy.enabled) or _policy.is_admin(source.user_id)
 
         args = event.get_command_args().strip().lower()
         resolve_all = "all" in args
 
-        count = resolve_gateway_approval(session_key, "deny", resolve_all=resolve_all)
+        if has_blocking_approval(session_key):
+            count = resolve_gateway_approval(session_key, "deny", resolve_all=resolve_all)
+        else:
+            # Mirror _handle_approve_command: an admin must be able to deny a
+            # pending approval bound to another participant's per-user session
+            # in the same chat (group_sessions_per_user), else a non-admin's
+            # command can only time out.
+            count = 0
+            if is_admin_approver:
+                scope = self._chat_scope_session_key(source)
+                if scope:
+                    count = resolve_gateway_approval_in_scope(
+                        scope, "deny", resolve_all=resolve_all, exclude=session_key,
+                    )
+
         if not count:
+            if session_key in self._pending_approvals:
+                self._pending_approvals.pop(session_key)
+                return t("gateway.deny.stale")
             return t("gateway.deny.no_pending")
 
         # Resume typing indicator — agent continues (with BLOCKED result).

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -647,3 +647,117 @@ class TestFallbackNoCallback:
         assert result["approved"] is False
         assert result.get("status") == "pending_approval"
         assert result.get("approval_pending") is True
+
+
+# ------------------------------------------------------------------
+# Cross-session admin approval (group_sessions_per_user)
+# ------------------------------------------------------------------
+
+
+class TestCrossSessionAdminApproval:
+    """In groups with per-user sessions, a dangerous command is keyed to the
+    *triggering* participant's session — not the approver's. An admin's
+    /approve must still clear that sibling session's pending approval, or a
+    non-admin can trigger a command nobody can ever approve."""
+
+    def setup_method(self):
+        _clear_approval_state()
+
+    @staticmethod
+    def _group_source(user_id: str) -> SessionSource:
+        return SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id=user_id,
+            chat_id="g1",
+            user_name=user_id,
+            chat_type="group",
+        )
+
+    @staticmethod
+    def _runner_with_admin(admin_id: str):
+        runner = _make_runner()
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=True,
+                    token="***",
+                    extra={"group_allow_admin_from": [admin_id]},
+                )
+            }
+        )
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_admin_approve_clears_other_participants_pending(self):
+        """Admin /approve resolves a pending approval bound to another user's
+        per-user session in the same group."""
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        runner = self._runner_with_admin("u_admin")
+
+        triggerer = self._group_source("u_cam")  # non-admin who hit the command
+        trig_key = runner._session_key_for_source(triggerer)
+        entry = _ApprovalEntry({"command": "ffprobe x | python3", "description": "scan"})
+        _gateway_queues[trig_key] = [entry]
+
+        admin_event = MessageEvent(
+            text="/approve session",
+            source=self._group_source("u_admin"),
+            message_id="m1",
+        )
+        result = await runner._handle_approve_command(admin_event)
+
+        assert entry.event.is_set()
+        assert entry.result == "session"
+        assert trig_key not in _gateway_queues
+        assert "no pending" not in result.lower()
+        assert "not authorized" not in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_nonadmin_cannot_cross_approve(self):
+        """A non-admin must NOT be able to clear another participant's pending
+        approval — admin-only gating still applies to cross-session resolves."""
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        runner = self._runner_with_admin("u_admin")
+
+        triggerer = self._group_source("u_other")
+        trig_key = runner._session_key_for_source(triggerer)
+        entry = _ApprovalEntry({"command": "rm -rf /", "description": "scan"})
+        _gateway_queues[trig_key] = [entry]
+
+        nonadmin_event = MessageEvent(
+            text="/approve",
+            source=self._group_source("u_cam"),  # not in group_allow_admin_from
+            message_id="m2",
+        )
+        result = await runner._handle_approve_command(nonadmin_event)
+
+        assert not entry.event.is_set()
+        assert trig_key in _gateway_queues
+        assert "not authorized" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_admin_deny_clears_other_participants_pending(self):
+        """Admin /deny must also resolve another participant's stuck pending
+        approval — otherwise a non-admin-triggered command can only time out."""
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        runner = self._runner_with_admin("u_admin")
+
+        triggerer = self._group_source("u_cam")
+        trig_key = runner._session_key_for_source(triggerer)
+        entry = _ApprovalEntry({"command": "rm -rf /", "description": "scan"})
+        _gateway_queues[trig_key] = [entry]
+
+        admin_event = MessageEvent(
+            text="/deny",
+            source=self._group_source("u_admin"),
+            message_id="m3",
+        )
+        result = await runner._handle_deny_command(admin_event)
+
+        assert entry.event.is_set()
+        assert entry.result == "deny"
+        assert trig_key not in _gateway_queues
+        assert "no pending" not in result.lower()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -665,6 +665,50 @@ def has_blocking_approval(session_key: str) -> bool:
         return bool(_gateway_queues.get(session_key))
 
 
+def list_blocking_session_keys(scope_prefix: str = "", exclude: str = "") -> list:
+    """Session keys that currently have >=1 blocking gateway approval.
+
+    When *scope_prefix* is given, restrict to keys equal to it or nested under
+    it (``scope_prefix + ':'``) — i.e. sibling per-user sessions that share one
+    group/chat.  Insertion order is preserved (earliest-registered first).
+    """
+    with _lock:
+        keys = [k for k, q in _gateway_queues.items() if q]
+    if exclude:
+        keys = [k for k in keys if k != exclude]
+    if scope_prefix:
+        sep = scope_prefix + ":"
+        keys = [k for k in keys if k == scope_prefix or k.startswith(sep)]
+    return keys
+
+
+def resolve_gateway_approval_in_scope(scope_prefix: str, choice: str,
+                                      resolve_all: bool = False,
+                                      exclude: str = "") -> int:
+    """Resolve blocking approvals across sibling sessions sharing a chat scope.
+
+    ``group_sessions_per_user`` keys a dangerous-command approval to the
+    *triggering* participant's session, not the approver's.  This lets an
+    admin's /approve (or /deny) clear a pending approval owned by another
+    participant's per-user session in the same group — without it, a non-admin
+    can trigger a command that nobody is able to approve or deny, and it just
+    times out.
+
+    With *resolve_all* False, the single oldest approval from the
+    earliest-registered sibling session is resolved; True resolves every
+    pending approval in scope.  Returns the number resolved.
+    """
+    keys = list_blocking_session_keys(scope_prefix=scope_prefix, exclude=exclude)
+    if not keys:
+        return 0
+    if resolve_all:
+        total = 0
+        for k in keys:
+            total += resolve_gateway_approval(k, choice, resolve_all=True)
+        return total
+    return resolve_gateway_approval(keys[0], choice, resolve_all=False)
+
+
 def submit_pending(session_key: str, approval: dict):
     """Store a pending approval request for a session."""
     with _lock:


### PR DESCRIPTION
## Problem

In a **group** chat with `group_sessions_per_user` (the default), a dangerous-command approval is keyed to the **triggering participant's** per-user session — not the approver's. With `HERMES_APPROVAL_ADMIN_ONLY=true`, only an admin may `/approve`, **but** the admin's `/approve` resolves under their *own* session key, which holds no pending command.

Net effect: **a non-admin can trigger a dangerous command that nobody can approve or deny.** It just times out after the approval window (default 300s), wasting the agent's turn. The non-admin's own `/approve` is correctly rejected (admin-only), and the admin's `/approve` finds nothing pending under their key.

## Fix

When the approver's own session has no pending approval, an **admin** `/approve` or `/deny` now resolves a sibling per-user session's pending approval in the **same chat scope**:

- `tools/approval.py`: `list_blocking_session_keys()` + `resolve_gateway_approval_in_scope()` — resolve blocking approvals across sessions sharing a chat-scope prefix.
- `gateway/run.py`: `_chat_scope_session_key()` (per-chat key, no per-user suffix); `_handle_approve_command` / `_handle_deny_command` fall back to scope resolution for admins when their own session is empty.

Non-admins remain gated (admin-only check unchanged). Own-session and DM behavior is unchanged. A single `/approve` resolves the oldest sibling approval; `/approve all` resolves all in scope.

## Tests (TDD)

New `TestCrossSessionAdminApproval` in `tests/gateway/test_approve_deny_commands.py`:
- admin `/approve` clears another participant's pending approval ✅
- admin `/deny` clears another participant's pending approval ✅
- non-admin **cannot** cross-approve (still rejected) ✅

```
24 passed  (test_approve_deny_commands.py)
214 passed (approval + session + slash + matrix/slack/telegram approval-button suites)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)