### PR TITLE
fix(signal): auto-approve pre-existing groups on connect (close add-at-creation gap)

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -354,6 +354,10 @@ class SignalAdapter(BasePlatformAdapter):
             # Resolve phone-number allowlists to UUIDs now that RPC is live.
             await self._resolve_allowlist_uuids()
 
+            # Auto-approve pre-existing groups the agent was added to without
+            # an invite envelope (e.g. added at group creation). Best-effort.
+            await self._reconcile_groups()
+
             # Set profile name from environment if configured.
             await self._set_profile_name()
 
@@ -581,6 +585,109 @@ class SignalAdapter(BasePlatformAdapter):
                 group_id[:12] if group_id else "?",
                 _APPROVED_GROUPS_FILE,
                 exc_info=True,
+            )
+
+    def _group_approval_reason(self, group: dict):
+        """Decide whether a group the agent already belongs to should be
+        auto-approved, returning the vouching identity or ``None``.
+
+        Mirrors the invite handler's trust model, but keyed on the group's
+        admins instead of an invite envelope's sender (which never arrives for
+        groups the agent was added to at creation time):
+
+        * ``allow-all`` policy  → approve any member group.
+        * open mode / wildcard  → approve (no DM allowlist configured).
+        * ``approved-only``     → approve only when an approved user is an
+                                  *admin* of the group (a trusted operator
+                                  established it).
+
+        Trust note: the invite handler trusts an *action* (an approved user
+        invited the bot); this trusts a *property* (an approved user is a group
+        admin). Those aren't identical — a hostile creator could, in principle,
+        add an approved user to a group and promote them to admin without that
+        user's consent, then add the bot. This is an accepted, bounded trade-off
+        (it still requires an approved operator to be present *as an admin*, and
+        only governs which groups the bot will *respond* in — not DM access or
+        command authority). Reconciliation only runs for groups the bot is
+        already a member of; it never joins new ones.
+
+        Returns ``(number, uuid, name)`` of the vouching admin (empty strings
+        for the policy/open-mode cases), or ``None`` to skip.
+        """
+        if self.group_invite_policy == "allow-all":
+            return ("", "", "allow-all-policy")
+        if not self.dm_allow_from or "*" in self.dm_allow_from:
+            return ("", "", "open-mode")
+        for admin in (group.get("admins") or []):
+            a_uuid = admin.get("uuid")
+            a_num = admin.get("number")
+            if (
+                (a_uuid and (a_uuid in self.dm_allow_from_uuids or a_uuid in self.dm_allow_from))
+                or (a_num and a_num in self.dm_allow_from)
+            ):
+                return (a_num or "", a_uuid or "", "")
+        return None
+
+    async def _reconcile_groups(self) -> None:
+        """Auto-approve groups the agent is already a member of.
+
+        Closes the add-at-creation gap: when an admin creates a group with the
+        agent already in it, no invite envelope is ever delivered, so the
+        invite handler never fires and the group stays unapproved. On connect
+        we list the agent's groups and approve any trusted ones
+        (see :meth:`_group_approval_reason`), reusing the same persistence so
+        they survive restarts. Best-effort — failures never break startup.
+        """
+        try:
+            result = await self._rpc("listGroups", {"account": self.account})
+        except Exception:
+            logger.debug(
+                "Signal: group reconciliation skipped (listGroups failed)",
+                exc_info=True,
+            )
+            return
+
+        # "*" already allows every group at message time — nothing to
+        # reconcile, and per-group persistence would just churn the JSON file
+        # on every connect.
+        if "*" in self.group_allow_from:
+            return
+
+        groups = result if isinstance(result, list) else []
+        approved = 0
+        for group in groups:
+            # Per-group isolation: a malformed entry (non-dict, or admins in an
+            # unexpected shape) must never break the connect path — this is a
+            # best-effort startup step.
+            try:
+                if not isinstance(group, dict):
+                    continue
+                gid = group.get("id")
+                if not gid or gid in self.group_allow_from:
+                    continue
+                if not group.get("isMember", False) or group.get("isBlocked", False):
+                    continue
+                reason = self._group_approval_reason(group)
+                if reason is None:
+                    continue
+                sender, sender_uuid, sender_name = reason
+                self.group_allow_from.add(gid)
+                approved += 1
+                logger.info(
+                    "Signal: reconciliation auto-approving pre-existing group %s (%s)",
+                    gid[:12],
+                    (sender_uuid or sender or sender_name or "?")[:12],
+                )
+                self._persist_approved_group(gid, sender, sender_uuid, sender_name)
+            except Exception:
+                logger.warning(
+                    "Signal: could not reconcile a group (non-fatal)",
+                    exc_info=True,
+                )
+        if approved:
+            logger.info(
+                "Signal: group reconciliation approved %d pre-existing group(s)",
+                approved,
             )
 
     # ------------------------------------------------------------------

