### PR TITLE
fix(gateway): drop dead is_platform_admin from Telegram/Signal admin gates ("approved = admin")

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1927,14 +1927,18 @@ class SignalAdapter(BasePlatformAdapter):
         if event is not None:
             sender = getattr(getattr(event, "source", None), "user_id", None)
             if sender and "*" not in self.dm_allow_from and sender not in self.dm_allow_from:
-                # Admin check - unified via HSM (approved users = admins)
+                # Sender not matched by user_id. Sealed-sender messages may carry
+                # the UUID as user_id_alt — match it against the allowlist (incl.
+                # resolved UUIDs) before denying. "approved = admin": the
+                # individual DM allowlist is the approved set.
+                #
+                # (Was a swarm_map_policy.is_platform_admin call — that HSM route
+                # does not exist, so it 404'd: it never matched and cost a ~5s
+                # timeout per group message from a non-allowlisted sender.)
                 sender_uuid = getattr(getattr(event, "source", None), "user_id_alt", None)
-                try:
-                    from plugins.swarm_map_policy import is_platform_admin
-                    if is_platform_admin(sender, "signal") or (sender_uuid and is_platform_admin(sender_uuid, "signal")):
-                        return True
-                except Exception:
-                    pass
+                allow_uuids = getattr(self, "dm_allow_from_uuids", set())
+                if sender_uuid and (sender_uuid in self.dm_allow_from or sender_uuid in allow_uuids):
+                    return True
                 return False
         return True
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -560,37 +560,69 @@ class TelegramAdapter(BasePlatformAdapter):
         allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
         return "*" in allowed_ids or normalized_user_id in allowed_ids
 
-    def _is_user_admin(self, user_id: str) -> bool:
-        """Check whether *user_id* is an admin for approval gating.
+    def _is_user_admin(
+        self,
+        user_id: str,
+        *,
+        chat_id: Optional[str] = None,
+        chat_type: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        user_name: Optional[str] = None,
+    ) -> bool:
+        """Whether *user_id* may approve/deny dangerous commands via inline buttons.
 
