### PR TITLE
fix(memory): break scoped-context consolidation loop on global entries (#39)

### DIFF
--- a/tests/tools/test_memory_scoping.py
+++ b/tests/tools/test_memory_scoping.py
@@ -248,6 +248,80 @@ class TestPathTraversalAndEdgeCases:
         assert "global" in result["error"].lower()
 
 
+class TestGlobalEntryGuardLoopBreak:
+    """Modifying a global entry from a scoped context must fail without coaching
+    the model toward an impossible action, and must degrade to a terminal result
+    so the turn can proceed instead of looping (issue #39)."""
+
+    def test_guard_message_has_no_phantom_scope_param(self, mem_dir):
+        """The old guard said 'use scope=global' — a parameter that does not
+        exist on the memory tool — so the model could never comply and looped."""
+        (mem_dir / "MEMORY.md").write_text("The sky is blue")
+        store = MemoryStore(context_id="group-x")
+        store.load_from_disk()
+
+        result = store.replace("memory", "sky is blue", "sky is green")
+        assert result["success"] is False
+        # still explains it's a global-entry problem
+        assert "global" in result["error"].lower()
+        # but must NOT reference a nonexistent parameter
+        assert "scope=" not in result["error"]
+        assert "scope='global'" not in result["error"]
+
+    def test_guard_terminates_after_cap_on_replace(self, mem_dir):
+        (mem_dir / "MEMORY.md").write_text("The sky is blue")
+        store = MemoryStore(context_id="group-y")
+        store.load_from_disk()
+
+        n = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
+        results = [store.replace("memory", "sky is blue", "sky is green")
+                   for _ in range(n + 1)]
+
+        assert all(r["success"] is False for r in results)
+        # early attempts are recoverable (model may still self-correct)
+        assert not results[0].get("done")
+        # once the per-turn cap is exceeded the result is terminal, so the
+        # model stops retrying and answers the user
+        assert results[-1].get("done") is True
+
+    def test_guard_terminates_after_cap_on_remove(self, mem_dir):
+        (mem_dir / "MEMORY.md").write_text("global truth")
+        store = MemoryStore(context_id="group-z")
+        store.load_from_disk()
+
+        n = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
+        results = [store.remove("memory", "global truth") for _ in range(n + 1)]
+        assert results[-1].get("done") is True
+
+    def test_turn_reset_clears_guard_failures(self, mem_dir):
+        """A new turn resets the per-turn counter so guidance is offered afresh."""
+        (mem_dir / "MEMORY.md").write_text("The sky is blue")
+        store = MemoryStore(context_id="group-reset")
+        store.load_from_disk()
+
+        n = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
+        for _ in range(n + 1):
+            store.replace("memory", "sky is blue", "sky is green")
+
+        store.reset_consolidation_failures()
+        result = store.replace("memory", "sky is blue", "sky is green")
+        # first attempt of the new turn is recoverable again, not terminal
+        assert result["success"] is False
+        assert not result.get("done")
+
+    def test_scoped_add_overflow_flags_global_readonly(self, mem_dir):
+        """When a scoped add overflows because global entries fill the budget,
+        the coaching should tell the model global entries are read-only here so
+        it doesn't reach for an entry it can't edit."""
+        (mem_dir / "MEMORY.md").write_text("x" * 2100)  # near the 2200 cap
+        store = MemoryStore(context_id="ctx-hint")
+        store.load_from_disk()
+
+        result = store.add("memory", "y" * 300)
+        assert result["success"] is False
+        assert "global memory" in result["error"].lower()
+
+
 class TestConcurrentContextWrites:
     """Different contexts use different lock files, so they don't block each other."""
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -175,6 +175,34 @@ class MemoryStore:
             ),
         }
 