--- a/tests/gateway/test_signal_group_reconcile.py
+++ b/tests/gateway/test_signal_group_reconcile.py
@@ -1,0 +1,303 @@
+"""Tests for Signal adapter group reconciliation (Gap G1: added-at-creation).
+
+The invite handler only auto-approves a group when an invite *envelope*
+(groupV2 update with no dataMessage) arrives from an approved user. When an
+admin *creates* a group with the agent already in it, no invite envelope is
+ever delivered, so that handler never fires and the group stays unapproved —
+its messages are silently dropped.
+
+`_reconcile_groups()` closes that gap, envelope-agnostically: on connect it
+lists the agent's groups and auto-approves any the agent is already a member
+of when an approved user is a group admin. It mirrors the invite handler's
+trust model (open-mode / wildcard / approved-admin) and reuses the same
+persistence so reconciled groups survive restarts.
+"""
+import json
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_signal_adapter(monkeypatch, tmp_path, account="+15551234567", **extra):
+    """Create a SignalAdapter with a tmp HERMES_HOME so tests never touch the real one."""
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "gateway.platforms.signal.get_hermes_home", lambda: tmp_path, raising=False
+    )
+
+    monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", extra.pop("group_allowed", ""))
+    if "allowed_users" in extra:
+        monkeypatch.setenv("SIGNAL_ALLOWED_USERS", extra.pop("allowed_users"))
+    if "group_invite_policy" in extra:
+        monkeypatch.setenv("SIGNAL_GROUP_INVITE_POLICY", extra.pop("group_invite_policy"))
+
+    from gateway.platforms.signal import SignalAdapter
+    config = PlatformConfig()
+    config.enabled = True
+    config.extra = {
+        "http_url": "http://localhost:8080",
+        "account": account,
+        **extra,
+    }
+    return SignalAdapter(config)
+
+
+@pytest.fixture(autouse=True)
+def _reset_signal_scheduler():
+    from gateway.platforms.signal_rate_limit import _reset_scheduler
+    _reset_scheduler()
+    yield
+    _reset_scheduler()
+
+
+def _group(gid, *, admin_number=None, admin_uuid=None, is_member=True,
+           is_blocked=False, extra_members=None):
+    """Build a listGroups-shaped group dict."""
+    admins = []
+    members = list(extra_members or [])
+    if admin_number or admin_uuid:
+        admin = {"number": admin_number, "uuid": admin_uuid}
+        admins.append(admin)
+        members.append({"number": admin_number, "uuid": admin_uuid, "isAdmin": True})
+    return {
+        "id": gid,
+        "name": f"group {gid}",
+        "isMember": is_member,
+        "isBlocked": is_blocked,
+        "members": members,
+        "admins": admins,
+    }
+
+
+def _mock_list_groups(adapter, groups):
+    """Patch adapter._rpc so listGroups returns `groups`; record calls."""
+    calls = []
+
+    async def mock_rpc(method, params=None, rpc_id=None, **kwargs):
+        calls.append((method, params))
+        if method == "listGroups":
+            return groups
+        return {"success": True}
+
+    adapter._rpc = mock_rpc
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Approve when an approved user is a group admin (the real use case)
+# ---------------------------------------------------------------------------
+
+class TestReconcileApprovesTrustedGroup:
+
+    @pytest.mark.asyncio
+    async def test_approves_group_with_approved_admin_by_number(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(monkeypatch, tmp_path, allowed_users="+15559999999")
+        _mock_list_groups(adapter, [_group("grp-1", admin_number="+15559999999")])
+
+        await adapter._reconcile_groups()
+
+        assert "grp-1" in adapter.group_allow_from
+
+    @pytest.mark.asyncio
+    async def test_approves_group_with_approved_admin_by_uuid(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(monkeypatch, tmp_path, allowed_users="+15559999999")
+        # UUID-only allowlist entry, resolved as DMs are at boot.
+        adapter.dm_allow_from_uuids.add("66666666-6666-6666-6666-666666666666")
+        _mock_list_groups(
+            adapter,
+            [_group("grp-2", admin_uuid="66666666-6666-6666-6666-666666666666")],
+        )
+
+        await adapter._reconcile_groups()
+
+        assert "grp-2" in adapter.group_allow_from
+
+    @pytest.mark.asyncio
+    async def test_persists_reconciled_group(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(monkeypatch, tmp_path, allowed_users="+15559999999")
+        _mock_list_groups(adapter, [_group("grp-3", admin_number="+15559999999")])
+
+        await adapter._reconcile_groups()
+
+        from gateway.platforms.signal import _APPROVED_GROUPS_FILE
+        data = json.loads((tmp_path / _APPROVED_GROUPS_FILE).read_text())
+        assert "grp-3" in data
+        assert data["grp-3"]["added_by_uuid"] or data["grp-3"]["added_by"]
+
+
+# ---------------------------------------------------------------------------
+# Do NOT approve untrusted / ineligible groups
+# ---------------------------------------------------------------------------
+
+class TestReconcileSkipsUntrusted:
+
+    @pytest.mark.asyncio
+    async def test_skips_group_without_approved_admin(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(monkeypatch, tmp_path, allowed_users="+15559999999")
+        _mock_list_groups(adapter, [_group("grp-x", admin_number="+15550000000")])
+
+        await adapter._reconcile_groups()
+
+        assert "grp-x" not in adapter.group_allow_from
+
+    @pytest.mark.asyncio
+    async def test_skips_non_member_group(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(monkeypatch, tmp_path, allowed_users="+15559999999")
+        _mock_list_groups(
+            adapter,
+            [_group("grp-nm", admin_number="+15559999999", is_member=False)],
+        )
+
+        await adapter._reconcile_groups()
+
+        assert "grp-nm" not in adapter.group_allow_from
+
+    @pytest.mark.asyncio
+    async def test_skips_blocked_group(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(monkeypatch, tmp_path, allowed_users="+15559999999")
+        _mock_list_groups(
+            adapter,
+            [_group("grp-bl", admin_number="+15559999999", is_blocked=True)],
+        )
+
+        await adapter._reconcile_groups()
+
+        assert "grp-bl" not in adapter.group_allow_from
+
+    @pytest.mark.asyncio
+    async def test_already_approved_group_not_repersisted(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(
+            monkeypatch, tmp_path, allowed_users="+15559999999", group_allowed="grp-known"
+        )
+        _mock_list_groups(adapter, [_group("grp-known", admin_number="+15559999999")])
+
+        await adapter._reconcile_groups()
+
+        from gateway.platforms.signal import _APPROVED_GROUPS_FILE
+        # Idempotent: an already-approved group should not create a persistence entry.
+        path = tmp_path / _APPROVED_GROUPS_FILE
+        if path.exists():
+            assert "grp-known" not in json.loads(path.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Policy parity with the invite handler
+# ---------------------------------------------------------------------------
+
+class TestReconcilePolicyParity:
+
+    @pytest.mark.asyncio
+    async def test_allow_all_policy_approves_any_member_group(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(
+            monkeypatch, tmp_path, allowed_users="+15559999999",
+            group_invite_policy="allow-all",
+        )
+        # No approved admin in the group, but policy is allow-all.
+        _mock_list_groups(adapter, [_group("grp-aa", admin_number="+15550000000")])
+
+        await adapter._reconcile_groups()
+
+        assert "grp-aa" in adapter.group_allow_from
+
+    @pytest.mark.asyncio
+    async def test_open_mode_no_allowlist_approves_member_group(self, monkeypatch, tmp_path):
+        # No SIGNAL_ALLOWED_USERS configured = open mode (mirrors invite handler).
+        adapter = _make_signal_adapter(monkeypatch, tmp_path)
+        _mock_list_groups(adapter, [_group("grp-open", admin_number="+15550000000")])
+
+        await adapter._reconcile_groups()
+
+        assert "grp-open" in adapter.group_allow_from
+
+
+# ---------------------------------------------------------------------------
+# Robustness: a malformed listGroups payload must never break startup
+# ---------------------------------------------------------------------------
+
+class TestReconcileRobustness:
+
+    @pytest.mark.asyncio
+    async def test_malformed_admins_does_not_raise(self, monkeypatch, tmp_path):
+        # admins as a list of strings (unexpected shape) must not crash startup.
+        adapter = _make_signal_adapter(monkeypatch, tmp_path, allowed_users="+15559999999")
+        bad = {
+            "id": "grp-bad",
+            "isMember": True,
+            "isBlocked": False,
+            "admins": ["+15559999999"],  # strings, not dicts
+            "members": [],
+        }
+        good = _group("grp-good", admin_number="+15559999999")
+        _mock_list_groups(adapter, [bad, good])
+
+        await adapter._reconcile_groups()  # must not raise
+
+        # The malformed group is skipped; the well-formed one still approved.
+        assert "grp-bad" not in adapter.group_allow_from
+        assert "grp-good" in adapter.group_allow_from
+
+    @pytest.mark.asyncio
+    async def test_non_dict_group_entry_does_not_raise(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(monkeypatch, tmp_path, allowed_users="+15559999999")
+        _mock_list_groups(
+            adapter,
+            ["i am not a dict", _group("grp-ok", admin_number="+15559999999")],
+        )
+
+        await adapter._reconcile_groups()  # must not raise
+
+        assert "grp-ok" in adapter.group_allow_from
+
+    @pytest.mark.asyncio
+    async def test_wildcard_groups_does_not_repersist_every_group(self, monkeypatch, tmp_path):
+        # SIGNAL_GROUP_ALLOWED_USERS="*" already allows all groups — reconciliation
+        # must not individually approve+persist each member group on every connect.
+        adapter = _make_signal_adapter(
+            monkeypatch, tmp_path, allowed_users="+15559999999", group_allowed="*"
+        )
+        _mock_list_groups(
+            adapter,
+            [_group("grp-a", admin_number="+15559999999"),
+             _group("grp-b", admin_number="+15559999999")],
+        )
+
+        await adapter._reconcile_groups()
+
+        from gateway.platforms.signal import _APPROVED_GROUPS_FILE
+        path = tmp_path / _APPROVED_GROUPS_FILE
+        assert not path.exists(), "wildcard allow-all should not persist per-group entries"
+
+
+# ---------------------------------------------------------------------------
+# Wiring: connect() runs reconciliation after a successful health check
+# ---------------------------------------------------------------------------
+
+class TestReconcileWiredIntoConnect:
+
+    @pytest.mark.asyncio
+    async def test_connect_invokes_reconcile_groups(self, monkeypatch, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        adapter = _make_signal_adapter(monkeypatch, tmp_path, allowed_users="+15559999999")
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=MagicMock(status_code=200))
+        mock_client.aclose = AsyncMock()
+
+        # Replace the network-touching collaborators so connect() stays local.
+        monkeypatch.setattr(adapter, "_resolve_allowlist_uuids", AsyncMock())
+        monkeypatch.setattr(adapter, "_set_profile_name", AsyncMock())
+        monkeypatch.setattr(adapter, "_sse_listener", AsyncMock())
+        monkeypatch.setattr(adapter, "_health_monitor", AsyncMock())
+        reconcile = AsyncMock()
+        monkeypatch.setattr(adapter, "_reconcile_groups", reconcile)
+        monkeypatch.setattr(adapter, "_acquire_platform_lock", lambda *a, **k: True)
+        monkeypatch.setattr(adapter, "_release_platform_lock", lambda *a, **k: None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            ok = await adapter.connect()
+
+        await adapter.disconnect()
+
+        assert ok is True
+        reconcile.assert_awaited_once()


### PR DESCRIPTION
## Problem

The Signal gateway only auto-approves a group when an **invite envelope** (groupV2 update, no dataMessage) arrives from an approved user. When an admin **creates a group with the agent already in it**, Signal delivers no invite envelope, so the invite handler never fires and the group stays unapproved — every message (including the operator's own) is silently dropped.

This bit us twice bringing agents online: "I added the agent to the group and it never responds." (Gap G1 from the group-approval debugging notes.)

## Fix

Add `_reconcile_groups()`, run once in `connect()` right after allowlist-UUID resolution. It lists the agent's groups and auto-approves any it already belongs to when the group is **trusted**, via `_group_approval_reason()`:

| policy | approves |
|---|---|
| `allow-all` | any member group |
| open mode / wildcard `*` | approve (no DM allowlist configured) |
| `approved-only` (default) | only when an **approved user is a group admin** |

- Mirrors the existing invite handler's trust tiers; reuses `_persist_approved_group` so reconciled groups survive restarts.
- Only runs for groups the bot **already belongs to** — it never joins new ones — and only governs which groups the bot **responds** in (not DM access or command authority).
- The approved-admin predicate is a deliberately bounded analog to the invite handler's approved-inviter check; the trade-off is documented inline in the helper.

## Robustness (from review)

- Skips entirely when groups are wildcard-allowed (`*`) — avoids churning the persisted JSON on every connect.
- Per-group `try/except` so a malformed `listGroups` entry (non-dict, unexpected admins shape) can never break the connect/startup path (best-effort contract).

## Tests

13 new tests in `tests/gateway/test_signal_group_reconcile.py`: trust matching by number/uuid, persistence, skip non-member/blocked/already-approved, allow-all + open-mode parity, malformed-payload robustness, wildcard no-churn, and `connect()` wiring. Full Signal suite green in natural collection order (**250 passed**). ruff clean; no new `ty` diagnostics.

> Note: there is a **pre-existing**, order-dependent test-isolation flake in `tests/gateway/test_signal_group_persistence.py` (a `get_hermes_home` monkeypatch survives into a later `test_signal.py::test_init_empty_allowlist` when the persistence file is collected *before* `test_signal.py`). It reproduces on `main` without this change and does not occur in natural collection order. Flagged for a separate test-infra cleanup; not addressed here to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)