### PR TITLE
fix(guardrails): surrogatepass in result hasher — lone surrogates crashed the conversation loop

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -472,4 +472,8 @@ def _positive_int(value: Any, default: int) -> int:
 
 
 def _sha256(value: str) -> str:
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+    # surrogatepass: tool results scraped from the web can carry unpaired
+    # UTF-16 surrogates (e.g. half of a mathematical-bold pair); a strict
+    # encode raises and takes down the whole conversation loop. The hash only
+    # needs deterministic bytes, not valid UTF-8.
+    return hashlib.sha256(value.encode("utf-8", "surrogatepass")).hexdigest()

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -256,3 +256,24 @@ def test_reset_for_turn_clears_bounded_guardrail_state():
 
     assert controller.before_call("web_search", {"query": "same"}).action == "allow"
     assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+
+def test_after_call_survives_lone_surrogates_in_result_and_args():
+    # Scraped web/social text can contain unpaired UTF-16 surrogates (e.g. the
+    # first half of a mathematical-bold pair, '\ud835'). str.encode('utf-8')
+    # rejects them, and the result hasher crashed the whole conversation loop
+    # (live outage: "Outer loop error in API call #34 ... surrogates not
+    # allowed"). Weird text must never take down the loop.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, exact_failure_block_after=2, no_progress_block_after=2)
+    )
+    dirty = "price \ud835 update"
+
+    decision = controller.after_call("web_search", {"query": dirty}, dirty, failed=False)
+    assert decision.action in {"allow", "warn"}
+
+    # hashing stays deterministic: the same dirty failure twice still trips
+    # the exact-failure guard, proving the hash is stable across calls
+    controller.after_call("web_search", {"query": dirty}, '{"error":"\ud835 boom"}', failed=True)
+    controller.after_call("web_search", {"query": dirty}, '{"error":"\ud835 boom"}', failed=True)
+    assert controller.before_call("web_search", {"query": dirty}).action == "block"


### PR DESCRIPTION
Live outage (reported by Juniper from agent logs): `UnicodeEncodeError: 'utf-8' codec can't encode character '\ud835' ... surrogates not allowed` escaping as **Outer loop error in API call #34**, killing the agent's turn.

Root cause: scraped web/social text can contain unpaired UTF-16 surrogates (half of a mathematical-bold pair — 𝐭𝐡𝐢𝐬 kind of text). `_result_hash → _sha256 → str.encode('utf-8')` rejects lone surrogates, and the guardrail layer's crash propagated out of the tool-execution path into the conversation loop. Internet text must never be able to take down a turn.

Fix: `value.encode('utf-8', 'surrogatepass')` — deterministic bytes for the dedup/loop-detection hash, never throws. Test reproduces the exact crash (dirty args + dirty results) and pins hash determinism: two identical dirty failures still trip the exact-failure guard.

Verified red→green **inside the production agent image** on the Mini (`cryptids-hermes-cryptids`): the test raised the exact live exception before the fix; full guardrail test module green after. Deploy note: agents are static until rebuild — fleet picks this up at the next image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)