### PR TITLE
fix(tests): isolate get_hermes_home across Signal gateway tests

### DIFF
--- a/tests/gateway/test_signal_group_persistence.py
+++ b/tests/gateway/test_signal_group_persistence.py
@@ -23,13 +23,21 @@ from gateway.config import Platform, PlatformConfig
 # ---------------------------------------------------------------------------
 
 def _make_signal_adapter(monkeypatch, tmp_path, account="+15551234567", **extra):
-    """Create a SignalAdapter with a tmp HERMES_HOME so tests never touch the real one."""
-    # Patch get_hermes_home at the source module AND in signal.py's own namespace
-    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
-    # Also patch via the signal module's import in case it imported directly
-    monkeypatch.setattr(
-        "gateway.platforms.signal.get_hermes_home", lambda: tmp_path, raising=False
-    )
+    """Create a SignalAdapter with a tmp HERMES_HOME so tests never touch the real one.
+
+    We point HERMES_HOME (the env var ``get_hermes_home`` reads) at ``tmp_path``
+    rather than monkeypatching the ``get_hermes_home`` function object. Patching
+    the function via the dotted string ``gateway.platforms.signal.get_hermes_home``
+    is a cross-test-pollution hazard: if the signal module has not been imported
+    yet, the *first* patch of ``hermes_constants.get_hermes_home`` runs before the
+    module is imported, so when the second patch triggers the import, signal.py's
+    ``from hermes_constants import get_hermes_home`` binds the already-patched
+    lambda into the module namespace. monkeypatch then records that lambda as the
+    "original" value and restores it (not the real function) on teardown, leaking
+    the lambda — and its captured tmp_path — into every later test. Setting the
+    env var exercises the real ``get_hermes_home`` code path and tears down cleanly.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
     monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", extra.pop("group_allowed", ""))
     if "allowed_users" in extra:
@@ -266,9 +274,7 @@ class TestPersistenceWriteFailure:
         # Make HERMES_HOME a file (not a dir) so writes will fail
         hermes_home_fake = tmp_path / "blocked_home"
         hermes_home_fake.write_text("not a directory")
-        monkeypatch.setattr(
-            "gateway.platforms.signal.get_hermes_home", lambda: hermes_home_fake
-        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home_fake))
 
         await _send_invite_envelope(adapter, "group-unwritable-dir")
 
@@ -318,3 +324,65 @@ class TestReInviteNoduplicates:
         assert persistence_file.exists()
         data = json.loads(persistence_file.read_text())
         assert "env-group-reinvited" in data
+
+
+# ---------------------------------------------------------------------------
+# 7. Test-isolation regression: the helper must NOT leak get_hermes_home
+# ---------------------------------------------------------------------------
+
+class TestHelperDoesNotLeakHermesHome:
+    """Regression for a cross-test pollution bug.
+
+    The old helper monkeypatched ``gateway.platforms.signal.get_hermes_home``
+    via a dotted string. When the signal module was imported for the first
+    time *during* that patch (because ``hermes_constants.get_hermes_home`` was
+    patched first, then the signal-module patch triggered the import),
+    monkeypatch recorded the already-patched lambda as the "original" value and
+    restored that lambda — not the real function — on teardown. The lambda,
+    closing over the test's ``tmp_path``, then leaked into every later test and
+    made unrelated tests load this test's persisted groups.
+
+    These tests assert the helper leaves the signal module's ``get_hermes_home``
+    binding identical to ``hermes_constants.get_hermes_home`` after a test runs,
+    and that an adapter built afterwards reads the *current* HERMES_HOME.
+    """
+
+    def test_helper_leaves_signal_get_hermes_home_unpatched(
+        self, monkeypatch, tmp_path
+    ):
+        import hermes_constants
+        import gateway.platforms.signal as signal_mod
+
+        # Persist a group under this test's home so a leak would be observable.
+        from gateway.platforms.signal import _APPROVED_GROUPS_FILE
+        (tmp_path / _APPROVED_GROUPS_FILE).write_text('{"leaked-group": {}}')
+
+        _make_signal_adapter(monkeypatch, tmp_path, allowed_users="+15559999999")
+
+        # The signal module must still resolve get_hermes_home to the real
+        # function object — not a lambda left behind by the helper.
+        assert signal_mod.get_hermes_home is hermes_constants.get_hermes_home
+
+    def test_fresh_adapter_reads_current_hermes_home(self, monkeypatch, tmp_path):
+        """After the helper runs for one home, a plain adapter built against a
+        different HERMES_HOME must see that new home, proving no stale binding."""
+        from gateway.platforms.signal import SignalAdapter, _APPROVED_GROUPS_FILE
+
+        # First: run the helper pointed at tmp_path with a persisted group.
+        (tmp_path / _APPROVED_GROUPS_FILE).write_text('{"old-home-group": {}}')
+        _make_signal_adapter(monkeypatch, tmp_path, allowed_users="+15559999999")
+
+        # Now point HERMES_HOME somewhere clean and build an adapter directly.
+        clean_home = tmp_path / "clean"
+        clean_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(clean_home))
+        monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", "")
+
+        config = PlatformConfig()
+        config.enabled = True
+        config.extra = {"http_url": "http://localhost:8080", "account": "+15551234567"}
+        adapter = SignalAdapter(config)
+
+        # Must NOT have loaded the group from the previous home.
+        assert "old-home-group" not in adapter.group_allow_from
+        assert len(adapter.group_allow_from) == 0

--- a/tests/gateway/test_signal_group_reconcile.py
+++ b/tests/gateway/test_signal_group_reconcile.py
@@ -19,11 +19,16 @@ from gateway.config import PlatformConfig
 
 
 def _make_signal_adapter(monkeypatch, tmp_path, account="+15551234567", **extra):
-    """Create a SignalAdapter with a tmp HERMES_HOME so tests never touch the real one."""
-    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
-    monkeypatch.setattr(
-        "gateway.platforms.signal.get_hermes_home", lambda: tmp_path, raising=False
-    )
+    """Create a SignalAdapter with a tmp HERMES_HOME so tests never touch the real one.
+
+    Sets HERMES_HOME (read live by ``get_hermes_home``) rather than monkeypatching
+    the function object. Patching ``gateway.platforms.signal.get_hermes_home`` via a
+    dotted string leaks across tests when the module is imported for the first time
+    *during* the patch (monkeypatch records the already-patched lambda as the
+    "original" and never restores the real function). See the matching helper in
+    ``test_signal_group_persistence.py`` for the full root-cause writeup.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
     monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", extra.pop("group_allowed", ""))
     if "allowed_users" in extra:


### PR DESCRIPTION
## Root cause (proven)

The `_make_signal_adapter` helpers in `tests/gateway/test_signal_group_persistence.py` and `tests/gateway/test_signal_group_reconcile.py` patched `get_hermes_home` in this order:

```python
monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
monkeypatch.setattr("gateway.platforms.signal.get_hermes_home", lambda: tmp_path, raising=False)
```

When `gateway.platforms.signal` has **not yet been imported** in the pytest process (e.g. a persistence/reconcile test runs before `test_signal.py`):

1. The first `setattr` replaces the real function object in `hermes_constants`.
2. The second `setattr`'s dotted-string target triggers the **first import** of `gateway.platforms.signal`. That module body runs `from hermes_constants import get_hermes_home` (signal.py:29), which binds the **already-patched lambda** into the signal module namespace.
3. monkeypatch's `setattr` records the current value as the "original" to restore. Because the module was just imported with the lambda already in place, the recorded original **is the lambda, not the real function**.
4. On teardown (LIFO undo), `gateway.platforms.signal.get_hermes_home` is "restored" to that lambda — which closes over the first test's `tmp_path`. It never goes back to the real function.

Every later test that constructs a `SignalAdapter` then calls `get_hermes_home()` via the signal module and gets the stale `tmp_path`, loading that earlier test's persisted `signal_approved_groups.json`. Concrete failure: `test_signal.py::TestSignalAdapterInit::test_init_empty_allowlist` asserts `group_allow_from` is empty but finds `{'group-aaa-111'}` from the first persistence test.

This is **purely a test-isolation bug — production code is correct**. `get_hermes_home()` reads `HERMES_HOME` live with no caching. It stayed hidden because in natural pytest collection order `test_signal.py` imports the signal module first (with no patch active), so the recorded original is the real function and undo works. The bug only bites when a polluting file that imports signal cold is collected/run before `test_signal.py`.

### Verification of the mechanism

Reproduced in isolation: with the signal module unimported, running the two `setattr` calls in helper order and then `mp.undo()` leaves `gateway.platforms.signal.get_hermes_home` as the lambda (`is_real=False, is_lambda=True`), while `hermes_constants.get_hermes_home` is correctly restored.

## Fix

The helpers now set the `HERMES_HOME` env var (the value `get_hermes_home` reads live) instead of monkeypatching the function object:

```python
monkeypatch.setenv("HERMES_HOME", str(tmp_path))
```

This exercises the real `get_hermes_home` code path and tears down cleanly with no module-namespace residue. The `test_write_failure_unwritable_dir` test is updated to point `HERMES_HOME` at a file the same way.

## New regression tests

`TestHelperDoesNotLeakHermesHome` (in `test_signal_group_persistence.py`):
- `test_helper_leaves_signal_get_hermes_home_unpatched` — asserts the signal module's `get_hermes_home` is still the real `hermes_constants.get_hermes_home` after the helper runs.
- `test_fresh_adapter_reads_current_hermes_home` — builds an adapter against a clean `HERMES_HOME` after the helper ran for a different home, and asserts the previous home's persisted group did not leak.

## Test evidence

**Before (red)** — original 2-file repro:
```
tests/gateway/test_signal_group_persistence.py tests/gateway/test_signal.py::TestSignalAdapterInit::test_init_empty_allowlist
> assert len(adapter.group_allow_from) == 0
E AssertionError: assert 1 == 0
E  + where 1 = len({'group-aaa-111'})
1 failed, 12 passed
```

The new regression tests against the old buggy helper:
```
TestHelperDoesNotLeakHermesHome
> assert "old-home-group" not in adapter.group_allow_from
E AssertionError: assert 'old-home-group' not in {'old-home-group'}
2 failed
```

**After (green):**
- Original 2-file repro: `15 passed`
- New regression tests: `2 passed`
- Full signal suite, **natural order**: `252 passed`
- Full signal suite, **polluter-first order** (persistence + reconcile before test_signal.py): `252 passed`
- `ruff check` on both changed files: `All checks passed!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)