### PR TITLE
fix(signal): authorize group senders in adapter-approved groups (not just env)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7355,6 +7355,22 @@ class GatewayRunner:
                     ):
                         return True
 
+            # Signal: also honor groups the adapter approved at runtime — invite
+            # acceptance, startup reconciliation, or the persisted approved-groups
+            # file — which are tracked in the adapter's `group_allow_from` but are
+            # NOT reflected in the SIGNAL_GROUP_ALLOWED_USERS env var. The adapter
+            # already gated this message by that same set at intake; authorizing
+            # the sender here keeps run.py consistent with the adapter's decision
+            # (otherwise auto-approved groups silently reject their members).
+            if source.platform == Platform.SIGNAL:
+                _signal_adapter = (getattr(self, "adapters", None) or {}).get(Platform.SIGNAL)
+                _approved_groups = getattr(_signal_adapter, "group_allow_from", None)
+                if _approved_groups and (
+                    "*" in _approved_groups
+                    or self._chat_id_in_allowlist(source, _approved_groups)
+                ):
+                    return True
+
         if not user_id:
             return False
 

--- a/tests/gateway/test_signal_group_auth.py
+++ b/tests/gateway/test_signal_group_auth.py
@@ -111,3 +111,52 @@ def test_group_sender_denied_when_no_group_allowlist(monkeypatch):
     monkeypatch.setenv("SIGNAL_ALLOWED_USERS", ADMIN)
     runner = _make_bare_runner()
     assert runner._is_user_authorized(_group_source(user_id="+15550009999")) is False
+
+
+# ---------------------------------------------------------------------------
+# Adapter runtime-approved groups (invite-accept / reconcile / persisted) must
+# authorize their senders even when the group is NOT in the env var. run.py's
+# group-sender auth previously read only SIGNAL_GROUP_ALLOWED_USERS, so groups
+# the adapter approved at runtime had their senders rejected as "Unauthorized".
+# ---------------------------------------------------------------------------
+
+def test_group_member_authorized_by_adapter_runtime_approval(monkeypatch):
+    """Group present in adapter.group_allow_from but NOT in the env var → the
+    sender is authorized (run.py honors the adapter's own approval decision)."""
+    # A DM allowlist is set, so the "no allowlist → honor adapter" fallback does
+    # NOT apply; and the group is deliberately absent from the env group list.
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", ADMIN)
+    monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", "someothergroup")
+    runner = _make_bare_runner()
+    runner.adapters = {Platform.SIGNAL: SimpleNamespace(group_allow_from={"runtimegid"})}
+    src = _group_source(user_id="+15550009999", gid="runtimegid")
+    assert runner._is_user_authorized(src) is True
+
+
+def test_group_member_authorized_by_adapter_wildcard(monkeypatch):
+    """Adapter group_allow_from == {'*'} authorizes any group sender."""
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", ADMIN)
+    monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", "someothergroup")
+    runner = _make_bare_runner()
+    runner.adapters = {Platform.SIGNAL: SimpleNamespace(group_allow_from={"*"})}
+    src = _group_source(user_id="+15550009999", gid="anygid")
+    assert runner._is_user_authorized(src) is True
+
+
+def test_group_member_denied_when_not_in_env_or_adapter(monkeypatch):
+    """A group in neither the env var nor the adapter's approved set still denies."""
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", ADMIN)
+    monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", "someothergroup")
+    runner = _make_bare_runner()
+    runner.adapters = {Platform.SIGNAL: SimpleNamespace(group_allow_from={"differentgid"})}
+    src = _group_source(user_id="+15550009999", gid="runtimegid")
+    assert runner._is_user_authorized(src) is False
+
+
+def test_adapter_runtime_approval_no_adapters_attr_does_not_crash(monkeypatch):
+    """A bare runner without `.adapters` must not raise (defensive getattr)."""
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", ADMIN)
+    monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", "someothergroup")
+    runner = _make_bare_runner()  # no .adapters set
+    src = _group_source(user_id="+15550009999", gid="runtimegid")
+    assert runner._is_user_authorized(src) is False


### PR DESCRIPTION
## Problem (found via live testing of #53)

After #53 (startup group reconciliation), a freshly add-at-creation group was correctly auto-approved at the **adapter** level (`group_allow_from`) — the gateway log showed `reconciliation auto-approving pre-existing group …`. But messaging that group still produced:

```
WARNING gateway.run: Unauthorized user: <uuid> (…) on signal
```

Root cause: `run.py::_is_user_authorized` authorizes Signal group **senders** off the `SIGNAL_GROUP_ALLOWED_USERS` **env var only**. A group can be approved at the adapter level *without* being in that env var — via invite acceptance, `_reconcile_groups`, or the persisted `signal_approved_groups.json` loaded at boot. The adapter passes those messages through (group is in `group_allow_from`), but run.py then default-denies the sender. The "no env allowlist → honor adapter gating" fallback doesn't help because it only fires when *no* env allowlist exists; with a DM allowlist set (normal), it falls through to deny.

This affected the **pre-existing invite-accept path too**, not just #53's reconcile.

## Fix

In the Signal group branch of `_is_user_authorized`, after the env check, also consult the live adapter's `group_allow_from` (env ∪ persisted ∪ runtime) via the existing `_chat_id_in_allowlist` matcher. This makes run.py consistent with the adapter's own intake gating — literally what the existing comment already claims. Defensive `getattr` so a runner without `.adapters` never raises.

**No new authorization surface:** it only honors groups the adapter already approved through the same trust gates (env / invite-from-approved-admin / reconcile-with-approved-admin).

## Tests

4 new in `test_signal_group_auth.py`: runtime-approved group authorizes its sender; adapter wildcard `*`; denial when group is in neither env nor adapter; bare runner without `.adapters` doesn't crash. Full group-auth suite + broader signal/access-policy suites green (**205 passed**). ruff clean.

## Validation plan

Redeploy + re-run the live add-at-creation test (create group with the agent at creation + an approved admin → message it → expect a response, no "Unauthorized user").

🤖 Generated with [Claude Code](https://claude.com/claude-code)