+    def _global_entry_guard_response(self, target: str) -> Dict[str, Any]:
+        """Response for an attempt to modify a global entry from a scoped context.
+
+        Global entries are read-only from a scoped context: writes land in the
+        scoped file only, so the edit would silently vanish on the next reload.
+        The memory tool has no ``scope`` parameter, so the previous message
+        ("use scope='global' to modify global entries") coached the model
+        toward an action it could never take. At capacity the model was already
+        being told to consolidate — it would pick a global entry, hit this
+        guard, retry the same forbidden edit, and loop the turn to budget
+        exhaustion while the user's real request waited (issue #39).
+
+        Fix: give scope-honest, actionable guidance (consolidate a *scoped*
+        entry, or proceed without saving) AND route it through the per-turn
+        consolidation-failure cap so repeated attempts degrade to a terminal
+        result and the turn can proceed — sharing the #42405 loop-breaker.
+        """
+        return self._consolidation_failure({
+            "success": False,
+            "error": (
+                "That entry belongs to global memory and can't be edited from "
+                "this scoped context. To free space, consolidate one of your "
+                "context-scoped entries instead (replace or remove an entry you "
+                "added in this context), or continue without saving — the fact "
+                "can be recorded in a later turn."
+            ),
+        })
+
     def load_from_disk(self):
         """Load entries from MEMORY.md and USER.md, capture system prompt snapshot.
 
@@ -430,6 +458,17 @@ class MemoryStore:
 
             if new_total > limit:
                 current = self._char_count(target)
+                # In a scoped context, global entries can't be edited here.
+                # Flag it so the model consolidates its scoped entries instead
+                # of reaching for a global one and looping on the guard (#39).
+                scope_hint = ""
+                if (self.context_id is not None and target == "memory"
+                        and self._global_entry_count):
+                    scope_hint = (
+                        " Note: entries from global memory can't be edited from "
+                        "this context — consolidate only your context-scoped "
+                        "entries (or continue without saving)."
+                    )
                 return self._consolidation_failure({
                     "success": False,
                     "error": (
@@ -438,6 +477,7 @@ class MemoryStore:
                         f"Consolidate now: use 'replace' to merge overlapping entries into "
                         f"shorter ones or 'remove' stale or less important entries (see "
                         f"current_entries below), then retry this add — all in this turn."
+                        f"{scope_hint}"
                     ),
                     "current_entries": entries,
                     "usage": f"{current:,}/{limit:,}",
@@ -497,13 +537,7 @@ class MemoryStore:
             # the merged list. Saving goes to the scoped file only, so any
             # modification would be lost on the next reload.
             if self.context_id is not None and idx < self._global_entry_count:
-                return {
-                    "success": False,
-                    "error": (
-                        "Cannot modify a global entry from a scoped context. "
-                        "Use scope='global' to modify global entries."
-                    ),
-                }
+                return self._global_entry_guard_response(target)
 
             limit = self._char_limit(target)
 
@@ -569,13 +603,7 @@ class MemoryStore:
 
             # Guard: refuse to remove a global entry from a scoped context.
             if self.context_id is not None and idx < self._global_entry_count:
-                return {
-                    "success": False,
-                    "error": (
-                        "Cannot modify a global entry from a scoped context. "
-                        "Use scope='global' to modify global entries."
-                    ),
-                }
+                return self._global_entry_guard_response(target)
 
             entries.pop(idx)
             self._set_entries(target, entries)


### PR DESCRIPTION
Fixes #39.

## Root cause
When a scoped-context agent's memory store hits its char cap, the tool coaches the model to consolidate and shows `current_entries` — which, in a scoped context, includes **global** entries. Editing a global entry from a scoped context is (correctly) refused, because the write would land in the scoped file and vanish on the next reload. But the refusal message said:

> Cannot modify a global entry from a scoped context. Use `scope='global'` to modify global entries.

The memory tool has **no `scope` parameter** (see `MEMORY_SCHEMA`). The model could never comply, so it retried the same forbidden edit. The guard rejection also returned a plain, non-terminal error that bypassed the per-turn consolidation-failure loop-breaker (added in #42405), so nothing ever stopped the retries — the turn burned to budget exhaustion while the user's actual request (a Notion update, in the live report) waited.

## Fix (option (b) from the issue — minimal, additive, self-contained)
1. **Corrected guard message.** New `_global_entry_guard_response()` returns scope-honest, actionable guidance — consolidate one of *your context-scoped* entries, or proceed without saving — with no reference to a nonexistent parameter. It routes through the existing `_consolidation_failure()` cap, so after `_MAX_CONSOLIDATION_FAILURES_PER_TURN` attempts the result becomes terminal (`done: True`) and the model proceeds to answer the user. Used by both `replace` and `remove`.
2. **Earlier steering.** When a scoped `add` overflows because global entries fill the budget, the overflow message now flags that global entries are read-only in this context, so the model consolidates its own scoped entries instead of reaching for a global one it can't edit.

No new tool parameters, no change to scope semantics or budgeting — global entries remain read-only from a scoped context. The change only fixes the dead-end coaching and wires the guard into the existing loop-breaker.

## Tests
Adds `TestGlobalEntryGuardLoopBreak` in `tests/tools/test_memory_scoping.py`:
- guard message no longer references a phantom `scope=` parameter (still identifies the global-entry problem);
- repeated global-entry `replace`/`remove` degrade to a terminal result after the per-turn cap;
- a new turn resets the counter (guidance offered afresh);
- scoped `add` overflow flags global entries as read-only.

Red→green confirmed. Full memory suite green: `test_memory_scoping.py`, `test_memory_tool.py`, `test_memory_tool_schema.py`, `test_display_tool_failure.py` — 133 passed. (Two unrelated `test_mcp_*` files fail to collect due to missing optional deps, pre-existing and untouched by this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)