### PR TITLE
fix(web-search): honor site:<domain> operator in Exa/Tavily providers

### DIFF
--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -121,12 +121,28 @@ class ExaWebSearchProvider(WebSearchProvider):
             if is_interrupted():
                 return {"success": False, "error": "Interrupted"}
 
-            logger.info("Exa search: '%s' (limit=%d)", query, limit)
-            response = _get_exa_client().search(
-                query,
-                num_results=limit,
-                contents={"highlights": True},
+            # ``site:<domain>`` is an operator, not a literal term. Exa has a
+            # native domain filter (``include_domains``), so parse the operator
+            # out and apply it natively — otherwise the ``site:`` token is sent
+            # verbatim and results come back with empty highlights.
+            from tools.web_tools import parse_site_operator
+
+            domains, residual = parse_site_operator(query)
+            effective_query = residual if domains else query
+
+            logger.info(
+                "Exa search: '%s' (limit=%d, include_domains=%s)",
+                effective_query,
+                limit,
+                domains or None,
             )
+            search_kwargs: Dict[str, Any] = {
+                "num_results": limit,
+                "contents": {"highlights": True},
+            }
+            if domains:
+                search_kwargs["include_domains"] = domains
+            response = _get_exa_client().search(effective_query, **search_kwargs)
 
             web_results = []
             for i, result in enumerate(response.results or []):

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -154,16 +154,30 @@ class TavilyWebSearchProvider(WebSearchProvider):
             if is_interrupted():
                 return {"success": False, "error": "Interrupted"}
 
-            logger.info("Tavily search: '%s' (limit=%d)", query, limit)
-            raw = _tavily_request(
-                "search",
-                {
-                    "query": query,
-                    "max_results": min(limit, 20),
-                    "include_raw_content": False,
-                    "include_images": False,
-                },
+            # For ``site:<domain>`` scoped queries, Tavily honors the operator
+            # in-query but its default ``basic`` depth frequently returns empty
+            # ``content`` snippets. Bumping to ``advanced`` depth (only when a
+            # site scope is present) restores real snippets without changing
+            # cost/behavior for ordinary queries.
+            from tools.web_tools import parse_site_operator
+
+            domains, _residual = parse_site_operator(query)
+
+            logger.info(
+                "Tavily search: '%s' (limit=%d, site_scope=%s)",
+                query,
+                limit,
+                bool(domains),
             )
+            payload: Dict[str, Any] = {
+                "query": query,
+                "max_results": min(limit, 20),
+                "include_raw_content": False,
+                "include_images": False,
+            }
+            if domains:
+                payload["search_depth"] = "advanced"
+            raw = _tavily_request("search", payload)
             return _normalize_tavily_search_results(raw)
         except ValueError as exc:
             return {"success": False, "error": str(exc)}

--- a/tests/tools/test_web_tools_site_operator.py
+++ b/tests/tools/test_web_tools_site_operator.py
@@ -1,0 +1,151 @@
+"""Tests for the ``site:<domain>`` search operator handling.
+
+Background: ``site:nature.com CRISPR`` style queries used to be passed to
+web-search providers verbatim, so providers with a native domain-filter
+parameter (Exa) never used it, and Tavily's default ``basic`` search depth
+frequently returned empty ``content`` snippets for domain-scoped queries.
+
+These tests pin the shared ``parse_site_operator`` helper plus the
+provider-specific wiring (Exa ``include_domains`` + residual query, Tavily
+``search_depth="advanced"``).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ─── parse_site_operator (shared helper) ─────────────────────────────────────
+
+
+class TestParseSiteOperator:
+    def test_single_operator_leading(self):
+        from tools.web_tools import parse_site_operator
+
+        domains, residual = parse_site_operator("site:nature.com CRISPR")
+        assert domains == ["nature.com"]
+        assert residual == "CRISPR"
+
+    def test_no_operator_passthrough(self):
+        from tools.web_tools import parse_site_operator
+
+        domains, residual = parse_site_operator("CRISPR gene editing")
+        assert domains == []
+        assert residual == "CRISPR gene editing"
+
+    def test_operator_midquery(self):
+        from tools.web_tools import parse_site_operator
+
+        domains, residual = parse_site_operator("CRISPR site:nature.com review")
+        assert domains == ["nature.com"]
+        assert residual == "CRISPR review"
+
+    def test_multiple_operators(self):
+        from tools.web_tools import parse_site_operator
+
+        domains, residual = parse_site_operator(
+            "site:nature.com site:science.org foo bar"
+        )
+        assert domains == ["nature.com", "science.org"]
+        assert residual == "foo bar"
+
+    def test_strips_scheme_and_dedups(self):
+        from tools.web_tools import parse_site_operator
+
+        domains, residual = parse_site_operator(
+            "site:https://nature.com site:nature.com foo"
+        )
+        assert domains == ["nature.com"]
+        assert residual == "foo"
+
+    def test_empty_query(self):
+        from tools.web_tools import parse_site_operator
+
+        domains, residual = parse_site_operator("")
+        assert domains == []
+        assert residual == ""
+
+
+# ─── Exa: include_domains + residual query ───────────────────────────────────
+
+
+class TestExaSiteOperator:
+    def _mock_client(self):
+        client = MagicMock()
+        resp = MagicMock()
+        resp.results = []
+        client.search.return_value = resp
+        return client
+
+    def test_site_query_uses_include_domains_and_residual(self):
+        from plugins.web.exa.provider import ExaWebSearchProvider
+
+        client = self._mock_client()
+        with patch.dict(os.environ, {"EXA_API_KEY": "exa-key"}):
+            with patch(
+                "plugins.web.exa.provider._get_exa_client", return_value=client
+            ):
+                ExaWebSearchProvider().search("site:nature.com CRISPR", limit=5)
+
+        client.search.assert_called_once()
+        call = client.search.call_args
+        # residual query passed positionally, site: token stripped
+        assert call.args[0] == "CRISPR"
+        assert call.kwargs.get("include_domains") == ["nature.com"]
+
+    def test_plain_query_omits_include_domains(self):
+        from plugins.web.exa.provider import ExaWebSearchProvider
+
+        client = self._mock_client()
+        with patch.dict(os.environ, {"EXA_API_KEY": "exa-key"}):
+            with patch(
+                "plugins.web.exa.provider._get_exa_client", return_value=client
+            ):
+                ExaWebSearchProvider().search("CRISPR gene editing", limit=5)
+
+        call = client.search.call_args
+        assert call.args[0] == "CRISPR gene editing"
+        assert call.kwargs.get("include_domains") is None
+
+
+# ─── Tavily: search_depth="advanced" for site-scoped queries ─────────────────
+
+
+class TestTavilySiteOperator:
+    def test_site_query_uses_advanced_depth(self):
+        from plugins.web.tavily.provider import TavilyWebSearchProvider
+
+        captured = {}
+
+        def fake_request(endpoint, payload):
+            captured["endpoint"] = endpoint
+            captured["payload"] = payload
+            return {"results": []}
+
+        with patch(
+            "plugins.web.tavily.provider._tavily_request", side_effect=fake_request
+        ):
+            TavilyWebSearchProvider().search("site:nature.com CRISPR", limit=5)
+
+        assert captured["payload"].get("search_depth") == "advanced"
+        # Tavily honors site: at advanced depth — query is retained.
+        assert "site:nature.com" in captured["payload"]["query"]
+
+    def test_plain_query_keeps_default_depth(self):
+        from plugins.web.tavily.provider import TavilyWebSearchProvider
+
+        captured = {}
+
+        def fake_request(endpoint, payload):
+            captured["payload"] = payload
+            return {"results": []}
+
+        with patch(
+            "plugins.web.tavily.provider._tavily_request", side_effect=fake_request
+        ):
+            TavilyWebSearchProvider().search("CRISPR gene editing", limit=5)
+
+        assert captured["payload"].get("search_depth") != "advanced"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -108,6 +108,39 @@ import sys
 logger = logging.getLogger(__name__)
 
 
+# ─── Query Operators ──────────────────────────────────────────────────────────
+
+# Matches a ``site:<domain>`` search operator token. The domain runs to the
+# next whitespace; an optional ``http(s)://`` scheme is tolerated and stripped
+# by :func:`parse_site_operator`.
+_SITE_OPERATOR_RE = re.compile(r"\bsite:(\S+)", re.IGNORECASE)
+
+
+def parse_site_operator(query: str) -> tuple[list[str], str]:
+    """Split ``site:<domain>`` operators out of a web-search query.
+
+    Returns ``(domains, residual_query)`` where ``domains`` is the
+    order-preserving, de-duplicated list of domains referenced by ``site:``
+    tokens (scheme stripped, lower-cased) and ``residual_query`` is the query
+    with those tokens removed and whitespace collapsed.
+
+    When no ``site:`` operator is present, ``domains`` is empty and
+    ``residual_query`` is the whitespace-collapsed input. This lets providers
+    with a native domain filter (e.g. Exa ``include_domains``) apply it
+    natively instead of shipping ``site:`` to the backend as a literal term.
+    """
+    if not query:
+        return [], ""
+    domains: list[str] = []
+    for match in _SITE_OPERATOR_RE.finditer(query):
+        dom = match.group(1).strip().strip("\"'").rstrip("/")
+        dom = re.sub(r"^https?://", "", dom, flags=re.IGNORECASE).lower()
+        if dom and dom not in domains:
+            domains.append(dom)
+    residual = " ".join(_SITE_OPERATOR_RE.sub("", query).split())
+    return domains, residual
+
+
 # ─── Backend Selection ────────────────────────────────────────────────────────
 
 def _env_value(name: str) -> str:


### PR DESCRIPTION
## Problem

`site:` queries (e.g. `site:nature.com CRISPR`) returned results with empty snippet/content fields. The web-search providers shipped `site:domain.com` to the backend as a **literal query term** rather than a domain filter:

- **Exa** has a native `include_domains` parameter that was never used — `site:` in the query string was treated literally, so highlights came back empty.
- **Tavily** maps `content` → snippet, but `site:`-scoped queries return empty `content` at the default `basic` search depth.

## Fix (minimal, additive)

1. New shared helper `parse_site_operator(query)` in `tools/web_tools.py` → returns `(domains, residual_query)`. Order-preserving, de-duplicated, strips an optional `http(s)://` scheme, collapses whitespace. No `site:` present → empty domains + passthrough query.
2. **Exa** (`plugins/web/exa/provider.py`): passes parsed domains as native `include_domains=[...]` and sends the **residual** query (without the `site:` token) so Exa filters by domain and returns real highlights.
3. **Tavily** (`plugins/web/tavily/provider.py`): when a site scope is present, sets `search_depth="advanced"` (query retained — Tavily honors `site:` at advanced depth) so `content` snippets come back.
4. Single shared regex helper rather than duplicated parsing in each provider; each provider's result-mapping is left intact.

No provider-selection changes; no unrelated behavior changes. **Plain (non-site) queries are byte-for-byte unchanged.** Brave and the other providers are untouched.

## Tests (TDD)

New hermetic suite `tests/tools/test_web_tools_site_operator.py` (mocked clients — no live API calls):
- `parse_site_operator`: single/mid-query/multiple operators, scheme-strip+dedup, no-op passthrough, empty input.
- Exa: `site:nature.com CRISPR` → client receives `include_domains=['nature.com']` and query `'CRISPR'`; plain query omits `include_domains`.
- Tavily: site-scoped query → payload `search_depth='advanced'` (query retained); plain query keeps default depth.

```
tests/tools/test_web_tools_site_operator.py ... 10 passed
tests/tools/test_web_providers.py + test_web_tools_tavily.py + test_web_providers_brave_free.py ... 49 passed (no regressions)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)