-        Resolution order:
-        1. ``swarm_map_policy.is_platform_admin`` (HSM-backed, if available)
-        2. First entry in ``TELEGRAM_ALLOWED_USERS`` is treated as admin
-        3. Fail-closed: returns False
+        Routes through the gateway's unified approval-admin check
+        (``GatewayRunner._is_approval_admin``) so a Telegram user has the SAME
+        approval authority whether they click a button or type ``/approve``:
+        "approved = admin" — membership in the individual allowlist
+        (``TELEGRAM_ALLOWED_USERS``) plus any configured ``allow_admin_from``
+        policy. Falls back to an env-only individual-allowlist check when the
+        runner isn't wired (mirrors ``_is_callback_user_authorized``).
+
+        Replaces the former ``swarm_map_policy.is_platform_admin`` call: that HSM
+        route does not exist, so it 404'd on every click (fail-closed plus a
+        needless ~5s timeout), and its "first allowlisted user only" fallback was
+        inconsistent with the slash ``/approve`` gate.
         """
-        normalized = str(user_id or "").strip()
-        if not normalized:
+        normalized_user_id = str(user_id or "").strip()
+        if not normalized_user_id:
             return False
 
-        # 1. HSM policy (swarm_map_policy plugin)
-        try:
-            from plugins.swarm_map_policy import is_platform_admin
-            if is_platform_admin(normalized, "telegram"):
-                return True
-        except Exception:
-            pass  # plugin not installed or HSM unreachable — fall through
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        admin_fn = getattr(runner, "_is_approval_admin", None)
+        if callable(admin_fn):
+            try:
+                from gateway.session import SessionSource
 
-        # 2. First user in TELEGRAM_ALLOWED_USERS is admin
+                normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
+                if normalized_chat_type == "private":
+                    normalized_chat_type = "dm"
+                elif normalized_chat_type == "supergroup":
+                    normalized_chat_type = "forum" if thread_id is not None else "group"
+
+                source = SessionSource(
+                    platform=Platform.TELEGRAM,
+                    chat_id=str(chat_id or normalized_user_id),
+                    chat_type=normalized_chat_type,
+                    user_id=normalized_user_id,
+                    user_name=str(user_name).strip() if user_name else None,
+                    thread_id=str(thread_id) if thread_id is not None else None,
+                )
+                return bool(admin_fn(source))
+            except Exception:
+                logger.debug(
+                    "[Telegram] Falling back to env-only admin check for user %s",
+                    normalized_user_id,
+                    exc_info=True,
+                )
+
+        # Env-only fallback (no runner wired): "approved = admin" against the
+        # individual allowlist, consistent with _is_individual_allowlisted.
         allowed_csv = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
-        if allowed_csv:
-            first_id = next(
-                (uid.strip() for uid in allowed_csv.split(",") if uid.strip() and uid.strip() != "*"),
-                None,
-            )
-            if first_id and normalized == first_id:
-                return True
-
-        return False
+        if not allowed_csv:
+            return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+        return "*" in allowed_ids or normalized_user_id in allowed_ids
 
     @classmethod
     def _metadata_thread_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
@@ -3330,11 +3362,21 @@ class TelegramAdapter(BasePlatformAdapter):
                 try:
                     from tools.approval import _get_approval_config
                     approval_cfg = _get_approval_config()
-                    if approval_cfg.get("admin_only", True) and not self._is_user_admin(caller_id):
+                    if approval_cfg.get("admin_only", True) and not self._is_user_admin(
+                        caller_id,
+                        chat_id=query_chat_id,
+                        chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                        thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                        user_name=query_user_name,
+                    ):
                         await query.answer(text="⛔ Not authorized — only admin users can approve commands.")
                         return
                 except Exception as _admin_err:
+                    # Fail closed: a dangerous-command approval must not slip
+                    # through because the admin check raised.
                     logger.warning("Admin-only approval check failed: %s", _admin_err)
+                    await query.answer(text="⛔ Could not verify approval permissions — denied.")
+                    return
 
                 session_key = self._approval_state.pop(approval_id, None)
                 if not session_key:

--- a/tests/gateway/test_approval_admin_gating.py
+++ b/tests/gateway/test_approval_admin_gating.py
@@ -409,40 +409,121 @@ class TestTelegramCallbackAdminGating:
         # Should have been resolved — no admin block
         assert 12 not in adapter._approval_state
 
+    @pytest.mark.asyncio
+    async def test_admin_check_error_denies(self):
+        """Fail closed: if the admin check raises, the dangerous-command
+        approval must be denied, not allowed through."""
+        adapter = _make_adapter()
+        adapter._approval_state[13] = "agent:main:telegram:group:12345:99"
+
+        query = AsyncMock()
+        query.data = "ea:once:13"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.chat = MagicMock()
+        query.message.chat.type = "private"
+        query.message.message_thread_id = None
+        query.from_user = MagicMock()
+        query.from_user.id = "111"
+        query.from_user.first_name = "Admin"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval._get_approval_config", return_value={"admin_only": True}):
+                with patch.object(adapter, "_is_user_admin", side_effect=RuntimeError("boom")):
+                    with patch("tools.approval.resolve_gateway_approval", return_value=1):
+                        await adapter._handle_callback_query(update, context)
+
+        # Denied — state NOT consumed, denial surfaced.
+        assert 13 in adapter._approval_state
+        assert query.answer.called
+        assert "denied" in query.answer.call_args[1]["text"].lower()
+
 
 # ===========================================================================
 # _is_user_admin method
 # ===========================================================================
 
 
+class _FakeAdminRunner:
+    """Stands in for GatewayRunner: exposes _is_approval_admin and a bound
+    method so the adapter can reach it via _message_handler.__self__."""
+
+    def __init__(self, verdict):
+        self._verdict = verdict
+        self.seen = None
+
+    def _is_approval_admin(self, source):
+        self.seen = source
+        return self._verdict
+
+    def _handler(self, *a, **k):  # used purely as a bound method
+        pass
+
+
+# Env baseline so the host environment can't leak into fallback assertions.
+_TG_ENV_OFF = {"TELEGRAM_ALLOWED_USERS": "", "GATEWAY_ALLOW_ALL_USERS": ""}
+
+
 class TestIsUserAdmin:
-    """Test the _is_user_admin method on TelegramAdapter."""
+    """_is_user_admin gates Telegram inline-button approvals. It must mirror the
+    slash /approve gate ("approved = admin"): a user's approval authority can't
+    depend on whether they clicked a button or typed a command."""
 
-    def test_first_allowed_user_is_admin(self):
+    def test_delegates_to_runner_approval_admin(self):
+        """When the gateway runner is wired, _is_user_admin returns the runner's
+        _is_approval_admin verdict — the SAME check the slash gate uses — and
+        builds a Telegram source from the button context."""
         adapter = _make_adapter()
-        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "111,222,333"}, clear=False):
-            with patch("plugins.swarm_map_policy.is_platform_admin", side_effect=Exception("not installed"), create=True):
-                assert adapter._is_user_admin("111") is True
-                assert adapter._is_user_admin("222") is False
+        runner = _FakeAdminRunner(True)
+        adapter._message_handler = runner._handler  # __self__ == runner
 
-    def test_wildcard_not_treated_as_admin(self):
+        assert adapter._is_user_admin(
+            "u1", chat_id="g1", chat_type="supergroup", thread_id="7", user_name="x"
+        ) is True
+        assert runner.seen is not None
+        assert runner.seen.user_id == "u1"
+        assert runner.seen.platform == Platform.TELEGRAM
+        # supergroup + thread → forum scope
+        assert runner.seen.chat_type == "forum"
+
+        # A False verdict from the runner denies.
+        adapter._message_handler = _FakeAdminRunner(False)._handler
+        assert adapter._is_user_admin("u1", chat_id="g1", chat_type="group") is False
+
+    def test_fallback_any_allowlisted_user_is_admin(self):
+        """No runner wired → env-only fallback: ANY user in TELEGRAM_ALLOWED_USERS
+        is admin (not just the first), consistent with _is_individual_allowlisted."""
         adapter = _make_adapter()
-        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*,111"}, clear=False):
-            # "*" is skipped, first real ID is admin
+        env = {**_TG_ENV_OFF, "TELEGRAM_ALLOWED_USERS": "111,222,333"}
+        with patch.dict(os.environ, env, clear=False):
             assert adapter._is_user_admin("111") is True
-            assert adapter._is_user_admin("222") is False
+            assert adapter._is_user_admin("222") is True
+            assert adapter._is_user_admin("444") is False
 
-    def test_empty_allowed_users_returns_false(self):
+    def test_fallback_wildcard_makes_anyone_admin(self):
+        """"*" in the allowlist → open mode → anyone is admin (matches the slash
+        gate / _is_individual_allowlisted)."""
         adapter = _make_adapter()
-        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": ""}, clear=False):
+        env = {**_TG_ENV_OFF, "TELEGRAM_ALLOWED_USERS": "*"}
+        with patch.dict(os.environ, env, clear=False):
+            assert adapter._is_user_admin("anyone") is True
+
+    def test_fallback_gateway_allow_all_makes_admin(self):
+        adapter = _make_adapter()
+        env = {**_TG_ENV_OFF, "GATEWAY_ALLOW_ALL_USERS": "true"}
+        with patch.dict(os.environ, env, clear=False):
+            assert adapter._is_user_admin("anyone") is True
+
+    def test_fallback_empty_allowed_users_returns_false(self):
+        adapter = _make_adapter()
+        with patch.dict(os.environ, _TG_ENV_OFF, clear=False):
             assert adapter._is_user_admin("111") is False
-
-    def test_hsm_policy_checked_first(self):
-        adapter = _make_adapter()
-        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "999"}, clear=False):
-            with patch("plugins.swarm_map_policy.is_platform_admin", return_value=True, create=True):
-                # HSM says admin, even though not first in allowlist
-                assert adapter._is_user_admin("222") is True
 
     def test_empty_user_id_returns_false(self):
         adapter = _make_adapter()

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -2028,6 +2028,47 @@ class TestObserveOnlyReactionSuppression:
         adapter.send_reaction.assert_called_once()
 
 
+class TestReactionAllowlistUuidMatch:
+    """The 👀 reaction gate is "approved = admin": a sender reachable only by
+    UUID (sealed-sender) is matched against the DM allowlist via user_id_alt,
+    and a sender in neither id form is denied — replacing the removed dead
+    swarm_map_policy.is_platform_admin call (HSM 404 + ~5s timeout)."""
+
+    def _event(self, user_id, user_id_alt=None):
+        from gateway.platforms.base import MessageEvent
+        from gateway.session import SessionSource
+        return MessageEvent(
+            text="hi",
+            source=SessionSource(
+                platform=Platform.SIGNAL,
+                chat_id="group123",
+                chat_type="group",
+                user_id=user_id,
+                user_id_alt=user_id_alt,
+            ),
+        )
+
+    def test_uuid_in_allowlist_enables_reaction(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter.dm_allow_from = {"uuid-approved"}
+        # phone not in allowlist, but its UUID (user_id_alt) is.
+        ev = self._event("+15550001111", user_id_alt="uuid-approved")
+        assert adapter._reactions_enabled(ev) is True
+
+    def test_resolved_uuid_set_enables_reaction(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter.dm_allow_from = {"+15551112222"}
+        adapter.dm_allow_from_uuids = {"uuid-resolved"}
+        ev = self._event("+15550001111", user_id_alt="uuid-resolved")
+        assert adapter._reactions_enabled(ev) is True
+
+    def test_unlisted_sender_denied(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter.dm_allow_from = {"+15551112222"}
+        ev = self._event("+15550001111", user_id_alt="uuid-unlisted")
+        assert adapter._reactions_enabled(ev) is False
+
+
 class TestSignalMessageTypeClassification:
     """Inbound attachments must be classified so run.py surfaces them.
 


