### PR TITLE
feat(zai): list glm-5.2 / glm-4.6 in the GLM provider catalog

### DIFF
--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -11,6 +11,8 @@ zai = ProviderProfile(
     description="Z.AI / GLM — Zhipu AI models",
     signup_url="https://z.ai/",
     fallback_models=(
+        "glm-5.2",
+        "glm-4.6",
         "glm-5",
         "glm-4-9b",
     ),

--- a/tests/hermes_cli/test_zai_glm_catalog.py
+++ b/tests/hermes_cli/test_zai_glm_catalog.py
@@ -1,0 +1,37 @@
+"""GLM-5.2 (and 4.6) must be recognised model ids on the first-class `zai` provider.
+
+HSM's cascade editor emits `{provider: "zai", model: "glm-5.2"}`; the runtime
+`zai` plugin should carry those ids in its fallback catalog so model selection
+and suggestion surfaces know about them. The endpoint (Z.ai cloud, or a future
+self-hosted GPU box) is configured via base_url — this only asserts the catalog.
+"""
+
+from __future__ import annotations
+
+from providers import get_provider_profile
+
+
+def _zai():
+    profile = get_provider_profile("zai")
+    assert profile is not None, "zai provider plugin should be registered"
+    return profile
+
+
+def test_zai_profile_lists_glm_5_2():
+    assert "glm-5.2" in _zai().fallback_models
+
+
+def test_zai_profile_lists_glm_4_6():
+    assert "glm-4.6" in _zai().fallback_models
+
+
+def test_zai_aliases_cover_glm_naming():
+    # HSM/users may say "glm"/"zhipu"; the plugin must resolve those to zai.
+    aliases = _zai().aliases
+    assert "glm" in aliases
+    assert "zhipu" in aliases
+
+
+def test_zai_authenticates_via_glm_key():
+    # The canonical credential HSM writes is GLM_API_KEY (plugin also accepts ZAI_*).
+    assert "GLM_API_KEY" in _zai().env_vars


### PR DESCRIPTION
## What
Adds the current Z.ai/GLM flagship ids — `glm-5.2` and `glm-4.6` — to the `zai` provider plugin's `fallback_models`, so model-selection and suggestion surfaces (and HSM's cascade editor) recognise them.

The `zai` provider already existed (aliases `glm`/`zhipu`; base_url resolved by the runtime; key via `GLM_API_KEY`/`ZAI_API_KEY`/`Z_AI_API_KEY`) — this is purely catalog data. Endpoint and auth are unchanged.

## Why
Pairs with HSM PR NimbleCoAI/hermes-swarm-map#123, which surfaces GLM as a first-class cascade provider. HSM emits `provider: zai` + a model id with no base_url; the runtime owns the Z.ai endpoint, so the same selection points at Z.ai today or a self-hosted GPU box (`GLM_BASE_URL`) later.

## Verification
- Slugs confirmed against Z.ai docs (`glm-5.1` convention) + models.dev (`glm-5.2` exact).
- New test `tests/hermes_cli/test_zai_glm_catalog.py` (4 tests) asserts the catalog/alias/key contract.
- `tests/hermes_cli/test_runtime_provider_resolution.py`, `test_model_switch_custom_providers.py`, `test_gmi_provider.py` — **171 pass, no regression.**

Additive, self-contained (minimal upstream divergence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)