### PR TITLE
feat(agent): surface the live (post-fallback) model to the LLM each turn

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -33,6 +33,7 @@ from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
 from agent.turn_context import build_turn_context
 from agent.memory_manager import build_memory_context_block
+from agent.model_awareness import append_current_model_line
 from agent.message_sanitization import (
     _repair_tool_call_arguments,
     _sanitize_messages_non_ascii,
@@ -619,6 +620,14 @@ def run_conversation(
                         _injections.append(_fenced)
                 if _plugin_user_context:
                     _injections.append(_plugin_user_context)
+                # Model self-awareness: surface the LIVE model so the LLM can
+                # answer "what model are you?" truthfully instead of guessing.
+                # Read here — at per-API-call assembly, after any
+                # try_activate_fallback() mutation of agent.model/provider — so
+                # a degraded turn shows the fallback backend, not the configured
+                # primary. Call-time only (never persisted), like the injections
+                # above. See agent/model_awareness.py.
+                append_current_model_line(_injections, agent)
                 if _injections:
                     _base = api_msg.get("content", "")
                     if isinstance(_base, str):

--- a/agent/model_awareness.py
+++ b/agent/model_awareness.py
@@ -1,0 +1,61 @@
+"""Model self-awareness: surface the live (post-fallback) model each turn.
+
+The runtime always *knows* which model is live — ``try_activate_fallback``
+mutates ``agent.model`` / ``agent.provider`` in place when it swaps backends —
+but the LLM never sees it, so "what model are you?" gets answered by
+hallucination. The pre-migration ``hermes-swarm`` repo fixed this by appending
+a ``[Current model: X via Y]`` line to the ephemeral per-turn context; that was
+lost in the ``hermes-swarm`` → ``hermes-agent-mt`` migration and is re-ported
+here.
+
+Sourcing (the load-bearing detail): the line reads ``agent.model`` /
+``agent.provider`` — the live runtime fields — at per-API-call assembly time,
+NOT the ``_RUNTIME_MAIN_*`` process globals (which are published once at turn
+start, before ``restore_primary_runtime``, and are *not* updated by
+``try_activate_fallback``, so they go stale on a degraded turn). Reading the
+agent fields means a fallback turn shows the fallback backend, not the
+configured primary.
+
+Placement: it is appended to the current turn's user message (call-time only,
+never persisted to the session DB), mirroring the existing memory-prefetch /
+``pre_llm_call`` plugin injection. It deliberately never touches the cached
+system prompt — that prefix must stay byte-stable for prompt caching.
+
+Contents are two non-secret slugs (model + provider); no credentials, no PII.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+
+def format_current_model_line(model: str, provider: str) -> str:
+    """Return ``[Current model: <model> via <provider>]``.
+
+    Falls back to ``[Current model: <model>]`` when the provider is unknown,
+    and to ``""`` when the model itself is unknown (inject nothing rather than
+    a half-formed line).
+    """
+    model = (model or "").strip()
+    provider = (provider or "").strip()
+    if not model:
+        return ""
+    if provider:
+        return f"[Current model: {model} via {provider}]"
+    return f"[Current model: {model}]"
+
+
+def append_current_model_line(injections: List[str], agent: Any) -> None:
+    """Append the live-model line to ``injections``, read from ``agent``.
+
+    Reads ``agent.model`` / ``agent.provider`` at call time so that when this
+    runs after ``try_activate_fallback`` has mutated those fields it reflects
+    the fallback backend, not the configured primary. No-op when the model is
+    unknown.
+    """
+    line = format_current_model_line(
+        getattr(agent, "model", "") or "",
+        getattr(agent, "provider", "") or "",
+    )
+    if line:
+        injections.append(line)

--- a/tests/agent/test_model_awareness.py
+++ b/tests/agent/test_model_awareness.py
@@ -1,0 +1,71 @@
+"""Tests for model self-awareness — the live (post-fallback) model line.
+
+Re-ports the pre-migration ``hermes-swarm`` behaviour: a
+``[Current model: X via Y]`` line is appended to the ephemeral per-turn
+context so the LLM can answer "what model are you?" truthfully instead of
+hallucinating. The line must reflect the LIVE runtime — i.e. after
+``try_activate_fallback`` mutates ``agent.model`` / ``agent.provider`` in
+place it must show the FALLBACK model, not the configured primary.
+"""
+
+from agent.model_awareness import (
+    append_current_model_line,
+    format_current_model_line,
+)
+
+
+class _FakeAgent:
+    """Minimal stand-in exposing the two live runtime fields the loop reads."""
+
+    def __init__(self, model: str, provider: str) -> None:
+        self.model = model
+        self.provider = provider
+
+
+def test_format_with_provider():
+    assert (
+        format_current_model_line("claude-opus-4-8", "anthropic")
+        == "[Current model: claude-opus-4-8 via anthropic]"
+    )
+
+
+def test_format_without_provider():
+    assert format_current_model_line("glm-4-9b", "") == "[Current model: glm-4-9b]"
+
+
+def test_format_unknown_model_is_empty():
+    # No model configured yet → inject nothing rather than a half-line.
+    assert format_current_model_line("", "anthropic") == ""
+    assert format_current_model_line("   ", "") == ""
+
+
+def test_append_injects_line_for_configured_primary():
+    agent = _FakeAgent("claude-opus-4-8", "anthropic")
+    injections: list[str] = []
+    append_current_model_line(injections, agent)
+    assert injections == ["[Current model: claude-opus-4-8 via anthropic]"]
+
+
+def test_append_reflects_fallback_after_simulated_activation():
+    # Turn starts on the configured primary.
+    agent = _FakeAgent("claude-opus-4-8", "anthropic")
+    primary: list[str] = []
+    append_current_model_line(primary, agent)
+    assert primary == ["[Current model: claude-opus-4-8 via anthropic]"]
+
+    # Simulate try_activate_fallback(): it mutates agent.model / agent.provider
+    # in place. A fresh per-API-call assembly must now surface the FALLBACK.
+    agent.model = "glm-4.6"
+    agent.provider = "zai"
+    after_fallback: list[str] = []
+    append_current_model_line(after_fallback, agent)
+    assert after_fallback == ["[Current model: glm-4.6 via zai]"]
+    # The stale configured primary must NOT leak into the degraded turn.
+    assert "claude-opus-4-8" not in after_fallback[0]
+
+
+def test_append_is_noop_when_model_unknown():
+    agent = _FakeAgent("", "")
+    injections: list[str] = ["existing"]
+    append_current_model_line(injections, agent)
+    assert injections == ["existing"]


### PR DESCRIPTION
## The bug

The runtime always *knows* which model is live — `try_activate_fallback()` mutates `agent.model` / `agent.provider` in place when it swaps backends, and `set_runtime_main()` publishes `_RUNTIME_MAIN_*` process globals each turn — but the **LLM never sees any of it**. There is no prompt injection and no introspection path, so "what model are you?" is answered by hallucination. On a degraded turn (primary out of credits → fallback active) the agent will confidently claim to be the configured primary.

## What this does

Re-ports a feature that shipped in the pre-migration `hermes-swarm` repo (2026-05-26: `[Current model: X via Y]` injected into the ephemeral prompt) and was **lost in the `hermes-swarm` → `hermes-agent-mt` migration**. `[model-awareness]` item **B1** of the 2026-07-02 role-gating + model-awareness design.

- New zero-dependency helper `agent/model_awareness.py` (`format_current_model_line`, `append_current_model_line`).
- The loop appends `[Current model: <model> via <provider>]` into the **current turn's user message** at per-API-call assembly time, alongside the existing memory-prefetch / `pre_llm_call` plugin injections (same call-time-only, never-persisted pattern). It does **not** touch the cached system prompt — that prefix must stay byte-stable for prompt caching.

## Sourcing — the load-bearing detail

The line reads `agent.model` / `agent.provider` (the live runtime fields), **not** the `_RUNTIME_MAIN_*` process globals. Verified against the code:

- `set_runtime_main(...)` publishes the globals once at turn start in `build_turn_context` (`agent/turn_context.py:95`) — and crucially **before** `agent._restore_primary_runtime()` (`agent/turn_context.py:112`).
- `try_activate_fallback()` (`agent/chat_completion_helpers.py:1005`) mutates `agent.model` / `agent.provider` in place and sets `_fallback_activated = True`, but **never calls `set_runtime_main`** — so the globals go stale on a degraded turn.
- Therefore `agent.model` / `agent.provider` are authoritative at any read point. `api_messages` (and thus the injection) is rebuilt at the top of every outer iteration (`agent/conversation_loop.py` ~605), so a fallback that persists into a turn (billing/rate-limit cooldown keeps the agent on the fallback across turns via `restore_primary_runtime`) is reflected truthfully.

Scope: self-awareness only. The user-request / single-turn-override path (B3) is explicitly **out of scope**. No secrets/PII — the line is two non-secret slugs.

## Test evidence

New `tests/agent/test_model_awareness.py` (6 tests). Run with the system pytest and `-o addopts=""` because `pytest-timeout` (a dev-extra) isn't installed in this scratch env — same approach PR #65 used:

```
$ python3 -m pytest tests/agent/test_model_awareness.py -o addopts="" -p no:cacheprovider -v
tests/agent/test_model_awareness.py::test_format_with_provider PASSED
tests/agent/test_model_awareness.py::test_format_without_provider PASSED
tests/agent/test_model_awareness.py::test_format_unknown_model_is_empty PASSED
tests/agent/test_model_awareness.py::test_append_injects_line_for_configured_primary PASSED
tests/agent/test_model_awareness.py::test_append_reflects_fallback_after_simulated_activation PASSED
tests/agent/test_model_awareness.py::test_append_is_noop_when_model_unknown PASSED
============================== 6 passed in 0.04s ===============================
```

The load-bearing test, `test_append_reflects_fallback_after_simulated_activation`, asserts that after mutating `agent.model` / `agent.provider` the way `try_activate_fallback` does, the assembled line shows the **fallback** model and the configured primary does **not** leak into it.

## PROPOSE-ONLY

**Needs a fleet rebuild to take effect — deploy batched with #65.** Not merged, not deployed here (per `no-rebuild-mid-task` / `nail-the-release`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)