### PR DESCRIPTION
## What

Follow-up to #49. The `swarm_map_policy.is_platform_admin` plugin calls `GET /api/harnesses/{id}/surfaces/{platform}/admins/{user_id}` — **a route that doesn't exist**, so it 404s → fail-closed `False` for everyone, plus a **~5s timeout on every call**. #49 removed it from the slash `/approve` gate; two live call sites remained:

### Telegram button approvals — `_is_user_admin`
- Now delegates to the gateway's unified `_is_approval_admin` (the same check the slash gate uses), so a user has **identical approval authority whether they click "Approve" or type `/approve`** ("approved = admin"). Env-only fallback when no runner is wired, mirroring `_is_callback_user_authorized`.
- Drops `is_platform_admin` and the inconsistent **"first allowlisted user only"** model — now any allowlisted user can approve (within the already-authorized set; `_is_callback_user_authorized` still gates authorization first).
- **Hardened the call site to fail closed**: if the admin check raises, the approval is denied rather than falling through and resolving it.

### Signal 👀 reaction gate — `_reactions_enabled`
- A non-`dm_allow_from` sender triggered **up to two dead 5s-timeout HTTP calls per group message**. Replaced with a `user_id_alt` (Signal UUID) check against `dm_allow_from` / `dm_allow_from_uuids` — **also fixing a phone↔UUID gap** where a sealed-sender message from an allowlisted-by-UUID user was wrongly denied the reaction. Purely additive narrowing; an unlisted sender is still denied.

After this, `is_platform_admin` is no longer called anywhere in `gateway/` (only a docstring references what it replaced).

## Tests
- `TestIsUserAdmin` rewritten: delegates to `runner._is_approval_admin`; env fallback admits **any** allowlisted user + wildcard + `GATEWAY_ALLOW_ALL_USERS`.
- `test_admin_check_error_denies`: admin-check exception → approval denied (fail closed).
- `TestReactionAllowlistUuidMatch`: UUID-in-allowlist and resolved-UUID enable the reaction; unlisted sender denied.
- 193 affected gateway tests green; ruff clean. Independent adversarial review: **SAFE TO MERGE** (no unauthorized/group-only over-grant; chat_type scoping matches the slash gate).

## Deploy
After merge: same flow as #49 — `git pull --ff-only origin main` on the Mini, then rebuild the running agents via HSM API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)