### PR TITLE
fix(slack): honor `*` wildcard in SLACK_ALLOWED_CHANNELS + surface channel drops (#69)

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2338,11 +2338,21 @@ class SlackAdapter(BasePlatformAdapter):
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
 
         if not is_dm and bot_uid:
-            # Check allowed channels — if set, only respond in these channels (whitelist)
+            # Check allowed channels — if set, only respond in these channels
+            # (whitelist).  "*" is a wildcard meaning no channel restriction,
+            # matching the Signal group allowlist and the documented contract.
             allowed_channels = self._slack_allowed_channels()
-            if allowed_channels and channel_id not in allowed_channels:
-                logger.debug(
-                    "[Slack] Ignoring message in non-allowed channel: %s", channel_id
+            if (
+                allowed_channels
+                and "*" not in allowed_channels
+                and channel_id not in allowed_channels
+            ):
+                # INFO, not debug: a silent drop here is undiagnosable at the
+                # default log level (issue #69 — cost an hour of live debugging).
+                logger.info(
+                    "[Slack] Ignoring message in non-allowed channel: %s "
+                    "(SLACK_ALLOWED_CHANNELS whitelist active)",
+                    channel_id,
                 )
                 return
 
@@ -3607,9 +3617,11 @@ class SlackAdapter(BasePlatformAdapter):
     def _slack_allowed_channels(self) -> set:
         """Return the whitelist of channel IDs the bot will respond in.
 
-        When non-empty, messages from channels NOT in this set are silently
-        ignored — even if the bot is @mentioned.  DMs are never filtered.
+        When non-empty, messages from channels NOT in this set are ignored —
+        even if the bot is @mentioned.  DMs are never filtered.
         Empty set means no restriction (fully backward compatible).
+        A "*" entry is treated as a wildcard by the caller (no restriction),
+        matching the Signal group allowlist behavior.
         """
         raw = self.config.extra.get("allowed_channels")
         if raw is None:

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -4,8 +4,11 @@ Tests for Slack mention gating (require_mention / free_response_channels).
 Follows the same pattern as test_whatsapp_group_gating.py.
 """
 
+import logging
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from gateway.config import Platform, PlatformConfig
 
@@ -252,9 +255,10 @@ def _would_process(adapter, *, is_dm=False, channel_id=CHANNEL_ID,
     is_mentioned = bot_uid and f"<@{bot_uid}>" in text
 
     if not is_dm and bot_uid:
-        # allowed_channels check (whitelist — must pass before other gating)
+        # allowed_channels check (whitelist — must pass before other gating;
+        # "*" is a wildcard meaning no channel restriction)
         allowed = adapter._slack_allowed_channels()
-        if allowed and channel_id not in allowed:
+        if allowed and "*" not in allowed and channel_id not in allowed:
             return False
 
         if channel_id in adapter._slack_free_response_channels():
@@ -639,6 +643,112 @@ def test_allowed_channels_env_var_blocks_channel(monkeypatch):
     adapter = _make_adapter()  # no config value → falls back to env
     assert _would_process(adapter, channel_id=OTHER_CHANNEL_ID, text="hello") is False
     assert _would_process(adapter, channel_id=CHANNEL_ID, mentioned=True) is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: "*" wildcard + drop-log visibility (issue #69)
+# ---------------------------------------------------------------------------
+# SLACK_ALLOWED_CHANNELS=* must mean "no channel restriction" (matching the
+# Signal group wildcard and the documented allowlist contract). Previously
+# `{"*"}` was treated as a literal whitelist, so every real channel ID was
+# silently dropped — and the drop only logged at DEBUG, making it invisible
+# at the default INFO level. These tests exercise the REAL handler, not the
+# _would_process mirror above.
+
+_TS_COUNTER = iter(range(1, 10_000))
+
+
+def _make_real_adapter(allowed_channels=None):
+    """Build a full SlackAdapter (real __init__) with I/O mocked out."""
+    extra = {}
+    if allowed_channels is not None:
+        extra["allowed_channels"] = allowed_channels
+    config = PlatformConfig(enabled=True, token="xoxb-fake-token", extra=extra)
+    adapter = SlackAdapter(config)
+    adapter._app = MagicMock()
+    adapter._app.client = AsyncMock()
+    adapter._bot_user_id = BOT_USER_ID
+    adapter._running = True
+    adapter.handle_message = AsyncMock()
+    adapter._resolve_user_name = AsyncMock(return_value="Test User")
+    return adapter
+
+
+def _channel_event(channel_id, *, mentioned=True, text="hello"):
+    if mentioned:
+        text = f"<@{BOT_USER_ID}> {text}"
+    return {
+        "text": text,
+        "user": "U_USER",
+        "channel": channel_id,
+        "channel_type": "channel",
+        "ts": f"1700000000.{next(_TS_COUNTER):06d}",
+    }
+
+
+@pytest.mark.asyncio
+async def test_wildcard_allows_any_channel(monkeypatch):
+    """allowed_channels='*' lets an arbitrary channel through the gate."""
+    monkeypatch.delenv("SLACK_ALLOWED_CHANNELS", raising=False)
+    adapter = _make_real_adapter(allowed_channels="*")
+    await adapter._handle_slack_message(_channel_event(OTHER_CHANNEL_ID))
+    adapter.handle_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_wildcard_env_var_allows_any_channel(monkeypatch):
+    """SLACK_ALLOWED_CHANNELS=* (env var form) lets any channel through."""
+    monkeypatch.setenv("SLACK_ALLOWED_CHANNELS", "*")
+    adapter = _make_real_adapter()
+    await adapter._handle_slack_message(_channel_event(OTHER_CHANNEL_ID))
+    adapter.handle_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_wildcard_in_csv_allows_any_channel(monkeypatch):
+    """'*' anywhere in the CSV disables the restriction."""
+    monkeypatch.delenv("SLACK_ALLOWED_CHANNELS", raising=False)
+    adapter = _make_real_adapter(allowed_channels=f"{CHANNEL_ID},*")
+    await adapter._handle_slack_message(_channel_event(OTHER_CHANNEL_ID))
+    adapter.handle_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_channel_drop_logged_at_info_or_higher(monkeypatch, caplog):
+    """A dropped channel must be visible at the default INFO log level."""
+    monkeypatch.delenv("SLACK_ALLOWED_CHANNELS", raising=False)
+    adapter = _make_real_adapter(allowed_channels=[CHANNEL_ID])
+    with caplog.at_level(logging.DEBUG, logger="gateway.platforms.slack"):
+        await adapter._handle_slack_message(_channel_event(OTHER_CHANNEL_ID))
+    adapter.handle_message.assert_not_called()
+    drop_records = [
+        r for r in caplog.records
+        if "non-allowed channel" in r.getMessage() and OTHER_CHANNEL_ID in r.getMessage()
+    ]
+    assert drop_records, "channel drop was not logged at all"
+    assert all(r.levelno >= logging.INFO for r in drop_records), (
+        "channel drop logged below INFO — invisible at default log level"
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_allowlist_still_gates(monkeypatch):
+    """No wildcard: listed channel passes, unlisted channel drops."""
+    monkeypatch.delenv("SLACK_ALLOWED_CHANNELS", raising=False)
+    adapter = _make_real_adapter(allowed_channels=[CHANNEL_ID])
+    await adapter._handle_slack_message(_channel_event(CHANNEL_ID))
+    adapter.handle_message.assert_called_once()
+
+    adapter.handle_message.reset_mock()
+    await adapter._handle_slack_message(_channel_event(OTHER_CHANNEL_ID))
+    adapter.handle_message.assert_not_called()
+
+
+def test_would_process_wildcard_allows_any_channel(monkeypatch):
+    """Mirror check: '*' disables the restriction in the gating simulation."""
+    monkeypatch.delenv("SLACK_ALLOWED_CHANNELS", raising=False)
+    adapter = _make_adapter(allowed_channels="*")
+    assert _would_process(adapter, channel_id=OTHER_CHANNEL_ID, mentioned=True) is True
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -391,7 +391,7 @@ Slack supports both patterns: `@mention` required to start a conversation by def
 
 ### Channel allowlist (`allowed_channels`)
 
-Restrict the bot to a fixed set of Slack channels — useful when the bot is invited to many channels but should only respond in a few. When set, messages from channels NOT in this list are **silently ignored**, even if the bot is `@mentioned`.
+Restrict the bot to a fixed set of Slack channels — useful when the bot is invited to many channels but should only respond in a few. When set, messages from channels NOT in this list are **ignored** (with an INFO-level log line), even if the bot is `@mentioned`.
 
 **DMs are exempt** from this filter, so authorized users can always reach the bot in a direct message.
 
@@ -411,7 +411,8 @@ SLACK_ALLOWED_CHANNELS="C0123456789,C0987654321"
 Behavior:
 
 - Empty / unset → no restriction (fully backward compatible).
-- Non-empty → channel ID must be on the list, or the message is dropped before any other gating (mention requirement, `free_response_channels`, etc.) runs.
+- `*` anywhere in the list → wildcard, no restriction (matches the Signal group allowlist contract).
+- Non-empty → channel ID must be on the list, or the message is dropped before any other gating (mention requirement, `free_response_channels`, etc.) runs. Drops are logged at INFO (`Ignoring message in non-allowed channel`), so a misconfigured allowlist is diagnosable from default-level logs.
 - Slack channel IDs start with `C` (public), `G` (private), or `D` (DM). Look them up via the Slack UI's "Open channel details" → "About" panel, or via the API.
 
 See also: [admin/user slash command split](../../reference/slash-commands.md#permissions-and-adminuser-split).


### PR DESCRIPTION
Fixes #69

## Problem

`SLACK_ALLOWED_CHANNELS=*` did not work as a wildcard. `_slack_allowed_channels()` returned the literal set `{"*"}`, and the gate in `_handle_slack_message` did `if allowed_channels and channel_id not in allowed_channels: return` — so a real channel ID like `C0...` never matched and **every** channel message/@mention was dropped. Worse, the drop logged at `logger.debug()`, invisible at the default INFO level. A live setup lost ~an hour to this exact combination (bot connected, scopes correct, zero response, zero logs). This also contradicted the documented allowlist contract ("`*` in any allowlist permits all") that Signal already honors for groups.

## Change (surgical, additive)

- **`gateway/platforms/slack.py`** — gate now skips the restriction when `"*"` is present in the allowed set (`"*" not in allowed_channels and channel_id not in allowed_channels`), following the existing Signal pattern (`signal.py:870`). The drop log is raised **debug → info** and names the whitelist so it's diagnosable from default logs. Helper docstring updated.
- **`tests/gateway/test_slack_mention.py`** — 6 new tests (see below); `_would_process` mirror kept in sync with the real gate.
- **`website/docs/user-guide/messaging/slack.md`** — allowlist section documents the `*` wildcard and the INFO-level drop log.

No behavior change for empty allowlists or explicit channel lists.

## Test evidence (red-green TDD)

New tests exercise the **real** `_handle_slack_message` (full `SlackAdapter.__init__`, I/O mocked), not the simulation helper:

- `test_wildcard_allows_any_channel` — `allowed_channels: "*"` (config) passes an arbitrary channel
- `test_wildcard_env_var_allows_any_channel` — `SLACK_ALLOWED_CHANNELS=*` (env) passes
- `test_wildcard_in_csv_allows_any_channel` — `"C...,*"` passes
- `test_channel_drop_logged_at_info_or_higher` — non-allowed channel is dropped **and** the drop record is ≥ INFO (caplog)
- `test_explicit_allowlist_still_gates` — listed channel passes, unlisted drops (regression guard)
- `test_would_process_wildcard_allows_any_channel` — mirror-helper parity

**Red:** the 4 fix-dependent tests failed before the implementation (`4 failed, 57 passed`).
**Green:** `tests/gateway/test_slack_mention.py` — **61 passed**. Full related suites (per-file, matching CI isolation): `test_slack.py` 194 passed, `test_slack_channel_session_scope.py` 7, `test_slack_channel_skills.py` 11, `test_slack_approval_buttons.py` 26, `test_allowed_channels_widening.py` 27, `test_allowlist_startup_check.py` 4 — **330 passed, 0 failed**.

## Out of scope

Issue item 3 (HSM connect-flow default for `SLACK_ALLOWED_CHANNELS`) lives in hermes-swarm-map, not this repo. Other platforms covered by `test_allowed_channels_widening.py` (Telegram/Matrix/Mattermost/DingTalk) are untouched — kept minimal per the fork-divergence rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)