### PR TITLE
feat: intelligent_routing plugin + pre_llm_call model-override extension (Stage 1 DRAFT)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1109,7 +1109,28 @@ def restore_primary_runtime(agent) -> bool:
     The gateway caches agents across messages (``_agent_cache`` in
     ``gateway/run.py``), so this restoration IS needed there too.
     """
-    if not agent._fallback_activated:
+    # ── Proactive intelligent-routing override revert (dedicated, scoped) ──
+    # A routed turn (intelligent_routing plugin) swaps to a cheap tier via a
+    # DEDICATED flag, keeping _primary_runtime == cheap during the turn so
+    # in-turn recovery paths don't jump tiers. This block reverts it FIRST —
+    # before both the _fallback_activated gate and the rate-limit cooldown gate
+    # below — so a routed turn ALWAYS reverts to the configured primary next
+    # turn, regardless of any cooldown a cheap-model 429 may have armed. It must
+    # not be gated on _fallback_activated (the override never sets it) or on the
+    # cooldown (that gate would leak the cheap model past its turn — see
+    # audit Blocker 1). Falls through to the shared rebuild body below.
+    _override_revert = bool(getattr(agent, "_routing_override_active", False))
+    if _override_revert:
+        _saved = getattr(agent, "_routing_override_saved_primary", None)
+        if isinstance(_saved, dict):
+            agent._primary_runtime = _saved
+        # Clear the scoping state so this runs exactly once.
+        agent._routing_override_active = False
+        agent._routing_override_saved_primary = None
+        # Do NOT return here — proceed to rebuild the runtime from the restored
+        # (premium) _primary_runtime via the shared body below.
+
+    if not _override_revert and not agent._fallback_activated:
         # Reset the chain index even when no fallback was activated this
         # turn.  Without this, a turn where _try_activate_fallback() was
         # called but returned False (chain exhausted or provider not
@@ -1120,7 +1141,7 @@ def restore_primary_runtime(agent) -> bool:
         agent._fallback_index = 0
         return False
 
-    if getattr(agent, "_rate_limited_until", 0) > time.monotonic():
+    if not _override_revert and getattr(agent, "_rate_limited_until", 0) > time.monotonic():
         return False  # primary still in rate-limit cooldown, stay on fallback
 
     rt = agent._primary_runtime

--- a/agent/routing_override.py
+++ b/agent/routing_override.py
@@ -21,13 +21,29 @@ the turn's first API call assembles.
 ── Turn-scoping (the load-bearing detail) ──
 Proactive routing is a PER-TURN decision, exactly like reactive fallback — it
 must NOT pin the session to the cheap model. We reuse the agent's existing,
-tested ``switch_model`` (full atomic client rebuild + rollback), but
-``switch_model`` persists the swap into ``_primary_runtime`` (it's built for the
-session-scoped ``/model`` command). So after the swap we:
-  1. restore the pre-swap ``_primary_runtime`` snapshot, and
-  2. arm ``_fallback_activated``,
-which makes ``restore_primary_runtime`` revert the swap at the top of the NEXT
-turn — identical turn-scoping to the reactive fallback path, on a different axis.
+tested ``switch_model`` (full atomic client rebuild + rollback), which persists
+the swap into ``_primary_runtime``. Crucially we then scope it with a DEDICATED
+flag, NOT by overloading reactive-fallback state:
+
+  1. Stash the pre-swap premium ``_primary_runtime`` in
+     ``_routing_override_saved_primary``.
+  2. Set ``_routing_override_active = True``.
+  3. LEAVE ``_primary_runtime`` pointing at the CHEAP runtime for the turn, and
+     do NOT touch ``_fallback_activated``.
+
+``restore_primary_runtime`` then reverts the swap at the top of the NEXT turn via
+a dedicated block that runs BEFORE the ``_fallback_activated`` and rate-limit
+cooldown gates, so a routed turn always reverts regardless of cooldown state.
+
+Why the dedicated flag (three audit-confirmed bugs the old overload caused):
+  - Overloading ``_rate_limited_until``/``_fallback_activated`` for scoping let a
+    cheap turn LEAK past its turn when a cooldown gate skipped restoration
+    (Blocker 1); pointing ``_primary_runtime`` at premium made in-turn transient
+    recovery jump the routed turn onto premium (Major 2); and pre-arming
+    ``_fallback_activated`` corrupted the reactive cooldown accounting so a cheap
+    429 got no cooldown (Major 3). Keeping ``_primary_runtime`` == cheap and using
+    a dedicated flag fixes all three: reactive fallback runs normally UNDERNEATH a
+    routed turn with the cheap runtime as its "primary".
 
 ── Fail-safe ──
 Any error (bad override, ``switch_model`` raising on a bad key/network) leaves
@@ -92,8 +108,11 @@ def apply_routing_override(agent: Any, override: Optional[dict]) -> bool:
     ):
         return False
 
-    # Snapshot the configured-primary runtime so we can re-scope the swap to this
-    # turn only (switch_model would otherwise persist it across turns).
+    # Stash the configured-primary runtime so restore_primary_runtime can revert
+    # the swap next turn. switch_model will overwrite _primary_runtime with the
+    # cheap runtime — we deliberately KEEP that (so in-turn recovery paths that
+    # read _primary_runtime stay on cheap) and use the stash + a dedicated flag
+    # for the revert, NOT the reactive-fallback state.
     primary_snapshot = getattr(agent, "_primary_runtime", None)
 
     kwargs = {
@@ -108,14 +127,14 @@ def apply_routing_override(agent: Any, override: Optional[dict]) -> bool:
         )
         return False
 
-    # Re-scope to this turn: restore the primary snapshot and arm the fallback
-    # flag so restore_primary_runtime reverts the swap next turn.
+    # Mark the override turn-scoped with a DEDICATED flag. Do NOT restore the
+    # premium snapshot into _primary_runtime (keep it == cheap) and do NOT arm
+    # _fallback_activated (that would corrupt reactive cooldown accounting).
     try:
-        if primary_snapshot is not None:
-            agent._primary_runtime = primary_snapshot
-        agent._fallback_activated = True
-    except Exception:  # noqa: BLE001 — best-effort re-scoping; swap already applied
-        logger.debug("intelligent_routing: could not re-scope override to turn",
+        agent._routing_override_saved_primary = primary_snapshot
+        agent._routing_override_active = True
+    except Exception:  # noqa: BLE001 — best-effort scoping; swap already applied
+        logger.debug("intelligent_routing: could not scope override to turn",
                      exc_info=True)
 
     logger.info(

--- a/agent/routing_override.py
+++ b/agent/routing_override.py
@@ -1,0 +1,125 @@
+"""Pre-turn routing-override interface extension.
+
+This is the minimal reference implementation of the plugin-interface extension
+teknium1 offered on upstream PR #43534 ("Happy to support adding to the plugin
+interface to make this work"). It lets a ``pre_llm_call`` plugin hook RETURN a
+routing decision that the runtime actually ACTUATES for the turn — closing the
+gap that the existing hook can only inject context, never change which model
+runs (the model is frozen by ``restore_primary_runtime`` before the hook fires).
+
+── Contract ──
+A ``pre_llm_call`` hook result may be a dict carrying a ``route`` key::
+
+    {"context": "...optional injected text...",
+     "route": {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}}
+
+``model`` is required; ``provider`` (and optional ``base_url`` / ``api_key`` /
+``api_mode``) are passed through to ``switch_model``. ``turn_context`` extracts
+the first well-formed override and applies it right after the hook fires, before
+the turn's first API call assembles.
+
+── Turn-scoping (the load-bearing detail) ──
+Proactive routing is a PER-TURN decision, exactly like reactive fallback — it
+must NOT pin the session to the cheap model. We reuse the agent's existing,
+tested ``switch_model`` (full atomic client rebuild + rollback), but
+``switch_model`` persists the swap into ``_primary_runtime`` (it's built for the
+session-scoped ``/model`` command). So after the swap we:
+  1. restore the pre-swap ``_primary_runtime`` snapshot, and
+  2. arm ``_fallback_activated``,
+which makes ``restore_primary_runtime`` revert the swap at the top of the NEXT
+turn — identical turn-scoping to the reactive fallback path, on a different axis.
+
+── Fail-safe ──
+Any error (bad override, ``switch_model`` raising on a bad key/network) leaves
+the agent untouched and returns ``False`` — a routing miss must degrade to
+"answer on the configured primary", never break the turn.
+
+⚠️ AUDIT NOTE: this module + its single call site in ``turn_context.py`` are the
+ONLY core-runtime changes for intelligent routing. They touch the
+model-selection path (user-visible: they change which model answers a turn).
+Everything else lives in the ``intelligent_routing`` plugin. Reviewers should
+focus here.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Fields we forward from an override into switch_model (model/provider plus the
+# optional endpoint/credential fields switch_model already accepts).
+_PASSTHROUGH_FIELDS = ("base_url", "api_key", "api_mode")
+
+
+def extract_routing_override(results: Iterable[Any]) -> Optional[dict]:
+    """Return the first well-formed ``route`` override from hook results, or None.
+
+    A well-formed override is a dict with a non-empty ``model``. First match
+    wins (deterministic; matches how the ``pre_llm_call`` context parts are
+    consumed in registration order).
+    """
+    if not results:
+        return None
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        route = r.get("route")
+        if isinstance(route, dict) and str(route.get("model") or "").strip():
+            return route
+    return None
+
+
+def apply_routing_override(agent: Any, override: Optional[dict]) -> bool:
+    """Actuate a routing override for THIS turn. Return True iff a swap happened.
+
+    Turn-scoped and fail-safe (see module docstring). No-op (returns False) when
+    the override is empty or already matches the live model/provider.
+    """
+    if not override or not isinstance(override, dict):
+        return False
+
+    target_model = str(override.get("model") or "").strip()
+    if not target_model:
+        return False
+    target_provider = str(override.get("provider") or "").strip()
+
+    cur_model = str(getattr(agent, "model", "") or "").strip()
+    cur_provider = str(getattr(agent, "provider", "") or "").strip()
+    # Avoid churn: nothing to do if we're already on the target.
+    if target_model == cur_model and (
+        not target_provider or target_provider == cur_provider
+    ):
+        return False
+
+    # Snapshot the configured-primary runtime so we can re-scope the swap to this
+    # turn only (switch_model would otherwise persist it across turns).
+    primary_snapshot = getattr(agent, "_primary_runtime", None)
+
+    kwargs = {
+        k: override[k] for k in _PASSTHROUGH_FIELDS if override.get(k)
+    }
+    try:
+        agent.switch_model(target_model, target_provider, **kwargs)
+    except Exception as exc:  # noqa: BLE001 — a routing miss must never break the turn
+        logger.warning(
+            "intelligent_routing: switch to %s/%s failed (%s); staying on %s/%s",
+            target_model, target_provider or "?", exc, cur_model, cur_provider,
+        )
+        return False
+
+    # Re-scope to this turn: restore the primary snapshot and arm the fallback
+    # flag so restore_primary_runtime reverts the swap next turn.
+    try:
+        if primary_snapshot is not None:
+            agent._primary_runtime = primary_snapshot
+        agent._fallback_activated = True
+    except Exception:  # noqa: BLE001 — best-effort re-scoping; swap already applied
+        logger.debug("intelligent_routing: could not re-scope override to turn",
+                     exc_info=True)
+
+    logger.info(
+        "intelligent_routing: routed this turn to %s/%s (was %s/%s)",
+        target_model, target_provider or "?", cur_model, cur_provider,
+    )
+    return True

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -453,6 +453,24 @@ def build_turn_context(
                 _ctx_parts.append(r)
         if _ctx_parts:
             plugin_user_context = "\n\n".join(_ctx_parts)
+
+        # Routing-override interface extension (PR #43534's offered plugin hook
+        # extension, reference implementation): a pre_llm_call result may carry a
+        # ``route`` dict that proactively swaps the model/provider for THIS turn,
+        # before the first API call assembles. Turn-scoped and fail-safe — see
+        # agent/routing_override.py. This is the ONLY model-selection change; the
+        # classifier that produces the decision lives in the intelligent_routing
+        # plugin.
+        try:
+            from agent.routing_override import (
+                apply_routing_override,
+                extract_routing_override,
+            )
+            _override = extract_routing_override(_pre_results)
+            if _override:
+                apply_routing_override(agent, _override)
+        except Exception as _route_exc:
+            logger.warning("pre_llm_call routing override failed: %s", _route_exc)
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
 

--- a/plugins/intelligent_routing/README.md
+++ b/plugins/intelligent_routing/README.md
@@ -1,18 +1,24 @@
 # intelligent_routing
 
-Opt-in **pre-turn cost routing** for the Hermes main chat turn.
+Opt-in **pre-turn cost routing** for the Hermes main chat turn, built as the
+clean answer to how upstream PR #43534 was closed.
 
-When enabled per-agent, a cheap local heuristic classifies each incoming turn as
-**mechanical** (route to the cheap-metered tier — e.g. an OpenRouter workhorse)
-vs. **judgment** (route to the premium, Claude-class tier), and surfaces *why* in
-the model-awareness prompt line so a user is never confused by a silent quality-
-tier switch mid-thread.
+teknium1 closed #43534 (model-task-router) with a steer, not a merits rejection:
+> *"If you do want it, please create a plugin. Happy to support adding to the
+> plugin interface to make this work as one."*
 
-This is the plugin form of the routing mechanism four upstream issues have asked
-for (#30652, #61371/#61373, #32704) and PR #43534 attempted — built as a plugin
-per teknium1's steer on that PR, and motivated by NimbleCo's real fleet cost
-(`[intelligent-routing-cost]`: ~$1k/mo, 6/6 agents primary on metered Sonnet with
-no cheap rung anywhere in any cascade).
+This directory is both halves of that answer:
+
+1. **The plugin** — classifies each turn and, when it's mechanical/orchestration
+   work, routes it to a cheap-metered tier; premium/uncertain/public-facing stay
+   on the configured primary (fail-open).
+2. **The interface extension he offered** — `agent/routing_override.py` (+ one
+   call site in `agent/turn_context.py`): a `pre_llm_call` hook result may now
+   carry a `route` override that the runtime **actuates** for the turn. Without
+   it, `pre_llm_call` could only inject context, never change which model runs.
+
+The classifier is deliberately simple — it is **not** the contribution. The
+plugin form + the interface extension are.
 
 ## Enable
 
@@ -20,88 +26,108 @@ no cheap rung anywhere in any cascade).
 hermes plugins enable intelligent_routing
 ```
 
-Then, per agent, in `config.yaml` (default **OFF** — this is opt-in because it
-changes which model answers a user's message):
+Per agent, in `config.yaml` (default **OFF** — opt-in; it changes which model
+answers a user's message):
 
 ```yaml
 routing:
-  intelligent: true      # default false
-  mode: heuristic        # Option A (default). "llm-router" (Option B) = Phase 2, not built.
+  intelligent: true                       # default false
+  mode: heuristic                         # Option A (default); "llm-router" (Option B) = Phase 2, not built
+  cheap_model: deepseek/deepseek-v3.2     # cheap-tier target (default)
+  cheap_provider: openrouter              # cheap-tier provider (default)
 ```
 
-With the plugin enabled but `routing.intelligent` OFF, the hook is **inert** —
-it returns `None` and there is zero behavior change.
+Enabled but `routing.intelligent` OFF ⇒ the hook is inert (`None`, zero change).
 
-## What it classifies (Option A — heuristic, no extra LLM call)
-
-`classifier.classify_turn(TurnSignals) -> "mechanical" | "judgment" | "uncertain"`
-is a pure, deterministic function of cheap local signals. Definitions
-(spec open-question #3, per D-2026-07-08-01):
-
-**mechanical** (→ cheap tier):
-- cron / background / non-interactive jobs, OR
-- kanban-triage-shaped requests, OR
-- a **short, direct single-action ask** — a bare imperative command
-  (`mark card 42 done`, `close #17`) or a trivial lookup (`what's 2+2`).
-
-**judgment** (→ premium tier):
-- open-ended / multi-step reasoning,
-- long substantive human messages,
-- anything public-facing,
-- **any short-but-hedged / deferred / context-referencing ask**
-  (`Can you look at the thing we discussed and get back to me?`) — short length
-  is necessary but NOT sufficient for mechanical.
-
-**uncertain** → **fails open to premium.** `route_for()` only sends a turn to the
-cheap tier on a *confident* mechanical classification; judgment AND uncertain
-both go premium. This mirrors HSM's `validateCascadeEntries` fail-open discipline
-and honors the spec's rule: never silently downgrade a judgment turn.
-
-## What it surfaces
-
-The `pre_llm_call` hook injects an extended model-awareness line (built on
-`agent.model_awareness.format_current_model_line`, so the base format stays
-byte-identical):
+## How a turn flows
 
 ```
-[Current model: x-ai/grok via openrouter — routed: mechanical]
-[Current model: claude-sonnet-5 via anthropic — routed: judgment]
+turn arrives
+  └─ pre_llm_call hook (plugins/intelligent_routing/registration.py)
+       ├─ classify task type (classifier.py)  ── code-gen / architecture /
+       │                                          research / orchestration / mechanical
+       ├─ map to tier: mechanical|orchestration → cheap ; else → premium (fail open)
+       ├─ inject model-awareness reason line:
+       │     [Current model: … — routed: mechanical → cheap]
+       └─ if cheap: return {"route": {"model": …, "provider": …}}
+             └─ turn_context extracts + applies it (agent/routing_override.py)
+                  └─ agent.switch_model(...)  ── turn-scoped: reverted next turn
 ```
+
+## The interface extension (the centerpiece)
+
+`agent/routing_override.py` — a minimal, additive, reference implementation:
+
+- `extract_routing_override(results)` — pull the first `{"route": {...}}` from the
+  list of `pre_llm_call` results (first well-formed, `model` required).
+- `apply_routing_override(agent, override)` — actuate the swap by delegating to
+  the agent's existing, tested `switch_model` (full atomic client rebuild +
+  rollback), then **re-scope it to this turn**: restore the pre-swap
+  `_primary_runtime` snapshot and arm `_fallback_activated`, so
+  `restore_primary_runtime` reverts it at the top of the next turn. Identical
+  turn-scoping to the reactive fallback path — a different axis, same data
+  structure. Fail-safe: any error leaves the agent on its configured primary and
+  never raises into the turn loop.
+
+Call site: `agent/turn_context.py`, immediately after the `pre_llm_call` results
+are collected (before the turn's first API call assembles). That is the whole
+core change — one module + one call site.
+
+**Why this is the right shape for upstream.** It generalizes: any `pre_llm_call`
+plugin can now return a per-turn model/provider override, not just this one. It
+reuses `switch_model` rather than duplicating the swap logic. It's turn-scoped and
+fail-safe by construction. This is what teknium1 offered to add to the interface.
+
+## Task types → tiers
+
+Adopted from #43534 (see `references/prior-art.md`), adapted to our fleet:
+
+| task type      | tier    | why (directional, recalibrate from fleet data) |
+|----------------|---------|--------------------------------------------------|
+| architecture   | premium | highest reasoning; never cheap-route hard design/security/debug |
+| code-gen       | premium | DeepSWE: DeepSeek coding throughput directionally lower — keep on Claude |
+| research       | premium | analysis/judgment, often public-facing |
+| orchestration  | cheap   | DeepSeek competitive at CLI/tool orchestration (Terminal-Bench 67.9% @ $0.87/1M) |
+| mechanical     | cheap   | fast/cheap delegated workhorse |
+| uncertain / public-facing | premium | fail open — never silently downgrade |
+
+Cheap tier defaults to `deepseek/deepseek-v3.2` — v3.2, **not** v4-Pro; that
+choice is grounded in #43534's data (see `references/prior-art.md`).
 
 ## Scope — DONE vs DEFERRED
 
-**Done (this Stage-1 slice):**
-- Per-agent `routing.intelligent` toggle, default OFF, with `routing.mode`.
-- Option-A heuristic classifier as a pure, fully-tested function (mechanical /
-  judgment / uncertain, fail-open to premium).
-- `pre_llm_call` wiring that computes the decision and injects the routing-reason
-  line; inert when disabled; never raises into the turn loop.
-- Full RGTDD coverage (see `tests/plugins/intelligent_routing/`).
+**Done (Stage 1, our fork):**
+- Per-agent `routing.intelligent` toggle (default OFF), `routing.mode`,
+  `routing.cheap_model` / `cheap_provider`.
+- Task-type heuristic classifier (pure, deterministic, fail-open to premium).
+- `pre_llm_call` wiring: injects the routing-reason line AND emits the `route`
+  override for cheap turns; inert when disabled; never raises.
+- **Interface extension** (`routing_override.py` + `turn_context.py` call site)
+  that actuates the swap, turn-scoped and fail-safe.
+- Full RGTDD, incl. an end-to-end actuation test (decision → real swap).
 
 **Deferred:**
-- **Actuation of the model swap.** See below — needs a plugin-interface
-  extension. This slice *surfaces* the decision; it does not yet *change* which
-  model runs.
-- **Option B (`mode: llm-router`)** — cheap-LLM-as-router. Config key is read but
-  not implemented.
+- **Phase 3 measurement** — before/after per-agent token spend on a pilot agent
+  (the interface extension unlocks this; not yet run).
+- **Option B (`mode: llm-router`)** — cheap-LLM-as-router. Config key read, not built.
 - **HSM UI toggle** (Phase 2) — the Switch beside the cascade editor.
-- **Phase 3 measurement** — before/after per-agent token spend on a pilot agent.
-- Richer signals (tool-call history, kanban-shape detection from real context,
-  public-facing detection) — currently derived only from message text + platform;
-  absent signals default conservatively (keep the turn OUT of cheap).
+- Richer signals (tool-call history, real kanban/public-facing detection).
+- **Live-agent E2E** — the swap is proven against a faithful fake agent in tests,
+  NOT yet against a real running agent hitting OpenRouter.
 
-## The hook-surface limitation (concrete ask for the interface extension)
+## ⚠️ For the independent audit
 
-The existing `pre_llm_call` hook can only **inject context** — its return value
-cannot override `model` / `provider` for the turn. The model is frozen by
-`restore_primary_runtime` at `agent/turn_context.py:174`, ~250 lines before this
-hook fires (`turn_context.py:436`), and the hook receives `model` as a read-only
-value, not the agent object. Mutating `agent.model` in `on_session_start` is
-session-scoped, not per-turn, so it can't do per-turn routing either.
-
-**Concrete extension request** (answers teknium1's offer on PR #43534): a
-pre-turn hook whose return value may carry a `{"model": ..., "provider": ...}`
-override that `turn_context` applies *before* the client is built for the turn —
-i.e. select the tier's runtime the same way `restore_primary_runtime` sets it,
-but from a plugin decision rather than only the reactive fallback chain. With
-that, this plugin's `route_for()` result becomes actuating instead of advisory.
+The **only** core-runtime changes are `agent/routing_override.py` and the single
+call site in `agent/turn_context.py`. They touch the model-selection path and are
+**user-visible** (they change which model answers a turn). Everything else is
+plugin-local. Audit focus points:
+- Turn-scoping correctness: is the swap really reverted next turn? (relies on
+  `restore_primary_runtime`'s `_fallback_activated` gate — same mechanism reactive
+  fallback uses).
+- Interaction with reactive fallback within the same turn (both mutate
+  `agent.model`; proactive runs first, in the prologue; reactive still applies
+  underneath on failure).
+- Fail-safe coverage: a bad/unreachable cheap provider must degrade to the
+  primary, not break the turn.
+- The swap is verified against a fake agent only — a live-agent run is required
+  before fleet rollout.

--- a/plugins/intelligent_routing/README.md
+++ b/plugins/intelligent_routing/README.md
@@ -62,12 +62,27 @@ turn arrives
   list of `pre_llm_call` results (first well-formed, `model` required).
 - `apply_routing_override(agent, override)` — actuate the swap by delegating to
   the agent's existing, tested `switch_model` (full atomic client rebuild +
-  rollback), then **re-scope it to this turn**: restore the pre-swap
-  `_primary_runtime` snapshot and arm `_fallback_activated`, so
-  `restore_primary_runtime` reverts it at the top of the next turn. Identical
-  turn-scoping to the reactive fallback path — a different axis, same data
-  structure. Fail-safe: any error leaves the agent on its configured primary and
-  never raises into the turn loop.
+  rollback), then **scope it to this turn with a DEDICATED flag**
+  (`_routing_override_active`), stashing the premium `_primary_runtime` snapshot
+  in `_routing_override_saved_primary`. It deliberately leaves `_primary_runtime`
+  pointing at the **cheap** runtime for the turn and does **not** touch
+  `_fallback_activated`. `restore_primary_runtime` reverts the swap at the top of
+  the next turn via a dedicated block that runs **before** both the
+  `_fallback_activated` gate and the rate-limit cooldown gate. Fail-safe: any
+  error leaves the agent on its configured primary and never raises into the turn
+  loop.
+
+  > **Why the dedicated flag (three audit-confirmed bugs the earlier design had).**
+  > An earlier version scoped the override by restoring the premium snapshot into
+  > `_primary_runtime` and arming `_fallback_activated`. That overloaded reactive-
+  > fallback state and broke three error-adjacent paths: (1) the cheap model
+  > **leaked past its turn** when `restore_primary_runtime`'s rate-limit cooldown
+  > gate skipped restoration (Blocker 1); (2) in-turn transient-transport recovery
+  > (which rebuilds from `_primary_runtime`) **jumped the routed turn onto premium**
+  > (Major 2); (3) pre-arming `_fallback_activated` made a cheap-model 429 **skip
+  > arming its cooldown** (Major 3). Keeping `_primary_runtime == cheap` + a
+  > dedicated flag fixes all three, and lets reactive fallback run correctly
+  > UNDERNEATH a routed turn with the cheap runtime as its "primary".
 
 Call site: `agent/turn_context.py`, immediately after the `pre_llm_call` results
 are collected (before the turn's first API call assembles). That is the whole
@@ -121,13 +136,17 @@ The **only** core-runtime changes are `agent/routing_override.py` and the single
 call site in `agent/turn_context.py`. They touch the model-selection path and are
 **user-visible** (they change which model answers a turn). Everything else is
 plugin-local. Audit focus points:
-- Turn-scoping correctness: is the swap really reverted next turn? (relies on
-  `restore_primary_runtime`'s `_fallback_activated` gate — same mechanism reactive
-  fallback uses).
-- Interaction with reactive fallback within the same turn (both mutate
-  `agent.model`; proactive runs first, in the prologue; reactive still applies
-  underneath on failure).
+- Turn-scoping correctness: proven against the REAL `restore_primary_runtime` in
+  `tests/agent/test_routing_override_revert.py` — the revert runs before both the
+  `_fallback_activated` and rate-limit cooldown gates, so it happens regardless of
+  cooldown state (the first-round audit's leak repro is now a passing regression
+  test there).
+- Interaction with reactive fallback within the same turn: `_primary_runtime`
+  stays == cheap during the routed turn, so reactive fallback engages with the
+  cheap runtime as its "primary" and cooldown accounting is intact (covered by
+  `test_reactive_fallback_engages_under_a_routed_turn`).
 - Fail-safe coverage: a bad/unreachable cheap provider must degrade to the
   primary, not break the turn.
-- The swap is verified against a fake agent only — a live-agent run is required
-  before fleet rollout.
+- **The swap is verified against faithful fake agents + the real
+  `restore_primary_runtime`, but NOT yet against a live agent hitting OpenRouter —
+  a live-agent run is required before fleet rollout.**

--- a/plugins/intelligent_routing/README.md
+++ b/plugins/intelligent_routing/README.md
@@ -44,14 +44,26 @@ Enabled but `routing.intelligent` OFF ⇒ the hook is inert (`None`, zero change
 ```
 turn arrives
   └─ pre_llm_call hook (plugins/intelligent_routing/registration.py)
-       ├─ classify task type (classifier.py)  ── code-gen / architecture /
-       │                                          research / orchestration / mechanical
-       ├─ map to tier: mechanical|orchestration → cheap ; else → premium (fail open)
+       ├─ decide_tier(sig) (classifier.py) ── gate cheap on the CONSERVATIVE
+       │     binary classifier: cheap ONLY if classify_turn == MECHANICAL,
+       │     else PREMIUM (fail open). NO catch-all-to-cheap.
        ├─ inject model-awareness reason line:
-       │     [Current model: … — routed: mechanical → cheap]
+       │     [Current model: … — routed: mechanical → cheap]   (or "judgment → premium")
        └─ if cheap: return {"route": {"model": …, "provider": …}}
              └─ turn_context extracts + applies it (agent/routing_override.py)
                   └─ agent.switch_model(...)  ── turn-scoped: reverted next turn
+```
+
+**Probe the decision in isolation** (for re-audit / live-probe, no config/plumbing):
+
+```python
+from plugins.intelligent_routing.registration import probe_route
+probe_route("Write a Python function that merges two sorted linked lists.")
+#   -> {"tier": "premium", "classification": "uncertain"}
+probe_route("grep for TODO in the repo")
+#   -> {"tier": "cheap", "classification": "mechanical"}
+probe_route("run the nightly digest", platform="cron")
+#   -> {"tier": "cheap", "classification": "mechanical"}
 ```
 
 ## The interface extension (the centerpiece)
@@ -93,21 +105,33 @@ plugin can now return a per-turn model/provider override, not just this one. It
 reuses `switch_model` rather than duplicating the swap logic. It's turn-scoped and
 fail-safe by construction. This is what teknium1 offered to add to the interface.
 
-## Task types → tiers
+## The routing decision (simplified after a live-deploy bug)
 
-Adopted from #43534 (see `references/prior-art.md`), adapted to our fleet:
+**The decider is the conservative binary classifier, not the task-type table.**
+`decide_tier(sig)` routes to cheap **only** when `classify_turn(sig) == MECHANICAL`
+(a confident positive: cron/background, kanban-triage, or a short direct
+single-action ask). Everything else — architecture, code-gen, open-ended
+reasoning, hedged/ambiguous asks, long messages, public-facing — **fails open to
+premium**.
 
-| task type      | tier    | why (directional, recalibrate from fleet data) |
-|----------------|---------|--------------------------------------------------|
-| architecture   | premium | highest reasoning; never cheap-route hard design/security/debug |
-| code-gen       | premium | DeepSWE: DeepSeek coding throughput directionally lower — keep on Claude |
-| research       | premium | analysis/judgment, often public-facing |
-| orchestration  | cheap   | DeepSeek competitive at CLI/tool orchestration (Terminal-Bench 67.9% @ $0.87/1M) |
-| mechanical     | cheap   | fast/cheap delegated workhorse |
-| uncertain / public-facing | premium | fail open — never silently downgrade |
+> **Why (the live-deploy bug this fixes).** An earlier version routed on the
+> 5-way `classify_task_type`, whose catch-all default was `orchestration → cheap`.
+> A live deploy on the cyborg agent proved that hard architecture questions,
+> multi-file code-gen ("Write a Python function that merges two sorted linked
+> lists"), and hedged/uncertain asks ALL fell through the catch-all onto cheap —
+> the "fail open to premium" guarantee was false in practice. The fix: gate cheap
+> on the conservative binary classifier and make the default premium. There is no
+> catch-all-to-cheap. `tests/plugins/intelligent_routing/test_realistic_distribution.py`
+> feeds a representative batch through the FULL hook and asserts what actually
+> routes — the regression that would have caught this.
 
-Cheap tier defaults to `deepseek/deepseek-v3.2` — v3.2, **not** v4-Pro; that
-choice is grounded in #43534's data (see `references/prior-art.md`).
+`classify_task_type` (the 5-way path) still exists as a descriptive utility and
+is unit-tested, but it is **NOT consulted in the routing path**.
+
+Cheap tier defaults to `deepseek/deepseek-v3.2` — v3.2, **not** v4-Pro; grounded
+in #43534's data (DeepSeek coding throughput directionally lower → keep code-gen
+on Claude; DeepSeek only competitive AND cheap at CLI/tool orchestration). See
+`references/prior-art.md`.
 
 ## Scope — DONE vs DEFERRED
 

--- a/plugins/intelligent_routing/README.md
+++ b/plugins/intelligent_routing/README.md
@@ -1,0 +1,107 @@
+# intelligent_routing
+
+Opt-in **pre-turn cost routing** for the Hermes main chat turn.
+
+When enabled per-agent, a cheap local heuristic classifies each incoming turn as
+**mechanical** (route to the cheap-metered tier — e.g. an OpenRouter workhorse)
+vs. **judgment** (route to the premium, Claude-class tier), and surfaces *why* in
+the model-awareness prompt line so a user is never confused by a silent quality-
+tier switch mid-thread.
+
+This is the plugin form of the routing mechanism four upstream issues have asked
+for (#30652, #61371/#61373, #32704) and PR #43534 attempted — built as a plugin
+per teknium1's steer on that PR, and motivated by NimbleCo's real fleet cost
+(`[intelligent-routing-cost]`: ~$1k/mo, 6/6 agents primary on metered Sonnet with
+no cheap rung anywhere in any cascade).
+
+## Enable
+
+```bash
+hermes plugins enable intelligent_routing
+```
+
+Then, per agent, in `config.yaml` (default **OFF** — this is opt-in because it
+changes which model answers a user's message):
+
+```yaml
+routing:
+  intelligent: true      # default false
+  mode: heuristic        # Option A (default). "llm-router" (Option B) = Phase 2, not built.
+```
+
+With the plugin enabled but `routing.intelligent` OFF, the hook is **inert** —
+it returns `None` and there is zero behavior change.
+
+## What it classifies (Option A — heuristic, no extra LLM call)
+
+`classifier.classify_turn(TurnSignals) -> "mechanical" | "judgment" | "uncertain"`
+is a pure, deterministic function of cheap local signals. Definitions
+(spec open-question #3, per D-2026-07-08-01):
+
+**mechanical** (→ cheap tier):
+- cron / background / non-interactive jobs, OR
+- kanban-triage-shaped requests, OR
+- a **short, direct single-action ask** — a bare imperative command
+  (`mark card 42 done`, `close #17`) or a trivial lookup (`what's 2+2`).
+
+**judgment** (→ premium tier):
+- open-ended / multi-step reasoning,
+- long substantive human messages,
+- anything public-facing,
+- **any short-but-hedged / deferred / context-referencing ask**
+  (`Can you look at the thing we discussed and get back to me?`) — short length
+  is necessary but NOT sufficient for mechanical.
+
+**uncertain** → **fails open to premium.** `route_for()` only sends a turn to the
+cheap tier on a *confident* mechanical classification; judgment AND uncertain
+both go premium. This mirrors HSM's `validateCascadeEntries` fail-open discipline
+and honors the spec's rule: never silently downgrade a judgment turn.
+
+## What it surfaces
+
+The `pre_llm_call` hook injects an extended model-awareness line (built on
+`agent.model_awareness.format_current_model_line`, so the base format stays
+byte-identical):
+
+```
+[Current model: x-ai/grok via openrouter — routed: mechanical]
+[Current model: claude-sonnet-5 via anthropic — routed: judgment]
+```
+
+## Scope — DONE vs DEFERRED
+
+**Done (this Stage-1 slice):**
+- Per-agent `routing.intelligent` toggle, default OFF, with `routing.mode`.
+- Option-A heuristic classifier as a pure, fully-tested function (mechanical /
+  judgment / uncertain, fail-open to premium).
+- `pre_llm_call` wiring that computes the decision and injects the routing-reason
+  line; inert when disabled; never raises into the turn loop.
+- Full RGTDD coverage (see `tests/plugins/intelligent_routing/`).
+
+**Deferred:**
+- **Actuation of the model swap.** See below — needs a plugin-interface
+  extension. This slice *surfaces* the decision; it does not yet *change* which
+  model runs.
+- **Option B (`mode: llm-router`)** — cheap-LLM-as-router. Config key is read but
+  not implemented.
+- **HSM UI toggle** (Phase 2) — the Switch beside the cascade editor.
+- **Phase 3 measurement** — before/after per-agent token spend on a pilot agent.
+- Richer signals (tool-call history, kanban-shape detection from real context,
+  public-facing detection) — currently derived only from message text + platform;
+  absent signals default conservatively (keep the turn OUT of cheap).
+
+## The hook-surface limitation (concrete ask for the interface extension)
+
+The existing `pre_llm_call` hook can only **inject context** — its return value
+cannot override `model` / `provider` for the turn. The model is frozen by
+`restore_primary_runtime` at `agent/turn_context.py:174`, ~250 lines before this
+hook fires (`turn_context.py:436`), and the hook receives `model` as a read-only
+value, not the agent object. Mutating `agent.model` in `on_session_start` is
+session-scoped, not per-turn, so it can't do per-turn routing either.
+
+**Concrete extension request** (answers teknium1's offer on PR #43534): a
+pre-turn hook whose return value may carry a `{"model": ..., "provider": ...}`
+override that `turn_context` applies *before* the client is built for the turn —
+i.e. select the tier's runtime the same way `restore_primary_runtime` sets it,
+but from a plugin decision rather than only the reactive fallback chain. With
+that, this plugin's `route_for()` result becomes actuating instead of advisory.

--- a/plugins/intelligent_routing/__init__.py
+++ b/plugins/intelligent_routing/__init__.py
@@ -1,0 +1,16 @@
+"""Intelligent routing plugin — opt-in pre-turn cost routing (Option A).
+
+When enabled per-agent (``routing.intelligent: true`` in config.yaml, default
+OFF), a cheap local heuristic classifies each incoming turn as mechanical vs.
+judgment and surfaces the routing decision in the model-awareness prompt line so
+users see WHY a tier was picked. It fails open to the premium tier on any
+uncertainty.
+
+Actuating the model swap (making a mechanical turn actually go to the cheap
+provider) requires a plugin-interface extension the maintainer offered on
+PR #43534 — the existing ``pre_llm_call`` hook can inject context but cannot
+override model/provider for the turn. See ``registration.py`` for details.
+"""
+from .registration import register  # noqa: F401
+
+__all__ = ["register"]

--- a/plugins/intelligent_routing/__init__.py
+++ b/plugins/intelligent_routing/__init__.py
@@ -1,15 +1,16 @@
 """Intelligent routing plugin — opt-in pre-turn cost routing (Option A).
 
 When enabled per-agent (``routing.intelligent: true`` in config.yaml, default
-OFF), a cheap local heuristic classifies each incoming turn as mechanical vs.
-judgment and surfaces the routing decision in the model-awareness prompt line so
-users see WHY a tier was picked. It fails open to the premium tier on any
-uncertainty.
+OFF), a cheap local heuristic classifies each incoming turn by task type, routes
+mechanical/orchestration work to a cheap-metered tier (default
+``deepseek/deepseek-v3.2`` via OpenRouter), and surfaces the decision in the
+model-awareness prompt line. It fails open to the premium tier on any uncertainty.
 
-Actuating the model swap (making a mechanical turn actually go to the cheap
-provider) requires a plugin-interface extension the maintainer offered on
-PR #43534 — the existing ``pre_llm_call`` hook can inject context but cannot
-override model/provider for the turn. See ``registration.py`` for details.
+The swap is ACTUATED through the routing-override interface extension
+(``agent/routing_override.py`` + one call site in ``agent/turn_context.py``) —
+the clean plugin form of upstream PR #43534, per teknium1's steer + his offer to
+extend the plugin interface. Turn-scoped and fail-safe. See ``registration.py``
+and the README.
 """
 from .registration import register  # noqa: F401
 

--- a/plugins/intelligent_routing/classifier.py
+++ b/plugins/intelligent_routing/classifier.py
@@ -1,0 +1,158 @@
+"""Pre-turn heuristic classifier (Option A) for intelligent routing.
+
+Classifies an incoming turn as ``mechanical`` (route to the cheap-metered tier)
+vs. ``judgment`` (route to the premium tier) using ONLY cheap, local signals
+available before the LLM call — zero extra API cost, zero added latency. When
+the signals don't add up to a confident ``mechanical`` classification, the
+result is ``uncertain`` and ``route_for`` FAILS OPEN to premium: a judgment turn
+must never be silently downgraded to the cheap model, because a visibly worse
+answer to a human is the expensive failure mode (spec open-question #4). This
+mirrors the fail-open discipline HSM's ``validateCascadeEntries`` already uses
+for credential checks.
+
+Everything here is a PURE function of ``TurnSignals`` — deterministic, no I/O,
+no globals — so it is trivially testable and safe to call on the hot path.
+
+"Mechanical" is defined concretely (spec open-question #3, per D-2026-07-08-01):
+  - cron / background / non-interactive jobs, OR
+  - kanban-triage-shaped requests, OR
+  - short, single-tool-call-shaped asks (no multi-step reasoning),
+and NEVER anything public-facing.
+"Judgment" is everything substantive: open-ended / multi-step reasoning, long
+human messages, or anything public-facing.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Classification labels.
+MECHANICAL = "mechanical"
+JUDGMENT = "judgment"
+UNCERTAIN = "uncertain"
+
+# Routing tiers.
+TIER_CHEAP = "cheap"
+TIER_PREMIUM = "premium"
+
+# A short mechanical ask is bounded in characters. Above this, a message carries
+# enough substance that we no longer treat it as a one-shot mechanical request
+# and defer to the other signals (fail open if nothing else fires). Kept
+# deliberately conservative — false-mechanical on a real question is the costly
+# error, so the length gate errs toward "not mechanical."
+_SHORT_MESSAGE_CHARS = 120
+
+# Short length is NECESSARY but NOT SUFFICIENT for mechanical: plenty of short
+# human messages are judgment calls (e.g. "Can you look at the thing we
+# discussed and get back to me?"). A short interactive ask is only mechanical
+# when it ALSO looks like a direct single action — a bare imperative command or
+# a trivial factual/lookup query — and carries none of the deferral / prior-
+# context markers that signal an open, context-dependent request.
+
+# Leading imperative verbs that mark a direct single-action command.
+_IMPERATIVE_VERBS = frozenset({
+    "mark", "add", "remove", "delete", "close", "open", "set", "move", "assign",
+    "list", "show", "get", "fetch", "run", "start", "stop", "restart", "rename",
+    "tag", "label", "archive", "unarchive", "create", "update", "check", "sort",
+    "clear", "reset", "enable", "disable", "send", "post", "pin", "unpin",
+})
+
+# Trivial factual/lookup query openers (short "what's X" style asks).
+_TRIVIAL_QUERY_PREFIXES = ("what's ", "whats ", "what is ", "how many ", "when is ")
+
+# Markers of a hedged / deferred / context-dependent request — these push a
+# short message OUT of mechanical (fail open to judgment). "the thing we
+# discussed", "get back to me", "look into", etc.
+_DEFERRAL_MARKERS = (
+    "get back to me", "look at the", "look into", "we discussed", "we talked",
+    "the thing", "figure out", "think about", "your thoughts", "what do you think",
+    "not sure", "somehow", "whenever you", "when you get a chance",
+)
+
+
+def _is_short_mechanical_ask(message: str) -> bool:
+    """True when a short message is a direct single-action command or trivial query.
+
+    Returns False for hedged/deferred/context-referencing short messages so they
+    fail open to judgment rather than being silently cheap-routed.
+    """
+    text = message.strip().lower()
+    if not text:
+        return False
+    if any(marker in text for marker in _DEFERRAL_MARKERS):
+        return False
+    if text.startswith(_TRIVIAL_QUERY_PREFIXES):
+        return True
+    first_word = text.split(maxsplit=1)[0].strip(".,!?:")
+    return first_word in _IMPERATIVE_VERBS
+
+
+@dataclass(frozen=True)
+class TurnSignals:
+    """Cheap local signals for one turn, all available before the LLM call.
+
+    These map directly onto what the ``pre_llm_call`` hook already receives
+    (``user_message``, ``platform``, conversation/tool context) plus a few
+    booleans the registration layer derives from the runtime/session context.
+    """
+
+    user_message: str = ""
+    # Live human chat vs. non-interactive invocation.
+    is_interactive: bool = True
+    # Cron / scheduled / background job (non-interactive by nature).
+    is_background: bool = False
+    # The request is kanban-triage-shaped (assign/prioritize/sort a backlog).
+    is_kanban_triage: bool = False
+    # The turn is expected to require multi-step reasoning.
+    expects_multi_step: bool = False
+    # The output is public-facing (announcement, published content, DM to a
+    # non-operator). Public-facing ALWAYS goes premium.
+    is_public_facing: bool = False
+
+
+def classify_turn(sig: TurnSignals) -> str:
+    """Return ``MECHANICAL`` / ``JUDGMENT`` / ``UNCERTAIN`` for one turn.
+
+    Order matters: the strongest *judgment* signals are checked first so they
+    can never be overridden by a coincidental mechanical signal (e.g. a short
+    but public-facing message must not be classified mechanical).
+    """
+    message = (sig.user_message or "").strip()
+
+    # No signal at all -> we cannot claim it's mechanical. Fail open.
+    if not message and not sig.is_background:
+        return UNCERTAIN
+
+    # --- Judgment dominators (checked first, never overridden) ---
+    if sig.is_public_facing:
+        return JUDGMENT
+    if sig.expects_multi_step:
+        return JUDGMENT
+    if len(message) > _SHORT_MESSAGE_CHARS:
+        return JUDGMENT
+
+    # --- Mechanical signals ---
+    if sig.is_background or not sig.is_interactive:
+        return MECHANICAL
+    if sig.is_kanban_triage:
+        return MECHANICAL
+    if (
+        message
+        and len(message) <= _SHORT_MESSAGE_CHARS
+        and _is_short_mechanical_ask(message)
+    ):
+        # Short, interactive, not multi-step, not public-facing, AND shaped like
+        # a direct single action or trivial lookup: a one-shot mechanical ask.
+        return MECHANICAL
+
+    # Nothing decisive -> fail open.
+    return UNCERTAIN
+
+
+def route_for(sig: TurnSignals) -> str:
+    """Collapse a classification to a routing tier, failing open to premium.
+
+    ``mechanical`` -> ``TIER_CHEAP``. Everything else (``judgment`` AND
+    ``uncertain``) -> ``TIER_PREMIUM``. Only a confident mechanical result ever
+    reaches the cheap tier.
+    """
+    return TIER_CHEAP if classify_turn(sig) == MECHANICAL else TIER_PREMIUM

--- a/plugins/intelligent_routing/classifier.py
+++ b/plugins/intelligent_routing/classifier.py
@@ -69,10 +69,11 @@ _SHORT_MESSAGE_CHARS = 120
 
 # Short length is NECESSARY but NOT SUFFICIENT for mechanical: plenty of short
 # human messages are judgment calls (e.g. "Can you look at the thing we
-# discussed and get back to me?"). A short interactive ask is only mechanical
-# when it ALSO looks like a direct single action — a bare imperative command or
-# a trivial factual/lookup query — and carries none of the deferral / prior-
-# context markers that signal an open, context-dependent request.
+# discussed and get back to me?", or "what's the best architecture for this?").
+# A short interactive ask is only mechanical when it ALSO leads with an imperative
+# command verb (a positive signal). Question-shaped short asks fail open to
+# premium — we do NOT special-case "what's X" prefixes (they front real judgment
+# questions far more often than trivial lookups).
 
 # Leading imperative verbs that mark a direct single-action command. Includes the
 # unambiguous read-only shell verbs (grep/find/cat/ls/search/count) that are
@@ -85,12 +86,10 @@ _IMPERATIVE_VERBS = frozenset({
     "grep", "find", "cat", "ls", "search", "count", "diff", "print",
 })
 
-# Trivial factual/lookup query openers (short "what's X" style asks).
-_TRIVIAL_QUERY_PREFIXES = ("what's ", "whats ", "what is ", "how many ", "when is ")
-
-# Markers of a hedged / deferred / context-dependent request — these push a
-# short message OUT of mechanical (fail open to judgment). "the thing we
-# discussed", "get back to me", "look into", etc.
+# Markers of a hedged / deferred / context-dependent request — a defensive
+# early-out that keeps such short messages OUT of mechanical. Kept as a
+# belt-and-braces guard; the POSITIVE mechanical signal below is a leading
+# imperative verb, so this blocklist is not load-bearing on its own.
 _DEFERRAL_MARKERS = (
     "get back to me", "look at the", "look into", "we discussed", "we talked",
     "the thing", "figure out", "think about", "your thoughts", "what do you think",
@@ -99,18 +98,21 @@ _DEFERRAL_MARKERS = (
 
 
 def _is_short_mechanical_ask(message: str) -> bool:
-    """True when a short message is a direct single-action command or trivial query.
+    """True when a short message is a direct single-action command.
 
-    Returns False for hedged/deferred/context-referencing short messages so they
-    fail open to judgment rather than being silently cheap-routed.
+    Mechanical requires a POSITIVE signal — a leading imperative verb
+    (grep/list/mark/close/…). We deliberately DO NOT treat trivial-query prefixes
+    ("what's X" / "how many" / "when is") as mechanical: those routinely front
+    real JUDGMENT questions ("what's the best architecture for this?",
+    "when is it worth adding a cache?"), and a fail-*closed*-to-cheap prefix rule
+    can't be patched with a blocklist. A genuinely trivial "what's 2+2" going
+    premium is harmless — fail open to premium is the whole point.
     """
     text = message.strip().lower()
     if not text:
         return False
     if any(marker in text for marker in _DEFERRAL_MARKERS):
         return False
-    if text.startswith(_TRIVIAL_QUERY_PREFIXES):
-        return True
     first_word = text.split(maxsplit=1)[0].strip(".,!?:")
     return first_word in _IMPERATIVE_VERBS
 
@@ -169,8 +171,8 @@ def classify_turn(sig: TurnSignals) -> str:
         and len(message) <= _SHORT_MESSAGE_CHARS
         and _is_short_mechanical_ask(message)
     ):
-        # Short, interactive, not multi-step, not public-facing, AND shaped like
-        # a direct single action or trivial lookup: a one-shot mechanical ask.
+        # Short, interactive, not multi-step, not public-facing, AND leading with
+        # an imperative command verb: a one-shot mechanical ask.
         return MECHANICAL
 
     # Nothing decisive -> fail open.
@@ -233,8 +235,9 @@ _CODE_MARKERS = (
 _CODE_VERBS = frozenset({"implement", "refactor", "code"})
 
 # Research / analysis / lookup. Note: bare "what is"/"what's" are deliberately
-# NOT here — they collide with the idiomatic "what's up" and with trivial lookups
-# already handled by _TRIVIAL_QUERY_PREFIXES; research needs a stronger verb.
+# NOT here — they collide with the idiomatic "what's up" and, more importantly,
+# front real judgment questions; research needs a stronger verb. (This is the
+# descriptive task-type layer, not the routing path.)
 _RESEARCH_MARKERS = (
     "research", "summarize", "summarise", "explain", "look up", "look up the",
     "search the web", "analyze", "analyse", "compare the", "what are the tradeoffs",

--- a/plugins/intelligent_routing/classifier.py
+++ b/plugins/intelligent_routing/classifier.py
@@ -1,38 +1,64 @@
 """Pre-turn heuristic classifier (Option A) for intelligent routing.
 
-Classifies an incoming turn as ``mechanical`` (route to the cheap-metered tier)
-vs. ``judgment`` (route to the premium tier) using ONLY cheap, local signals
-available before the LLM call — zero extra API cost, zero added latency. When
-the signals don't add up to a confident ``mechanical`` classification, the
-result is ``uncertain`` and ``route_for`` FAILS OPEN to premium: a judgment turn
-must never be silently downgraded to the cheap model, because a visibly worse
-answer to a human is the expensive failure mode (spec open-question #4). This
-mirrors the fail-open discipline HSM's ``validateCascadeEntries`` already uses
-for credential checks.
+Classifies an incoming turn using ONLY cheap, local signals available before the
+LLM call — zero extra API cost, zero added latency. When the signals don't add
+up to a confident cheap-tier classification, it FAILS OPEN to premium: a judgment
+turn must never be silently downgraded, because a visibly worse answer to a human
+is the expensive failure mode (spec open-question #4). This mirrors the fail-open
+discipline HSM's ``validateCascadeEntries`` already uses for credential checks.
 
 Everything here is a PURE function of ``TurnSignals`` — deterministic, no I/O,
 no globals — so it is trivially testable and safe to call on the hot path.
 
-"Mechanical" is defined concretely (spec open-question #3, per D-2026-07-08-01):
-  - cron / background / non-interactive jobs, OR
-  - kanban-triage-shaped requests, OR
-  - short, single-tool-call-shaped asks (no multi-step reasoning),
-and NEVER anything public-facing.
-"Judgment" is everything substantive: open-ended / multi-step reasoning, long
-human messages, or anything public-facing.
+── Two layers ──
+1. **Binary** (``classify_turn`` / ``route_for``) — mechanical vs judgment. The
+   original, minimal split. Retained for back-compat.
+2. **Task-TYPE** (``classify_task_type`` / ``tier_for_task_type`` / ``route_task``)
+   — adopted from upstream **PR #43534** (model-task-router, closed on
+   NousResearch/hermes-agent), which routes by task TYPE rather than a binary
+   split and grounds the mapping in DeepSWE reliability data.
+
+── What we ADOPTED vs ADAPTED from #43534 ──
+ADOPTED: the five task categories (code-gen / hard-architecture / orchestration /
+research / mechanical), its keyword-priority decision tree (code > architecture >
+mechanical > research > orchestration), and its core principle — *route by task
+TYPE, not brand loyalty; treat benchmarks as directional* (see
+``references/prior-art.md``, credited to Sugumaran Balasubramaniyan +
+the deep-swe#21 correction thread).
+ADAPTED: the tier mapping is to OUR fleet's actual tiers, NOT #43534's non-fleet
+GPT-5.4/5.5. Specifically we route the cheap tier to OpenRouter
+``deepseek/deepseek-v3.2`` — deliberately v3.2, NOT v4-Pro. That choice is
+grounded directly in #43534's data: V4-Pro's DeepSWE *coding* throughput is
+directionally lower (~8%, heavily caveated), so we do NOT route hard code-gen to
+DeepSeek at all (code-gen -> premium/Claude); we route DeepSeek only where its
+own data shows it competitive AND cheap — CLI/tool orchestration and mechanical
+work (Terminal-Bench 67.9% @ $0.87/1M). See ``tier_for_task_type`` for the
+per-category grounding.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
 
-# Classification labels.
+# --- Binary classification labels (layer 1) ---
 MECHANICAL = "mechanical"
 JUDGMENT = "judgment"
 UNCERTAIN = "uncertain"
 
-# Routing tiers.
+# --- Task-TYPE categories (layer 2, adopted from PR #43534) ---
+TASK_CODE_GEN = "code_gen"
+TASK_ARCHITECTURE = "architecture"
+TASK_ORCHESTRATION = "orchestration"
+TASK_RESEARCH = "research"
+TASK_MECHANICAL = "mechanical_task"
+TASK_UNCERTAIN = "uncertain_task"
+
+# Routing tiers (our fleet):
+#   premium — Claude (per-agent primary: sonnet-5 / fable-5 / opus)
+#   cheap   — OpenRouter deepseek/deepseek-v3.2 (see module docstring for why v3.2)
+#   local   — ollama qwen/glm floor (not auto-selected by this classifier)
 TIER_CHEAP = "cheap"
 TIER_PREMIUM = "premium"
+TIER_LOCAL = "local"
 
 # A short mechanical ask is bounded in characters. Above this, a message carries
 # enough substance that we no longer treat it as a one-shot mechanical request
@@ -149,10 +175,138 @@ def classify_turn(sig: TurnSignals) -> str:
 
 
 def route_for(sig: TurnSignals) -> str:
-    """Collapse a classification to a routing tier, failing open to premium.
+    """Collapse a binary classification to a routing tier, failing open to premium.
 
     ``mechanical`` -> ``TIER_CHEAP``. Everything else (``judgment`` AND
     ``uncertain``) -> ``TIER_PREMIUM``. Only a confident mechanical result ever
     reaches the cheap tier.
     """
     return TIER_CHEAP if classify_turn(sig) == MECHANICAL else TIER_PREMIUM
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Layer 2: task-TYPE classification (adopted from PR #43534's model-task-router)
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Keyword sets track #43534's decision tree (SKILL.md lines 101-121). Matched on
+# a lowercased message. Priority order (first match wins) is #43534's:
+#   code-gen > architecture > mechanical > research > orchestration.
+# Architecture is checked before code-gen here ONLY when an explicit architecture
+# phrase is present, because "design a system" would otherwise be miscaught by a
+# bare code verb; the tests pin both orderings.
+
+# Hard-architecture / high-stakes reasoning (checked first when explicit).
+_ARCH_MARKERS = (
+    "architecture", "design a system", "design the", "design an",
+    "how would you structure", "security review", "complex debugging",
+    "distributed race", "threat model", "system design",
+)
+
+# Code generation: implement / fix / refactor / write code / PR.
+_CODE_MARKERS = (
+    "implement", "refactor", "write code", "fix the bug", "fix bug",
+    "add a feature", "add feature", "open a pr", "patch", "write a function",
+    "write the migration", "migration script",
+)
+# Bare code verbs (need "first word" or standalone match to avoid false hits).
+_CODE_VERBS = frozenset({"implement", "refactor", "code"})
+
+# Research / analysis / lookup. Note: bare "what is"/"what's" are deliberately
+# NOT here — they collide with the idiomatic "what's up" and with trivial lookups
+# already handled by _TRIVIAL_QUERY_PREFIXES; research needs a stronger verb.
+_RESEARCH_MARKERS = (
+    "research", "summarize", "summarise", "explain", "look up", "look up the",
+    "search the web", "analyze", "analyse", "compare the", "what are the tradeoffs",
+)
+
+# Mechanical: read-only or single-command shell/file ops.
+_MECHANICAL_MARKERS = (
+    "grep", "find all", "list files", "list all files", "run the test",
+    "run tests", "check if", "what's the content of", "list all", "show me the file",
+)
+
+
+def _has_any(text: str, markers) -> bool:
+    return any(m in text for m in markers)
+
+
+def classify_task_type(sig: TurnSignals) -> str:
+    """Classify a turn into one of #43534's five task types (or uncertain).
+
+    Priority (per #43534, SKILL.md line 92): code-gen > architecture > mechanical
+    > research > orchestration; orchestration is the catch-all. Structural
+    signals (background / kanban-triage) resolve to mechanical directly — those
+    are unambiguous non-interactive/triage work.
+    """
+    message = (sig.user_message or "").strip()
+    if not message and not (sig.is_background or sig.is_kanban_triage):
+        return TASK_UNCERTAIN
+
+    # Structural mechanical signals (no keyword needed).
+    if sig.is_background or not sig.is_interactive or sig.is_kanban_triage:
+        return TASK_MECHANICAL
+
+    text = message.lower()
+
+    # code-gen has top priority (a coding task that also says "run" is still
+    # code-gen — #43534 priority order).
+    if _has_any(text, _CODE_MARKERS) or text.split(maxsplit=1)[0].strip(".,!?:") in _CODE_VERBS:
+        # ...unless it's explicitly an architecture ask, which outranks routine
+        # coding (#43534: "do NOT use the architecture model for routine coding"
+        # — but DO for explicit design/security/hard-debug).
+        if _has_any(text, _ARCH_MARKERS):
+            return TASK_ARCHITECTURE
+        return TASK_CODE_GEN
+
+    if _has_any(text, _ARCH_MARKERS):
+        return TASK_ARCHITECTURE
+
+    # Mechanical: an explicit mechanical marker, OR a short SINGLE-CLAUSE direct
+    # command. Multi-clause asks ("check the deploy status AND tell me...") are
+    # orchestration/diagnostics, not a single mechanical op — so a conjunction
+    # disqualifies the short-command shortcut.
+    _is_multi_clause = any(c in text for c in (" and ", " then ", ", ", " tell me"))
+    if _has_any(text, _MECHANICAL_MARKERS) or (
+        not _is_multi_clause and _is_short_mechanical_ask(message)
+    ):
+        return TASK_MECHANICAL
+
+    if _has_any(text, _RESEARCH_MARKERS):
+        return TASK_RESEARCH
+
+    # Everything else — tool calls, shell, navigation, diagnostics, config,
+    # planning — is orchestration (the catch-all, per #43534).
+    return TASK_ORCHESTRATION
+
+
+def tier_for_task_type(task_type: str) -> str:
+    """Map a task type to one of our fleet tiers. Fail open to premium.
+
+    Grounding (see ``references/prior-art.md``):
+      - ARCHITECTURE -> premium: highest reasoning; Claude Opus 4.7 competitive on
+        DeepSWE (54%). Never cheap-route hard design/security/debugging.
+      - CODE_GEN     -> premium: DeepSWE indicates DeepSeek coding throughput is
+        directionally lower (V4-Pro ~8%, caveated); keep multi-file code-gen on
+        Claude for our fleet rather than risk a visibly worse implementation.
+      - RESEARCH     -> premium: analysis/judgment, frequently public-facing.
+      - ORCHESTRATION-> cheap:   DeepSeek is competitive at CLI/tool orchestration
+        (V4-Pro Terminal-Bench 67.9% @ $0.87/1M) — this is the empirical basis
+        for putting v3.2 here, NOT on code-gen.
+      - MECHANICAL   -> cheap:   fast/cheap delegated workhorse tier.
+      - anything else / UNCERTAIN -> premium (fail open).
+    """
+    if task_type in (TASK_ORCHESTRATION, TASK_MECHANICAL):
+        return TIER_CHEAP
+    # architecture, code_gen, research, uncertain, and any unknown -> premium.
+    return TIER_PREMIUM
+
+
+def route_task(sig: TurnSignals) -> str:
+    """Task-type-aware routing: classify -> map to tier, with fail-open guards.
+
+    Public-facing ALWAYS goes premium (dominates task type) — a public-facing
+    turn must never be cheap-routed regardless of its shape.
+    """
+    if sig.is_public_facing:
+        return TIER_PREMIUM
+    return tier_for_task_type(classify_task_type(sig))

--- a/plugins/intelligent_routing/classifier.py
+++ b/plugins/intelligent_routing/classifier.py
@@ -74,12 +74,15 @@ _SHORT_MESSAGE_CHARS = 120
 # a trivial factual/lookup query — and carries none of the deferral / prior-
 # context markers that signal an open, context-dependent request.
 
-# Leading imperative verbs that mark a direct single-action command.
+# Leading imperative verbs that mark a direct single-action command. Includes the
+# unambiguous read-only shell verbs (grep/find/cat/ls/search/count) that are
+# plainly mechanical work.
 _IMPERATIVE_VERBS = frozenset({
     "mark", "add", "remove", "delete", "close", "open", "set", "move", "assign",
     "list", "show", "get", "fetch", "run", "start", "stop", "restart", "rename",
     "tag", "label", "archive", "unarchive", "create", "update", "check", "sort",
     "clear", "reset", "enable", "disable", "send", "post", "pin", "unpin",
+    "grep", "find", "cat", "ls", "search", "count", "diff", "print",
 })
 
 # Trivial factual/lookup query openers (short "what's X" style asks).
@@ -180,6 +183,24 @@ def route_for(sig: TurnSignals) -> str:
     ``mechanical`` -> ``TIER_CHEAP``. Everything else (``judgment`` AND
     ``uncertain``) -> ``TIER_PREMIUM``. Only a confident mechanical result ever
     reaches the cheap tier.
+    """
+    return TIER_CHEAP if classify_turn(sig) == MECHANICAL else TIER_PREMIUM
+
+
+def decide_tier(sig: TurnSignals) -> str:
+    """THE routing decision — the single source of truth, easy to probe in isolation.
+
+    A turn goes to ``TIER_CHEAP`` ONLY when the CONSERVATIVE binary classifier is
+    confidently ``MECHANICAL``. Everything the binary reads as ``JUDGMENT`` or
+    ``UNCERTAIN`` — hard architecture, code-gen, open-ended reasoning,
+    hedged/ambiguous asks, long messages, public-facing — FAILS OPEN to
+    ``TIER_PREMIUM``. There is NO catch-all-to-cheap: the default is premium and
+    only a proven-mechanical turn escapes it.
+
+    This is intentionally identical to ``route_for``; it exists as a named,
+    stable entry point the live-probe / re-audit calls directly. (The 5-way
+    ``classify_task_type`` is NOT consulted here — it is a descriptive utility
+    only, kept out of the routing path after the live-deploy catch-all bug.)
     """
     return TIER_CHEAP if classify_turn(sig) == MECHANICAL else TIER_PREMIUM
 

--- a/plugins/intelligent_routing/config.py
+++ b/plugins/intelligent_routing/config.py
@@ -1,0 +1,64 @@
+"""Per-agent config for intelligent routing (read from config.yaml).
+
+Follows the ``image_gen`` plugin's pattern (``from hermes_cli.config import
+load_config``; read a named section; best-effort with ``{}`` on failure). The
+toggle lives in its own ``routing:`` namespace — a plugin owns its config
+namespace, so this sidesteps needing a core ``routing:`` section (per the spec's
+2026-07-09 update: teknium1 steered this to a plugin precisely so it doesn't
+fight for space in core).
+
+Defaults, on purpose:
+  - ``routing.intelligent`` defaults to **False** — opt-in, because it changes
+    which model answers a user's message (visible behavior). A failed/absent
+    config reads as OFF, never silently ON.
+  - ``routing.mode`` defaults to ``"heuristic"`` (Option A). ``"llm-router"``
+    (Option B) is Phase 2 and not implemented here.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+_DEFAULT_MODE = "heuristic"
+
+
+def _load_config() -> Dict[str, Any]:
+    """Load the full config dict (``{}`` on any failure). Patched in tests."""
+    from hermes_cli.config import load_config
+
+    cfg = load_config()
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def _routing_section() -> Dict[str, Any]:
+    try:
+        cfg = _load_config()
+    except Exception as exc:  # noqa: BLE001 — config is best-effort; fail OFF
+        logger.debug("intelligent_routing: could not load config: %s", exc)
+        return {}
+    section = cfg.get("routing") if isinstance(cfg, dict) else None
+    return section if isinstance(section, dict) else {}
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in _TRUTHY
+    return bool(value) if isinstance(value, (int, float)) else False
+
+
+def is_intelligent_routing_enabled() -> bool:
+    """True only when ``routing.intelligent`` is explicitly truthy. Default OFF."""
+    return _coerce_bool(_routing_section().get("intelligent", False))
+
+
+def routing_mode() -> str:
+    """``heuristic`` (Option A, default) or ``llm-router`` (Option B, Phase 2)."""
+    mode = _routing_section().get("mode", _DEFAULT_MODE)
+    mode = str(mode).strip().lower() if mode else _DEFAULT_MODE
+    return mode or _DEFAULT_MODE

--- a/plugins/intelligent_routing/config.py
+++ b/plugins/intelligent_routing/config.py
@@ -25,6 +25,15 @@ _TRUTHY = frozenset({"1", "true", "yes", "on"})
 
 _DEFAULT_MODE = "heuristic"
 
+# The cheap-metered tier target a mechanical/orchestration turn routes TO.
+# Default: OpenRouter deepseek/deepseek-v3.2 — deliberately v3.2, NOT v4-Pro
+# (grounded in PR #43534's DeepSWE data: V4-Pro's coding throughput is
+# directionally lower, so we route DeepSeek only to mechanical/orchestration
+# work where its Terminal-Bench data shows it competitive AND cheap, never to
+# code-gen). Overridable per-agent via routing.cheap_model / routing.cheap_provider.
+_DEFAULT_CHEAP_MODEL = "deepseek/deepseek-v3.2"
+_DEFAULT_CHEAP_PROVIDER = "openrouter"
+
 
 def _load_config() -> Dict[str, Any]:
     """Load the full config dict (``{}`` on any failure). Patched in tests."""
@@ -62,3 +71,11 @@ def routing_mode() -> str:
     mode = _routing_section().get("mode", _DEFAULT_MODE)
     mode = str(mode).strip().lower() if mode else _DEFAULT_MODE
     return mode or _DEFAULT_MODE
+
+
+def cheap_tier_target() -> tuple[str, str]:
+    """Return ``(model, provider)`` for the cheap tier. Defaults to v3.2/openrouter."""
+    section = _routing_section()
+    model = str(section.get("cheap_model") or _DEFAULT_CHEAP_MODEL).strip() or _DEFAULT_CHEAP_MODEL
+    provider = str(section.get("cheap_provider") or _DEFAULT_CHEAP_PROVIDER).strip() or _DEFAULT_CHEAP_PROVIDER
+    return model, provider

--- a/plugins/intelligent_routing/plugin.yaml
+++ b/plugins/intelligent_routing/plugin.yaml
@@ -1,0 +1,14 @@
+name: intelligent_routing
+version: "0.1.0"
+description: >-
+  Opt-in pre-turn cost routing. When enabled per-agent (routing.intelligent:
+  true in config.yaml, default OFF), a cheap local heuristic (Option A, no extra
+  LLM call) classifies each turn as mechanical vs judgment and surfaces the
+  routing decision in the model-awareness line. Fails open to the premium tier
+  on any uncertainty — never silently downgrades a judgment turn. The reactive
+  fallback chain (try_activate_fallback / FailoverReason) is untouched; this is a
+  proactive layer on a different axis. Stage-1 dogfood build; actuation of the
+  model swap awaits a plugin-interface extension (see README).
+author: NimbleCo
+hooks:
+  - pre_llm_call

--- a/plugins/intelligent_routing/plugin.yaml
+++ b/plugins/intelligent_routing/plugin.yaml
@@ -3,12 +3,14 @@ version: "0.1.0"
 description: >-
   Opt-in pre-turn cost routing. When enabled per-agent (routing.intelligent:
   true in config.yaml, default OFF), a cheap local heuristic (Option A, no extra
-  LLM call) classifies each turn as mechanical vs judgment and surfaces the
-  routing decision in the model-awareness line. Fails open to the premium tier
-  on any uncertainty — never silently downgrades a judgment turn. The reactive
-  fallback chain (try_activate_fallback / FailoverReason) is untouched; this is a
-  proactive layer on a different axis. Stage-1 dogfood build; actuation of the
-  model swap awaits a plugin-interface extension (see README).
+  LLM call) classifies each turn by task type and routes mechanical/orchestration
+  work to a cheap-metered tier (default deepseek/deepseek-v3.2 via OpenRouter),
+  keeping premium/uncertain/public-facing turns on the configured primary. Fails
+  open to premium on any uncertainty — never silently downgrades a judgment turn.
+  The plugin ACTUATES the swap via the routing-override interface extension
+  (agent/routing_override.py), turn-scoped and fail-safe. Reactive fallback
+  (try_activate_fallback / FailoverReason) is untouched — a different axis.
+  Built as the clean plugin form of upstream PR #43534 per teknium1's steer.
 author: NimbleCo
 hooks:
   - pre_llm_call

--- a/plugins/intelligent_routing/references/prior-art.md
+++ b/plugins/intelligent_routing/references/prior-art.md
@@ -1,0 +1,46 @@
+# Prior art — model-task-router (PR #43534)
+
+This plugin is a light adaptation of prior community work; the contribution here
+is **the plugin + the interface extension**, not the classifier. This doc is a
+short citation, not a reproduction of the original data.
+
+## Source
+
+- **PR #43534** — *"feat(skills): add model-task-router — automatic task-to-model
+  routing backed by DeepSWE data"* (CLOSED on `NousResearch/hermes-agent`), by
+  **Sugumaran Balasubramaniyan** (https://github.com/Sugumaran-Balasubramaniyan),
+  MIT-licensed. It shipped as a *skill* (two markdown files) and routed by task
+  TYPE (code-gen / hard-architecture / orchestration / research / mechanical).
+- Maintainer **teknium1** closed it with a steer, not a rejection on merits:
+  *"If you do want it, please create a plugin. Happy to support adding to the
+  plugin interface to make this work as one."* — which is exactly what this
+  plugin + `agent/routing_override.py` implement.
+
+## What we took (and what we did NOT)
+
+**Adopted:** the five task categories and the principle *route by task type, not
+brand loyalty; treat published benchmarks as directional*.
+
+**Adapted:** the tier mapping goes to our fleet's tiers (premium = Claude,
+cheap = OpenRouter `deepseek/deepseek-v3.2`, local floor = ollama), NOT #43534's
+non-fleet GPT-5.4/5.5 defaults.
+
+## The one data point that is load-bearing for our v3.2 choice
+
+From #43534's DeepSWE reference (and the `datacurve-ai/deep-swe#21` correction
+thread — note the original author **retracted** the solve-rate analysis; only the
+cost correction remained valid):
+
+- DeepSeek V4-Pro's DeepSWE **coding** score was directionally low (~8%, heavily
+  caveated: no effort tuning, OpenRouter guardrail 404s, ~5–8% community range).
+  → So we do **not** route hard code-gen to DeepSeek at all (code-gen → premium).
+- DeepSeek V4-Pro is **competitive at CLI/tool orchestration** (Terminal-Bench
+  67.9% at $0.87/1M output). → So we route DeepSeek only where it's both
+  competitive AND cheap: mechanical / orchestration turns.
+
+That asymmetry — cheap-and-fine for orchestration, risky for code-gen — is the
+whole reason the cheap tier is `deepseek-v3.2` and the mapping keeps code-gen on
+Claude. Treat these numbers as directional; recalibrate from real fleet data
+(Phase 3 measurement) before trusting them further.
+
+Full data lives in the original PR; we deliberately do not re-host the table here.

--- a/plugins/intelligent_routing/registration.py
+++ b/plugins/intelligent_routing/registration.py
@@ -1,0 +1,120 @@
+"""register(ctx) — wire intelligent routing onto the ``pre_llm_call`` hook.
+
+Enabling the plugin (``hermes plugins enable intelligent_routing``) attaches the
+hook; the PER-AGENT ``routing.intelligent`` toggle (config.yaml, default OFF)
+gates whether it does anything. When the toggle is OFF the hook returns ``None``
+— zero behavior change, the opt-in guarantee.
+
+When ON, the hook runs the Option-A heuristic classifier over cheap local
+signals derived from the hook kwargs and returns a context injection that
+EXTENDS the existing model-awareness line (``agent/model_awareness.py``,
+spec B1) with the routing reason, e.g.::
+
+    [Current model: claude-sonnet-5 via anthropic — routed: mechanical]
+
+so a user is never confused by a silent tier switch mid-thread (spec §"Where
+this plugs in").
+
+── Honest scope / the hook-surface limitation ──
+This hook can only INJECT CONTEXT; its return value cannot override
+``agent.model`` / ``agent.provider`` for the turn (the model is frozen by
+``restore_primary_runtime`` at ``turn_context.py:174``, ~250 lines before this
+hook fires, and the hook receives ``model`` as a read-only value, not the agent).
+So this Stage-1 slice computes and SURFACES the routing decision but does not yet
+ACTUATE the model swap. Actuation needs the plugin-interface extension teknium1
+offered on PR #43534: a per-turn hook whose return value can set
+``model``/``provider`` before the client is built. See README for the concrete
+ask.
+
+The reactive fallback chain (``try_activate_fallback`` /
+``FailoverReason``) is deliberately untouched — intelligent routing is a
+proactive pre-turn layer on a different axis.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from .classifier import MECHANICAL, TurnSignals, classify_turn
+from .config import is_intelligent_routing_enabled
+
+logger = logging.getLogger(__name__)
+
+# Platforms that are non-interactive by nature (cron/scheduled/background jobs).
+# A turn arriving on one of these is mechanical unless a stronger judgment
+# signal fires. Kept as a small, explicit set rather than guessing.
+_NON_INTERACTIVE_PLATFORMS = frozenset({"cron", "background", "scheduler", "batch"})
+
+
+def _signals_from_kwargs(**kwargs: Any) -> TurnSignals:
+    """Derive cheap ``TurnSignals`` from the ``pre_llm_call`` kwargs.
+
+    Only uses signals that are genuinely free to read here: the message text,
+    and the platform (to tell a background job from a live human chat). Richer
+    signals (tool-call history, kanban shape, public-facing) are wired as they
+    become reliably available from the hook context; absent, they default to the
+    conservative value that keeps a turn OUT of the cheap tier.
+    """
+    message = kwargs.get("user_message") or ""
+    if not isinstance(message, str):
+        message = str(message)
+    platform = (kwargs.get("platform") or "")
+    platform = platform.strip().lower() if isinstance(platform, str) else ""
+    is_background = platform in _NON_INTERACTIVE_PLATFORMS
+    return TurnSignals(
+        user_message=message,
+        is_interactive=not is_background,
+        is_background=is_background,
+    )
+
+
+def _reason_line(model: Any, provider: Any, reason: str) -> str:
+    """Build the extended model-awareness line: ``[... — routed: <reason>]``.
+
+    Reuses ``format_current_model_line`` so the base format stays byte-identical
+    to the existing model-awareness injection, then appends the routing reason.
+    """
+    from agent.model_awareness import format_current_model_line
+
+    base = format_current_model_line(
+        str(model or ""), str(provider or "")
+    )
+    if not base:
+        # No known model -> emit a minimal, still-informative line.
+        base = "[Current model: unknown]"
+    # Splice the reason inside the trailing bracket: "[...]" -> "[... — routed: x]".
+    if base.endswith("]"):
+        return f"{base[:-1]} — routed: {reason}]"
+    return f"{base} — routed: {reason}"
+
+
+def on_pre_llm_call(**kwargs: Any) -> Optional[dict]:
+    """pre_llm_call hook. Inert when disabled; otherwise inject the routing line.
+
+    Never raises into the turn loop — any error is swallowed and treated as
+    "inject nothing" (the safe, behavior-preserving default).
+    """
+    try:
+        if not is_intelligent_routing_enabled():
+            return None
+
+        sig = _signals_from_kwargs(**kwargs)
+        classification = classify_turn(sig)
+        # route_for semantics: only a confident MECHANICAL reaches cheap; both
+        # JUDGMENT and UNCERTAIN surface as "judgment" (fail open — we never tell
+        # the user a turn was cheap-routed unless it was confidently mechanical).
+        reason = "mechanical" if classification == MECHANICAL else "judgment"
+
+        line = _reason_line(kwargs.get("model"), kwargs.get("provider"), reason)
+        return {"context": line}
+    except Exception as exc:  # noqa: BLE001 — must never break the turn
+        logger.warning("intelligent_routing: pre_llm_call failed (inert): %s", exc)
+        return None
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_llm_call", on_pre_llm_call)
+    logger.info(
+        "intelligent_routing active: pre_llm_call classifier registered "
+        "(per-agent toggle routing.intelligent gates behavior; default OFF)"
+    )

--- a/plugins/intelligent_routing/registration.py
+++ b/plugins/intelligent_routing/registration.py
@@ -6,37 +6,60 @@ gates whether it does anything. When the toggle is OFF the hook returns ``None``
 — zero behavior change, the opt-in guarantee.
 
 When ON, the hook runs the Option-A heuristic classifier over cheap local
-signals derived from the hook kwargs and returns a context injection that
-EXTENDS the existing model-awareness line (``agent/model_awareness.py``,
-spec B1) with the routing reason, e.g.::
+signals derived from the hook kwargs and returns:
+  1. a context injection that EXTENDS the model-awareness line
+     (``agent/model_awareness.py``, spec B1) with the routing reason, e.g.::
 
-    [Current model: claude-sonnet-5 via anthropic — routed: mechanical]
+         [Current model: claude-sonnet-5 via anthropic — routed: mechanical → cheap]
 
-so a user is never confused by a silent tier switch mid-thread (spec §"Where
-this plugs in").
+     so a user is never confused by a silent tier switch mid-thread; and
+  2. for a cheap-tier turn, a ``route`` override
+     (``{"model": ..., "provider": ...}``) that the runtime ACTUATES via the
+     routing-override interface extension (``agent/routing_override.py``), which
+     swaps the model for THIS turn (turn-scoped, fail-safe). Premium / uncertain
+     / public-facing turns emit NO override and stay on the configured primary.
 
-── Honest scope / the hook-surface limitation ──
-This hook can only INJECT CONTEXT; its return value cannot override
-``agent.model`` / ``agent.provider`` for the turn (the model is frozen by
-``restore_primary_runtime`` at ``turn_context.py:174``, ~250 lines before this
-hook fires, and the hook receives ``model`` as a read-only value, not the agent).
-So this Stage-1 slice computes and SURFACES the routing decision but does not yet
-ACTUATE the model swap. Actuation needs the plugin-interface extension teknium1
-offered on PR #43534: a per-turn hook whose return value can set
-``model``/``provider`` before the client is built. See README for the concrete
-ask.
+This is the clean plugin form of upstream PR #43534, and the interface extension
+is teknium1's offered "add to the plugin interface" made concrete: a
+``pre_llm_call`` result may now carry a per-turn model/provider override.
 
-The reactive fallback chain (``try_activate_fallback`` /
-``FailoverReason``) is deliberately untouched — intelligent routing is a
-proactive pre-turn layer on a different axis.
+The reactive fallback chain (``try_activate_fallback`` / ``FailoverReason``) is
+deliberately untouched — intelligent routing is a proactive pre-turn layer on a
+different axis; reactive escalation still applies underneath the chosen tier.
 """
 from __future__ import annotations
 
 import logging
 from typing import Any, Optional
 
-from .classifier import MECHANICAL, TurnSignals, classify_turn
-from .config import is_intelligent_routing_enabled
+from .classifier import (
+    TASK_ARCHITECTURE,
+    TASK_CODE_GEN,
+    TASK_MECHANICAL,
+    TASK_ORCHESTRATION,
+    TASK_RESEARCH,
+    TASK_UNCERTAIN,
+    TIER_PREMIUM,
+    TurnSignals,
+    classify_task_type,
+    tier_for_task_type,
+)
+from .classifier import TIER_CHEAP
+from .config import cheap_tier_target, is_intelligent_routing_enabled
+
+# Human-readable labels for the routing-reason line.
+_TASK_LABELS = {
+    TASK_CODE_GEN: "code-gen",
+    TASK_ARCHITECTURE: "architecture",
+    TASK_ORCHESTRATION: "orchestration",
+    TASK_RESEARCH: "research",
+    TASK_MECHANICAL: "mechanical",
+    TASK_UNCERTAIN: "uncertain",
+}
+
+
+def _task_label(task_type: str) -> str:
+    return _TASK_LABELS.get(task_type, task_type)
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +88,7 @@ def _signals_from_kwargs(**kwargs: Any) -> TurnSignals:
         user_message=message,
         is_interactive=not is_background,
         is_background=is_background,
+        is_public_facing=bool(kwargs.get("is_public_facing", False)),
     )
 
 
@@ -99,14 +123,29 @@ def on_pre_llm_call(**kwargs: Any) -> Optional[dict]:
             return None
 
         sig = _signals_from_kwargs(**kwargs)
-        classification = classify_turn(sig)
-        # route_for semantics: only a confident MECHANICAL reaches cheap; both
-        # JUDGMENT and UNCERTAIN surface as "judgment" (fail open — we never tell
-        # the user a turn was cheap-routed unless it was confidently mechanical).
-        reason = "mechanical" if classification == MECHANICAL else "judgment"
+        # Task-TYPE routing (adopted from PR #43534): classify the turn into one
+        # of five task types, then map to a fleet tier (fail open to premium).
+        # Public-facing dominates — handled inside tier selection below.
+        if sig.is_public_facing:
+            task_type = classify_task_type(sig)
+            tier = TIER_PREMIUM  # never cheap-route public-facing
+        else:
+            task_type = classify_task_type(sig)
+            tier = tier_for_task_type(task_type)
+        reason = f"{_task_label(task_type)} → {tier}"
 
         line = _reason_line(kwargs.get("model"), kwargs.get("provider"), reason)
-        return {"context": line}
+        result: dict = {"context": line}
+
+        # Emit a `route` override ONLY for the cheap tier — this is what the
+        # runtime's routing-override extension (agent/routing_override.py)
+        # actuates. Premium/fail-open turns emit no override and stay on the
+        # configured primary. Never route public-facing to cheap.
+        if tier == TIER_CHEAP:
+            cheap_model, cheap_provider = cheap_tier_target()
+            if cheap_model:
+                result["route"] = {"model": cheap_model, "provider": cheap_provider}
+        return result
     except Exception as exc:  # noqa: BLE001 — must never break the turn
         logger.warning("intelligent_routing: pre_llm_call failed (inert): %s", exc)
         return None

--- a/plugins/intelligent_routing/registration.py
+++ b/plugins/intelligent_routing/registration.py
@@ -33,33 +33,12 @@ import logging
 from typing import Any, Optional
 
 from .classifier import (
-    TASK_ARCHITECTURE,
-    TASK_CODE_GEN,
-    TASK_MECHANICAL,
-    TASK_ORCHESTRATION,
-    TASK_RESEARCH,
-    TASK_UNCERTAIN,
-    TIER_PREMIUM,
+    TIER_CHEAP,
     TurnSignals,
-    classify_task_type,
-    tier_for_task_type,
+    classify_turn,
+    decide_tier,
 )
-from .classifier import TIER_CHEAP
 from .config import cheap_tier_target, is_intelligent_routing_enabled
-
-# Human-readable labels for the routing-reason line.
-_TASK_LABELS = {
-    TASK_CODE_GEN: "code-gen",
-    TASK_ARCHITECTURE: "architecture",
-    TASK_ORCHESTRATION: "orchestration",
-    TASK_RESEARCH: "research",
-    TASK_MECHANICAL: "mechanical",
-    TASK_UNCERTAIN: "uncertain",
-}
-
-
-def _task_label(task_type: str) -> str:
-    return _TASK_LABELS.get(task_type, task_type)
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +69,19 @@ def _signals_from_kwargs(**kwargs: Any) -> TurnSignals:
         is_background=is_background,
         is_public_facing=bool(kwargs.get("is_public_facing", False)),
     )
+
+
+def probe_route(message: str, **signals: Any) -> dict:
+    """Probe the routing decision for a message in ISOLATION — no config, no hook.
+
+    Returns ``{"tier": "cheap"|"premium", "classification": ...}`` so a live-probe
+    or re-audit can feed a batch of representative messages and see exactly what
+    each would route to, without mocking config or the pre_llm_call plumbing.
+    ``signals`` accepts the same kwargs as the hook (e.g. ``platform="cron"``,
+    ``is_public_facing=True``).
+    """
+    sig = _signals_from_kwargs(user_message=message, **signals)
+    return {"tier": decide_tier(sig), "classification": classify_turn(sig)}
 
 
 def _reason_line(model: Any, provider: Any, reason: str) -> str:
@@ -123,24 +115,25 @@ def on_pre_llm_call(**kwargs: Any) -> Optional[dict]:
             return None
 
         sig = _signals_from_kwargs(**kwargs)
-        # Task-TYPE routing (adopted from PR #43534): classify the turn into one
-        # of five task types, then map to a fleet tier (fail open to premium).
-        # Public-facing dominates — handled inside tier selection below.
-        if sig.is_public_facing:
-            task_type = classify_task_type(sig)
-            tier = TIER_PREMIUM  # never cheap-route public-facing
-        else:
-            task_type = classify_task_type(sig)
-            tier = tier_for_task_type(task_type)
-        reason = f"{_task_label(task_type)} → {tier}"
+
+        # THE routing decision — deliberately SIMPLE (the classifier is not the
+        # contribution; the interface extension is). decide_tier() gates cheap on
+        # the CONSERVATIVE binary classifier: cheap ONLY on a confident MECHANICAL,
+        # else premium. No catch-all-to-cheap.
+        tier = decide_tier(sig)
+
+        # Reason line reflects the ACTUAL decider (the binary classification), so
+        # the label never disagrees with the tier.
+        classification = classify_turn(sig)  # mechanical | judgment | uncertain
+        reason = f"{classification} → {tier}"
 
         line = _reason_line(kwargs.get("model"), kwargs.get("provider"), reason)
         result: dict = {"context": line}
 
         # Emit a `route` override ONLY for the cheap tier — this is what the
         # runtime's routing-override extension (agent/routing_override.py)
-        # actuates. Premium/fail-open turns emit no override and stay on the
-        # configured primary. Never route public-facing to cheap.
+        # actuates. Premium / fail-open turns emit no override and stay on the
+        # configured primary.
         if tier == TIER_CHEAP:
             cheap_model, cheap_provider = cheap_tier_target()
             if cheap_model:

--- a/tests/agent/test_routing_override.py
+++ b/tests/agent/test_routing_override.py
@@ -87,15 +87,25 @@ def test_apply_actuates_the_swap():
     agent.switch_model.assert_called_once()
 
 
-def test_apply_is_turn_scoped():
-    """After applying, _primary_runtime must still point at the CONFIGURED primary
-    and _fallback_activated must be armed, so restore_primary_runtime reverts the
-    swap next turn (proactive routing is turn-scoped, like reactive fallback)."""
+def test_apply_is_turn_scoped_with_dedicated_flag():
+    """After applying, scoping uses a DEDICATED flag — NOT reactive-fallback state.
+
+    _primary_runtime stays == cheap (so in-turn recovery paths don't jump tiers),
+    the premium snapshot is stashed for the revert, _routing_override_active is
+    set, and _fallback_activated is left untouched (arming it would corrupt
+    reactive cooldown accounting — audit Major 3)."""
     agent = _fake_agent()
     apply_routing_override(agent, {"model": "deepseek/deepseek-v3.2",
                                    "provider": "openrouter"})
-    assert agent._primary_runtime == {"model": "claude-sonnet-5", "provider": "anthropic"}
-    assert agent._fallback_activated is True
+    # _primary_runtime is the CHEAP runtime during the routed turn.
+    assert agent._primary_runtime == {"model": "deepseek/deepseek-v3.2",
+                                      "provider": "openrouter"}
+    # The premium snapshot is stashed for restore_primary_runtime to revert.
+    assert agent._routing_override_saved_primary == {"model": "claude-sonnet-5",
+                                                     "provider": "anthropic"}
+    assert agent._routing_override_active is True
+    # Reactive-fallback state is NOT touched.
+    assert agent._fallback_activated is False
 
 
 def test_apply_noop_when_target_equals_current():

--- a/tests/agent/test_routing_override.py
+++ b/tests/agent/test_routing_override.py
@@ -1,0 +1,128 @@
+"""Tests for the pre-turn routing-override interface extension.
+
+This is the minimal reference implementation of the plugin-interface extension
+teknium1 offered on PR #43534: a ``pre_llm_call`` hook result may carry a
+``{"route": {"model": ..., "provider": ...}}`` override that the runtime applies
+BEFORE the turn's client is built — turning a plugin routing DECISION into an
+actual model swap.
+
+Design (see agent/routing_override.py):
+  - ``extract_routing_override(results)`` pulls the first well-formed override
+    out of the list of pre_llm_call hook results.
+  - ``apply_routing_override(agent, override)`` actuates the swap by delegating
+    to the agent's existing, tested ``switch_model`` machinery, then makes the
+    swap TURN-SCOPED (reverted next turn by ``restore_primary_runtime``) by
+    restoring the pre-swap ``_primary_runtime`` snapshot and arming
+    ``_fallback_activated``. Fail-safe: any error leaves the agent untouched.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.routing_override import (
+    apply_routing_override,
+    extract_routing_override,
+)
+
+
+# ------------------------------------------------ extract_routing_override ----
+
+def test_extract_none_when_no_results():
+    assert extract_routing_override([]) is None
+
+
+def test_extract_none_when_only_context():
+    results = [{"context": "[Current model: x]"}, "some string"]
+    assert extract_routing_override(results) is None
+
+
+def test_extract_pulls_route_dict():
+    results = [{"context": "line", "route": {"model": "deepseek/deepseek-v3.2",
+                                             "provider": "openrouter"}}]
+    ov = extract_routing_override(results)
+    assert ov == {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}
+
+
+def test_extract_requires_model_key():
+    # A route dict with no model is not actionable.
+    assert extract_routing_override([{"route": {"provider": "openrouter"}}]) is None
+
+
+def test_extract_first_wins():
+    results = [
+        {"route": {"model": "a", "provider": "p1"}},
+        {"route": {"model": "b", "provider": "p2"}},
+    ]
+    assert extract_routing_override(results)["model"] == "a"
+
+
+# ------------------------------------------------- apply_routing_override -----
+
+def _fake_agent():
+    agent = MagicMock()
+    agent.model = "claude-sonnet-5"
+    agent.provider = "anthropic"
+    agent._primary_runtime = {"model": "claude-sonnet-5", "provider": "anthropic"}
+    agent._fallback_activated = False
+
+    # switch_model mutates model/provider like the real one, and (like the real
+    # one) would persist _primary_runtime — we assert the override code re-scopes.
+    def _switch(new_model, new_provider, **kw):
+        agent.model = new_model
+        agent.provider = new_provider
+        agent._primary_runtime = {"model": new_model, "provider": new_provider}
+        return {"ok": True}
+
+    agent.switch_model.side_effect = _switch
+    return agent
+
+
+def test_apply_actuates_the_swap():
+    agent = _fake_agent()
+    ok = apply_routing_override(agent, {"model": "deepseek/deepseek-v3.2",
+                                        "provider": "openrouter"})
+    assert ok is True
+    assert agent.model == "deepseek/deepseek-v3.2"
+    assert agent.provider == "openrouter"
+    agent.switch_model.assert_called_once()
+
+
+def test_apply_is_turn_scoped():
+    """After applying, _primary_runtime must still point at the CONFIGURED primary
+    and _fallback_activated must be armed, so restore_primary_runtime reverts the
+    swap next turn (proactive routing is turn-scoped, like reactive fallback)."""
+    agent = _fake_agent()
+    apply_routing_override(agent, {"model": "deepseek/deepseek-v3.2",
+                                   "provider": "openrouter"})
+    assert agent._primary_runtime == {"model": "claude-sonnet-5", "provider": "anthropic"}
+    assert agent._fallback_activated is True
+
+
+def test_apply_noop_when_target_equals_current():
+    """No swap when the override already matches the live model (avoid churn)."""
+    agent = _fake_agent()
+    ok = apply_routing_override(agent, {"model": "claude-sonnet-5",
+                                        "provider": "anthropic"})
+    assert ok is False
+    agent.switch_model.assert_not_called()
+    # _fallback_activated untouched — nothing was swapped.
+    assert agent._fallback_activated is False
+
+
+def test_apply_fail_safe_on_switch_error():
+    """If switch_model raises, the agent is left untouched and we return False."""
+    agent = _fake_agent()
+    agent.switch_model.side_effect = RuntimeError("bad key")
+    ok = apply_routing_override(agent, {"model": "deepseek/deepseek-v3.2",
+                                        "provider": "openrouter"})
+    assert ok is False
+    # Original model/provider preserved (switch_model itself rolls back; the
+    # applier must not leave a half-state or re-raise into the turn loop).
+    assert agent.model == "claude-sonnet-5"
+
+
+def test_apply_ignores_empty_override():
+    agent = _fake_agent()
+    assert apply_routing_override(agent, {}) is False
+    assert apply_routing_override(agent, None) is False
+    agent.switch_model.assert_not_called()

--- a/tests/agent/test_routing_override_revert.py
+++ b/tests/agent/test_routing_override_revert.py
@@ -1,0 +1,153 @@
+"""Regression tests driving the REAL restore_primary_runtime after a routing
+override — the error-adjacent paths the fake-agent unit tests missed.
+
+Covers the three CONFIRMED audit blockers:
+  BLOCKER 1 — cheap model must not leak past its turn when the primary is in
+              rate-limit cooldown (restore_primary_runtime's cooldown early-return
+              gate must NOT skip an override revert).
+  MAJOR 2  — during the routed turn, _primary_runtime must point at the CHEAP
+             runtime, so in-turn transient-transport recovery rebuilds cheap, not
+             premium.
+  MAJOR 3  — the override must NOT pre-arm _fallback_activated, so a cheap-model
+             429 arms its own cooldown correctly (fallback accounting intact).
+
+These drive the real ``restore_primary_runtime`` (not a fake) so they prove the
+revert actually happens, not merely that preconditions were set.
+"""
+import time
+
+import pytest
+
+from agent.agent_runtime_helpers import restore_primary_runtime
+from agent.routing_override import apply_routing_override
+
+
+class _Comp:
+    def update_model(self, **kw):
+        self.__dict__.update(kw)
+    model = "x"; base_url = ""; api_key = ""; provider = "anthropic"
+    context_length = 200000; api_mode = ""; threshold_tokens = 0
+
+
+def _premium_runtime():
+    return {
+        "model": "claude-sonnet-5", "provider": "anthropic", "base_url": "",
+        "api_mode": "anthropic_messages", "api_key": "pk", "client_kwargs": {},
+        "use_prompt_caching": True, "use_native_cache_layout": True,
+        "anthropic_api_key": "pk", "anthropic_base_url": "", "is_anthropic_oauth": False,
+        "compressor_model": "claude-sonnet-5", "compressor_base_url": "",
+        "compressor_api_key": "pk", "compressor_provider": "anthropic",
+        "compressor_context_length": 200000, "compressor_api_mode": "anthropic_messages",
+        "compressor_threshold_tokens": 0,
+    }
+
+
+def _make_agent():
+    class A:
+        pass
+    a = A()
+    a.model = "claude-sonnet-5"; a.provider = "anthropic"; a.base_url = ""
+    a.api_mode = "anthropic_messages"; a.api_key = "pk"; a.client = None
+    a._anthropic_client = "AC"; a._anthropic_api_key = "pk"; a._anthropic_base_url = ""
+    a._is_anthropic_oauth = False; a._client_kwargs = {}; a._use_prompt_caching = True
+    a._use_native_cache_layout = True; a._transport_cache = {}
+    a._fallback_activated = False; a._fallback_index = 0; a._fallback_chain = []
+    a._rate_limited_until = 0; a._credential_pool = None
+    a.context_compressor = _Comp()
+    a._primary_runtime = _premium_runtime()
+
+    def switch(nm, np, **kw):
+        a.model = nm; a.provider = np; a.api_mode = "chat_completions"
+        a.base_url = "https://cheap/v1"; a.api_key = "ck"; a.client = "CHEAP"
+        a._anthropic_client = None
+        a._client_kwargs = {"api_key": "ck", "base_url": a.base_url}
+        a._use_prompt_caching = False; a._use_native_cache_layout = False
+        # switch_model persists the cheap runtime into _primary_runtime.
+        a._primary_runtime = {
+            "model": nm, "provider": np, "base_url": a.base_url, "api_mode": a.api_mode,
+            "api_key": "ck", "client_kwargs": dict(a._client_kwargs),
+            "use_prompt_caching": False, "use_native_cache_layout": False,
+            "compressor_model": nm, "compressor_base_url": a.base_url,
+            "compressor_api_key": "ck", "compressor_provider": np,
+            "compressor_context_length": 128000, "compressor_api_mode": a.api_mode,
+            "compressor_threshold_tokens": 0,
+        }
+        a._fallback_activated = False; a._fallback_index = 0
+
+    a.switch_model = switch
+    a._create_openai_client = lambda kw, reason="", shared=True: "REBUILT"
+    return a
+
+
+# ─────────────────────────── BLOCKER 1: the leak repro ───────────────────────
+
+def test_routed_cheap_model_reverts_even_when_primary_in_cooldown():
+    """The auditor's leak repro, now expected to PASS: a routed cheap turn must
+    revert to premium next turn even if a rate-limit cooldown is armed."""
+    a = _make_agent()
+    apply_routing_override(a, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"})
+    assert a.model == "deepseek/deepseek-v3.2"
+
+    # Cheap model 429'd this turn, arming a primary cooldown:
+    a._rate_limited_until = time.monotonic() + 60
+
+    # Next turn's top-of-loop restore MUST revert despite the cooldown gate.
+    restore_primary_runtime(a)
+    assert a.model == "claude-sonnet-5", f"LEAK: turn2 answered by {a.model}"
+    assert a.provider == "anthropic"
+    # _primary_runtime is back to premium and the override flag is cleared.
+    assert a._primary_runtime["model"] == "claude-sonnet-5"
+    assert getattr(a, "_routing_override_active", False) is False
+
+
+def test_revert_happens_with_no_cooldown_too():
+    """Baseline: revert also works on the ordinary (no-cooldown) path."""
+    a = _make_agent()
+    apply_routing_override(a, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"})
+    restore_primary_runtime(a)
+    assert a.model == "claude-sonnet-5"
+    assert getattr(a, "_routing_override_active", False) is False
+
+
+# ─────────────────── MAJOR 2: _primary_runtime = cheap in-turn ───────────────
+
+def test_primary_runtime_points_at_cheap_during_routed_turn():
+    """During the routed turn, _primary_runtime must be the CHEAP runtime so
+    in-turn transient-transport recovery (which rebuilds from _primary_runtime)
+    stays on cheap and does not jump to premium."""
+    a = _make_agent()
+    apply_routing_override(a, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"})
+    # Mid-turn, before the next-turn restore:
+    assert a._primary_runtime["model"] == "deepseek/deepseek-v3.2"
+    assert a._primary_runtime["provider"] == "openrouter"
+    # The saved premium snapshot is stashed separately for the revert.
+    assert a._routing_override_saved_primary["model"] == "claude-sonnet-5"
+
+
+# ─────────────────── MAJOR 3: _fallback_activated NOT pre-armed ──────────────
+
+def test_override_does_not_prearm_fallback_activated():
+    """The override must not set _fallback_activated — that flag carries reactive
+    cooldown-accounting semantics (chat_completion_helpers:1195-1198)."""
+    a = _make_agent()
+    apply_routing_override(a, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"})
+    assert a._fallback_activated is False
+    assert a._routing_override_active is True
+
+
+def test_reactive_fallback_engages_under_a_routed_turn():
+    """Reactive fallback must still work UNDERNEATH a routed turn: if the cheap
+    model fails mid-turn, try_activate_fallback treats cheap as the current
+    'primary' (since _primary_runtime == cheap and _fallback_activated is False)
+    and arms the cheap-provider cooldown correctly."""
+    from agent.chat_completion_helpers import try_activate_fallback  # noqa: F401
+    from agent.error_classifier import FailoverReason
+
+    a = _make_agent()
+    apply_routing_override(a, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"})
+    # Empty chain -> exhausted, but the rate_limit branch must still arm cooldown
+    # because _fallback_activated is False and current provider == the (cheap)
+    # _primary_runtime provider.
+    before = getattr(a, "_rate_limited_until", 0)
+    try_activate_fallback(a, reason=FailoverReason.rate_limit)
+    assert a._rate_limited_until > before, "cheap 429 must arm a cooldown"

--- a/tests/plugins/intelligent_routing/test_classifier.py
+++ b/tests/plugins/intelligent_routing/test_classifier.py
@@ -1,0 +1,134 @@
+"""Tests for the intelligent-routing pre-turn classifier (Option A — heuristic).
+
+The classifier is a PURE function: given cheap local signals available before the
+LLM call (message text/length, tool-call context from recent turns, whether the
+turn is a background/cron/non-interactive job vs a live human chat, and whether
+the request is kanban-triage-shaped), it returns one of:
+
+    "mechanical" -> route to the cheap-metered tier (OpenRouter workhorse)
+    "judgment"   -> route to the premium (Claude-class) tier
+    "uncertain"  -> FAIL OPEN to premium (never silently downgrade a judgment turn)
+
+`route_for()` collapses (mechanical -> cheap, judgment/uncertain -> premium),
+mirroring the fail-open discipline of HSM's ``validateCascadeEntries``.
+"""
+import pytest
+
+from plugins.intelligent_routing.classifier import (
+    classify_turn,
+    route_for,
+    TurnSignals,
+    MECHANICAL,
+    JUDGMENT,
+    UNCERTAIN,
+    TIER_CHEAP,
+    TIER_PREMIUM,
+)
+
+
+# ---------------------------------------------------------------- mechanical ---
+
+def test_cron_background_job_is_mechanical():
+    """Non-interactive cron/background jobs are mechanical by definition."""
+    sig = TurnSignals(user_message="run the nightly digest", is_interactive=False,
+                      is_background=True)
+    assert classify_turn(sig) == MECHANICAL
+
+
+def test_short_single_tool_ask_is_mechanical():
+    """A short, single-tool-call-shaped ask is mechanical."""
+    sig = TurnSignals(user_message="mark card 42 done", is_interactive=True,
+                      expects_multi_step=False)
+    assert classify_turn(sig) == MECHANICAL
+
+
+def test_kanban_triage_shaped_request_is_mechanical():
+    """Kanban-triage-shaped requests are mechanical (per D-2026-07-08-01)."""
+    sig = TurnSignals(user_message="triage the backlog and assign priorities",
+                      is_interactive=True, is_kanban_triage=True)
+    assert classify_turn(sig) == MECHANICAL
+
+
+def test_short_mechanical_ask_routes_cheap():
+    sig = TurnSignals(user_message="what's 2+2", is_interactive=True)
+    assert route_for(sig) == TIER_CHEAP
+
+
+# ------------------------------------------------------------------ judgment ---
+
+def test_open_ended_chat_is_judgment():
+    """Open-ended, multi-step reasoning is a judgment turn."""
+    sig = TurnSignals(
+        user_message=(
+            "Think through the tradeoffs between our OpenRouter cheap tier and "
+            "keeping Sonnet primary, and recommend an approach with reasoning."
+        ),
+        is_interactive=True,
+        expects_multi_step=True,
+    )
+    assert classify_turn(sig) == JUDGMENT
+
+
+def test_public_facing_turn_is_judgment():
+    """Anything public-facing must go premium (visible quality matters)."""
+    sig = TurnSignals(user_message="draft the launch announcement", is_interactive=True,
+                      is_public_facing=True)
+    assert classify_turn(sig) == JUDGMENT
+
+
+def test_long_message_is_judgment():
+    """A long, substantive human message is judgment, not mechanical."""
+    long_msg = "Here is the situation. " * 60  # well over the mechanical length cap
+    sig = TurnSignals(user_message=long_msg, is_interactive=True)
+    assert classify_turn(sig) == JUDGMENT
+
+
+def test_judgment_turn_routes_premium():
+    sig = TurnSignals(user_message="weigh the options and decide", is_interactive=True,
+                      expects_multi_step=True)
+    assert route_for(sig) == TIER_PREMIUM
+
+
+# ------------------------------------------------ uncertain -> fail open -------
+
+def test_empty_message_is_uncertain():
+    """No signal to classify on -> uncertain."""
+    sig = TurnSignals(user_message="", is_interactive=True)
+    assert classify_turn(sig) == UNCERTAIN
+
+
+def test_uncertain_fails_open_to_premium():
+    """Uncertain MUST route premium — never silently downgrade a judgment turn."""
+    sig = TurnSignals(user_message="", is_interactive=True)
+    assert route_for(sig) == TIER_PREMIUM
+
+
+def test_ambiguous_midlength_interactive_fails_open():
+    """A medium interactive message that trips no mechanical signal fails open."""
+    # Not short enough to be mechanical, not clearly multi-step/public-facing.
+    sig = TurnSignals(
+        user_message="Can you look at the thing we discussed and get back to me?",
+        is_interactive=True,
+    )
+    assert route_for(sig) in (TIER_PREMIUM,)  # fail-open, never cheap on ambiguity
+
+
+def test_public_facing_beats_short_length():
+    """Public-facing dominates even a short message — never cheap-route it."""
+    sig = TurnSignals(user_message="ship it", is_interactive=True, is_public_facing=True)
+    assert route_for(sig) == TIER_PREMIUM
+
+
+# -------------------------------------------------------- purity / determinism -
+
+def test_classifier_is_pure_and_deterministic():
+    sig = TurnSignals(user_message="mark card 42 done", is_interactive=True)
+    assert classify_turn(sig) == classify_turn(sig)
+
+
+def test_route_for_only_returns_known_tiers():
+    for msg in ("", "x", "triage backlog", "a" * 5000):
+        assert route_for(TurnSignals(user_message=msg, is_interactive=True)) in (
+            TIER_CHEAP,
+            TIER_PREMIUM,
+        )

--- a/tests/plugins/intelligent_routing/test_classifier.py
+++ b/tests/plugins/intelligent_routing/test_classifier.py
@@ -50,8 +50,22 @@ def test_kanban_triage_shaped_request_is_mechanical():
 
 
 def test_short_mechanical_ask_routes_cheap():
-    sig = TurnSignals(user_message="what's 2+2", is_interactive=True)
+    # A short ask with a leading imperative verb is mechanical -> cheap.
+    sig = TurnSignals(user_message="list open PRs", is_interactive=True)
     assert route_for(sig) == TIER_CHEAP
+
+
+def test_trivial_query_prefix_is_not_cheap():
+    """"what's/how many/when is" prefixes front real judgment questions — they must
+    fail open to premium, not cheap-route just because they're short. (A genuinely
+    trivial "what's 2+2" going premium is harmless.)"""
+    for msg in (
+        "what's 2+2",
+        "what's the best architecture for this?",
+        "when is it worth adding a cache layer?",
+    ):
+        sig = TurnSignals(user_message=msg, is_interactive=True)
+        assert route_for(sig) == TIER_PREMIUM, msg
 
 
 # ------------------------------------------------------------------ judgment ---

--- a/tests/plugins/intelligent_routing/test_config.py
+++ b/tests/plugins/intelligent_routing/test_config.py
@@ -1,0 +1,59 @@
+"""Tests for intelligent-routing per-agent config (default OFF — opt-in)."""
+from unittest.mock import patch
+
+from plugins.intelligent_routing import config as cfgmod
+
+
+def test_default_is_off():
+    """No config -> intelligent routing is OFF (opt-in, changes visible behavior)."""
+    with patch.object(cfgmod, "_load_config", return_value={}):
+        assert cfgmod.is_intelligent_routing_enabled() is False
+
+
+def test_missing_routing_section_is_off():
+    with patch.object(cfgmod, "_load_config", return_value={"auxiliary": {}}):
+        assert cfgmod.is_intelligent_routing_enabled() is False
+
+
+def test_explicit_true_enables():
+    with patch.object(cfgmod, "_load_config",
+                      return_value={"routing": {"intelligent": True}}):
+        assert cfgmod.is_intelligent_routing_enabled() is True
+
+
+def test_explicit_false_disables():
+    with patch.object(cfgmod, "_load_config",
+                      return_value={"routing": {"intelligent": False}}):
+        assert cfgmod.is_intelligent_routing_enabled() is False
+
+
+def test_truthy_string_enables():
+    for val in ("true", "1", "yes", "on", "True"):
+        with patch.object(cfgmod, "_load_config",
+                          return_value={"routing": {"intelligent": val}}):
+            assert cfgmod.is_intelligent_routing_enabled() is True, val
+
+
+def test_falsy_string_disables():
+    for val in ("false", "0", "no", "off", ""):
+        with patch.object(cfgmod, "_load_config",
+                          return_value={"routing": {"intelligent": val}}):
+            assert cfgmod.is_intelligent_routing_enabled() is False, val
+
+
+def test_config_load_failure_fails_off():
+    """If config can't be read, default OFF (never silently change behavior)."""
+    with patch.object(cfgmod, "_load_config", side_effect=Exception("boom")):
+        assert cfgmod.is_intelligent_routing_enabled() is False
+
+
+def test_mode_defaults_to_heuristic():
+    """routing.mode defaults to 'heuristic' (Option A); llm-router is Phase 2."""
+    with patch.object(cfgmod, "_load_config", return_value={"routing": {}}):
+        assert cfgmod.routing_mode() == "heuristic"
+
+
+def test_mode_llm_router_is_read():
+    with patch.object(cfgmod, "_load_config",
+                      return_value={"routing": {"mode": "llm-router"}}):
+        assert cfgmod.routing_mode() == "llm-router"

--- a/tests/plugins/intelligent_routing/test_config.py
+++ b/tests/plugins/intelligent_routing/test_config.py
@@ -57,3 +57,20 @@ def test_mode_llm_router_is_read():
     with patch.object(cfgmod, "_load_config",
                       return_value={"routing": {"mode": "llm-router"}}):
         assert cfgmod.routing_mode() == "llm-router"
+
+
+def test_cheap_tier_default_is_deepseek_v32_openrouter():
+    """Default cheap target is deepseek/deepseek-v3.2 via openrouter (NOT v4)."""
+    with patch.object(cfgmod, "_load_config", return_value={"routing": {}}):
+        model, provider = cfgmod.cheap_tier_target()
+    assert model == "deepseek/deepseek-v3.2"
+    assert provider == "openrouter"
+
+
+def test_cheap_tier_overridable():
+    with patch.object(cfgmod, "_load_config", return_value={
+        "routing": {"cheap_model": "qwen/qwen-2.5", "cheap_provider": "ollama"}
+    }):
+        model, provider = cfgmod.cheap_tier_target()
+    assert model == "qwen/qwen-2.5"
+    assert provider == "ollama"

--- a/tests/plugins/intelligent_routing/test_end_to_end_actuation.py
+++ b/tests/plugins/intelligent_routing/test_end_to_end_actuation.py
@@ -1,0 +1,104 @@
+"""End-to-end: plugin routing DECISION -> actual model SWAP, turn-scoped.
+
+Proves the whole chain the coordinator asked for:
+  plugin.on_pre_llm_call() returns a `route` override
+    -> extract_routing_override() pulls it (as turn_context does)
+    -> apply_routing_override() actuates the swap via the agent's switch_model
+    -> the swap is turn-scoped (primary snapshot restored, fallback armed).
+
+Uses a fake agent that mimics switch_model's field mutation, so we exercise the
+real plugin + real routing_override glue without a live model/provider.
+"""
+from unittest.mock import MagicMock, patch
+
+from agent.routing_override import apply_routing_override, extract_routing_override
+from plugins.intelligent_routing import registration
+
+
+def _fake_agent(model="claude-sonnet-5", provider="anthropic"):
+    agent = MagicMock()
+    agent.model = model
+    agent.provider = provider
+    agent._primary_runtime = {"model": model, "provider": provider}
+    agent._fallback_activated = False
+
+    def _switch(new_model, new_provider, **kw):
+        agent.model = new_model
+        agent.provider = new_provider
+        agent._primary_runtime = {"model": new_model, "provider": new_provider}
+
+    agent.switch_model.side_effect = _switch
+    return agent
+
+
+def _run_hook(user_message, **kw):
+    """Invoke the plugin hook with routing enabled; return the list of results
+    the way turn_context collects them from invoke_hook."""
+    with patch(
+        "plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+        return_value=True,
+    ):
+        result = registration.on_pre_llm_call(
+            user_message=user_message, model="claude-sonnet-5",
+            provider="anthropic", platform="cli", **kw,
+        )
+    return [result]
+
+
+def test_mechanical_turn_swaps_to_cheap_end_to_end():
+    agent = _fake_agent()
+    results = _run_hook("grep for TODO in the repo")
+
+    override = extract_routing_override(results)
+    assert override == {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}
+
+    swapped = apply_routing_override(agent, override)
+    assert swapped is True
+    # The agent is now on the cheap tier for THIS turn.
+    assert agent.model == "deepseek/deepseek-v3.2"
+    assert agent.provider == "openrouter"
+    # ...but turn-scoped: primary snapshot preserved + fallback armed so the
+    # next turn's restore_primary_runtime reverts it.
+    assert agent._primary_runtime == {"model": "claude-sonnet-5", "provider": "anthropic"}
+    assert agent._fallback_activated is True
+
+
+def test_judgment_turn_does_not_swap_end_to_end():
+    agent = _fake_agent()
+    results = _run_hook("design a system for multi-tenant routing across the fleet")
+
+    override = extract_routing_override(results)
+    assert override is None  # premium -> no route emitted
+
+    swapped = apply_routing_override(agent, override)
+    assert swapped is False
+    assert agent.model == "claude-sonnet-5"  # untouched
+    agent.switch_model.assert_not_called()
+
+
+def test_public_facing_never_swaps_end_to_end():
+    agent = _fake_agent()
+    results = _run_hook("grep the announcement", is_public_facing=True)
+    override = extract_routing_override(results)
+    assert override is None
+    assert apply_routing_override(agent, override) is False
+    assert agent.model == "claude-sonnet-5"
+
+
+def test_disabled_plugin_emits_nothing_to_actuate():
+    agent = _fake_agent()
+    # Toggle OFF -> hook returns None -> nothing to extract/apply.
+    result = registration.on_pre_llm_call(
+        user_message="grep for TODO", model="claude-sonnet-5", platform="cli",
+    )
+    with patch(
+        "plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+        return_value=False,
+    ):
+        result = registration.on_pre_llm_call(
+            user_message="grep for TODO", model="claude-sonnet-5", platform="cli",
+        )
+    assert result is None
+    assert extract_routing_override([result]) is None
+    assert apply_routing_override(agent, None) is False
+    assert agent.model == "claude-sonnet-5"

--- a/tests/plugins/intelligent_routing/test_end_to_end_actuation.py
+++ b/tests/plugins/intelligent_routing/test_end_to_end_actuation.py
@@ -57,10 +57,15 @@ def test_mechanical_turn_swaps_to_cheap_end_to_end():
     # The agent is now on the cheap tier for THIS turn.
     assert agent.model == "deepseek/deepseek-v3.2"
     assert agent.provider == "openrouter"
-    # ...but turn-scoped: primary snapshot preserved + fallback armed so the
-    # next turn's restore_primary_runtime reverts it.
-    assert agent._primary_runtime == {"model": "claude-sonnet-5", "provider": "anthropic"}
-    assert agent._fallback_activated is True
+    # ...turn-scoped via a DEDICATED flag: _primary_runtime stays cheap (so
+    # in-turn recovery stays on cheap), the premium snapshot is stashed for the
+    # revert, and reactive-fallback state is untouched. (The actual next-turn
+    # revert against the real restore_primary_runtime is proven in
+    # tests/agent/test_routing_override_revert.py.)
+    assert agent._routing_override_active is True
+    assert agent._routing_override_saved_primary == {"model": "claude-sonnet-5",
+                                                     "provider": "anthropic"}
+    assert agent._fallback_activated is False
 
 
 def test_judgment_turn_does_not_swap_end_to_end():

--- a/tests/plugins/intelligent_routing/test_realistic_distribution.py
+++ b/tests/plugins/intelligent_routing/test_realistic_distribution.py
@@ -54,6 +54,15 @@ PREMIUM_MESSAGES = [
     "Think through the tradeoffs between OpenRouter and z.ai and recommend an approach.",
     # a plain question with no mechanical shape
     "Why is the deploy flaky lately?",
+    # SHORT judgment questions fronted by a trivial-query prefix — these are the
+    # round-3 leak: "what's/what is/how many/when is" prefixes routinely front
+    # real judgment questions and must NOT be cheap-routed just because they're
+    # short. Dropping _TRIVIAL_QUERY_PREFIXES fixes this (fail open to premium).
+    "what's the best architecture for this?",
+    "what's the right way to handle auth here?",
+    "whats your opinion on the design?",
+    "how many ways could this deadlock?",
+    "when is it worth adding a cache layer?",
 ]
 
 # Messages that SHOULD route cheap — confidently mechanical only.

--- a/tests/plugins/intelligent_routing/test_realistic_distribution.py
+++ b/tests/plugins/intelligent_routing/test_realistic_distribution.py
@@ -1,0 +1,124 @@
+"""Realistic-distribution test — the gap the unit tests + audit missed.
+
+The live deploy found that `classify_task_type`'s catch-all default
+(`TASK_ORCHESTRATION → cheap`) silently cheap-routed hard architecture questions,
+multi-file code-gen requests, and hedged/ambiguous asks — violating the
+"fail open to premium" guarantee. The prior tests only checked the tier MAPPING
+(`tier_for_task_type(ARCHITECTURE) == premium`) in isolation, never that real
+messages get ASSIGNED premium.
+
+This test feeds a batch of REPRESENTATIVE messages through the FULL
+`on_pre_llm_call` path and asserts what actually gets routed (the emitted `route`
+override, or its absence) — not an explicit-type mapping.
+
+Invariant: only a CONFIDENTLY mechanical turn emits a cheap `route`. Everything
+judgment / architecture / code-gen / uncertain / hedged / public-facing emits NO
+route (stays on the configured primary).
+"""
+from unittest.mock import patch
+
+import pytest
+
+from plugins.intelligent_routing import registration
+
+
+def _route_of(message, **kwargs):
+    """Run the full hook (routing enabled) and return the emitted route dict or None."""
+    with patch(
+        "plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+        return_value=True,
+    ):
+        result = registration.on_pre_llm_call(
+            user_message=message, model="claude-sonnet-5", provider="anthropic",
+            platform=kwargs.pop("platform", "cli"), **kwargs,
+        )
+    if not isinstance(result, dict):
+        return None
+    return result.get("route")
+
+
+# Messages that MUST stay on premium (no cheap route). This is the batch the live
+# run exposed — hard architecture, real code-gen, and hedged/ambiguous asks that
+# previously fell through the orchestration catch-all onto cheap.
+PREMIUM_MESSAGES = [
+    # hard architecture
+    "How should we structure the multi-tenant routing layer so tenants stay isolated?",
+    "Design a system for multi-tenant routing across the fleet with failure isolation.",
+    # multi-file / real code-gen
+    "Write a Python function that merges two sorted linked lists.",
+    "Implement the retry logic in agent/chat_completion_helpers.py and open a PR.",
+    # ambiguous / hedged
+    "Can you look at the thing we discussed and get back to me?",
+    "Not sure how to approach this — what do you think we should do about the parser?",
+    # open-ended reasoning
+    "Think through the tradeoffs between OpenRouter and z.ai and recommend an approach.",
+    # a plain question with no mechanical shape
+    "Why is the deploy flaky lately?",
+]
+
+# Messages that SHOULD route cheap — confidently mechanical only.
+CHEAP_MESSAGES = [
+    "grep for TODO in the repo",
+    "list the files in plugins/",
+    "mark card 42 done",
+    "run the tests",
+]
+
+
+@pytest.mark.parametrize("message", PREMIUM_MESSAGES)
+def test_premium_messages_never_cheap_routed(message):
+    assert _route_of(message) is None, f"LEAK: {message!r} was cheap-routed"
+
+
+@pytest.mark.parametrize("message", CHEAP_MESSAGES)
+def test_confident_mechanical_messages_cheap_routed(message):
+    route = _route_of(message)
+    assert route is not None, f"expected cheap route for {message!r}"
+    assert route["model"] == "deepseek/deepseek-v3.2"
+
+
+def test_background_cron_job_cheap_routed():
+    """A non-interactive/background job is confidently mechanical -> cheap."""
+    assert _route_of("run the nightly digest", platform="cron") is not None
+
+
+def test_public_facing_never_cheap_routed():
+    """Public-facing dominates even a mechanical-shaped message."""
+    assert _route_of("grep the announcement", is_public_facing=True) is None
+
+
+def test_empty_message_fails_open_to_premium():
+    assert _route_of("") is None
+
+
+def test_distribution_bias_is_conservative():
+    """Sanity on the whole batch: the premium set emits zero cheap routes, and the
+    cheap set emits only cheap routes — the safe asymmetry."""
+    assert all(_route_of(m) is None for m in PREMIUM_MESSAGES)
+    assert all(_route_of(m) is not None for m in CHEAP_MESSAGES)
+
+
+# ------------------------------------------------- isolation probe (re-audit) --
+
+def test_probe_route_matches_hook_decision():
+    """probe_route() is a config-free, plumbing-free view of the SAME decision the
+    hook makes — for the live-probe / re-audit."""
+    from plugins.intelligent_routing.registration import probe_route
+
+    for m in PREMIUM_MESSAGES:
+        assert probe_route(m)["tier"] == "premium", m
+    for m in CHEAP_MESSAGES:
+        assert probe_route(m)["tier"] == "cheap", m
+    # signal passthrough
+    assert probe_route("run the nightly digest", platform="cron")["tier"] == "cheap"
+    assert probe_route("grep the announcement", is_public_facing=True)["tier"] == "premium"
+
+
+def test_decide_tier_is_the_single_source_of_truth():
+    """decide_tier == route_for (both gate cheap on a confident MECHANICAL)."""
+    from plugins.intelligent_routing.classifier import (
+        decide_tier, route_for, TurnSignals,
+    )
+    for m in [m for m in PREMIUM_MESSAGES] + [m for m in CHEAP_MESSAGES] + [""]:
+        sig = TurnSignals(user_message=m)
+        assert decide_tier(sig) == route_for(sig), m

--- a/tests/plugins/intelligent_routing/test_registration.py
+++ b/tests/plugins/intelligent_routing/test_registration.py
@@ -39,8 +39,11 @@ def test_inert_when_disabled():
     assert result is None
 
 
-def test_mechanical_turn_injects_task_type_and_cheap_tier():
-    """A mechanical task surfaces its task type AND the cheap tier it routes to."""
+def test_mechanical_turn_injects_cheap_tier_reason():
+    """A confidently mechanical turn surfaces the cheap tier it routes to.
+
+    The reason line reflects the ACTUAL decider — the binary classification —
+    so the label never disagrees with the tier."""
     with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
                return_value=True):
         result = registration.on_pre_llm_call(
@@ -54,6 +57,7 @@ def test_mechanical_turn_injects_task_type_and_cheap_tier():
 
 
 def test_architecture_turn_routes_premium():
+    """A hard architecture question fails open to premium (binary: judgment)."""
     with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
                return_value=True):
         result = registration.on_pre_llm_call(
@@ -61,19 +65,22 @@ def test_architecture_turn_routes_premium():
             model="claude-sonnet-5", platform="cli",
         )
     ctx_text = result["context"] if isinstance(result, dict) else result
-    assert "routed: architecture → premium" in ctx_text
+    assert "→ premium" in ctx_text
+    assert "→ cheap" not in ctx_text
 
 
 def test_code_gen_turn_routes_premium():
-    """Code-gen -> premium (DeepSWE-grounded: keep coding on Claude)."""
+    """Code-gen -> premium: the binary classifier reads it as judgment (never
+    cheap), so multi-file coding stays on Claude."""
     with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
                return_value=True):
         result = registration.on_pre_llm_call(
-            user_message="implement the retry logic and open a PR",
+            user_message="Write a Python function that merges two sorted linked lists.",
             model="claude-sonnet-5", platform="cli",
         )
     ctx_text = result["context"] if isinstance(result, dict) else result
-    assert "routed: code-gen → premium" in ctx_text
+    assert "→ premium" in ctx_text
+    assert "→ cheap" not in ctx_text
 
 
 def test_uncertain_turn_fails_open_to_premium_reason():

--- a/tests/plugins/intelligent_routing/test_registration.py
+++ b/tests/plugins/intelligent_routing/test_registration.py
@@ -1,0 +1,102 @@
+"""Tests for the intelligent-routing pre_llm_call hook wiring.
+
+The hook:
+  - registers on ``pre_llm_call``,
+  - is INERT when the per-agent toggle is OFF (returns None -> zero behavior
+    change, the opt-in guarantee),
+  - when ON, classifies the turn and returns a context injection that extends
+    the model-awareness line with the routing reason, e.g.
+    ``[Current model: <model> via OpenRouter — routed: mechanical]``,
+  - fails open (routes premium / does not claim "mechanical") on uncertainty,
+  - never raises into the turn loop.
+"""
+from unittest.mock import MagicMock, patch
+
+from plugins.intelligent_routing import registration
+
+
+class FakeCtx:
+    def __init__(self):
+        self.hooks = {}
+
+    def register_hook(self, name, cb):
+        self.hooks.setdefault(name, []).append(cb)
+
+
+def test_registers_pre_llm_call_hook():
+    ctx = FakeCtx()
+    registration.register(ctx)
+    assert "pre_llm_call" in ctx.hooks
+
+
+def test_inert_when_disabled():
+    """Toggle OFF -> hook returns None (no context injected, no behavior change)."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=False):
+        result = registration.on_pre_llm_call(
+            user_message="mark card 42 done", model="claude-sonnet-5", platform="cli",
+        )
+    assert result is None
+
+
+def test_mechanical_turn_injects_routing_reason_when_enabled():
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="mark card 42 done", model="claude-sonnet-5", platform="cli",
+        )
+    assert result is not None
+    ctx_text = result["context"] if isinstance(result, dict) else result
+    assert "routed: mechanical" in ctx_text
+    assert "Current model:" in ctx_text
+
+
+def test_judgment_turn_injects_premium_reason_when_enabled():
+    long_open_ended = (
+        "Think through the tradeoffs and recommend an approach with full reasoning. "
+        * 4
+    )
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message=long_open_ended, model="claude-sonnet-5", platform="cli",
+        )
+    ctx_text = result["context"] if isinstance(result, dict) else result
+    assert "routed: judgment" in ctx_text
+
+
+def test_uncertain_turn_fails_open_to_judgment_reason():
+    """An empty message is uncertain -> reason must be judgment (fail open),
+    never 'mechanical'."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="", model="claude-sonnet-5", platform="cli",
+        )
+    ctx_text = result["context"] if isinstance(result, dict) else result
+    assert "routed: mechanical" not in ctx_text
+    assert "routed: judgment" in ctx_text
+
+
+def test_hook_never_raises_on_bad_input():
+    """Defensive: bad/missing kwargs must not raise into the turn loop."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        # No user_message, weird model type.
+        result = registration.on_pre_llm_call(model=None)
+    # Either None or a well-formed injection, but no exception.
+    assert result is None or "Current model:" in (
+        result["context"] if isinstance(result, dict) else result
+    )
+
+
+def test_background_context_classified_mechanical():
+    """A non-interactive/background platform routes mechanical when enabled."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="run nightly digest", model="claude-sonnet-5",
+            platform="cron",
+        )
+    ctx_text = result["context"] if isinstance(result, dict) else result
+    assert "routed: mechanical" in ctx_text

--- a/tests/plugins/intelligent_routing/test_registration.py
+++ b/tests/plugins/intelligent_routing/test_registration.py
@@ -39,43 +39,66 @@ def test_inert_when_disabled():
     assert result is None
 
 
-def test_mechanical_turn_injects_routing_reason_when_enabled():
+def test_mechanical_turn_injects_task_type_and_cheap_tier():
+    """A mechanical task surfaces its task type AND the cheap tier it routes to."""
     with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
                return_value=True):
         result = registration.on_pre_llm_call(
-            user_message="mark card 42 done", model="claude-sonnet-5", platform="cli",
+            user_message="grep for TODO in the repo", model="claude-sonnet-5",
+            platform="cli",
         )
     assert result is not None
     ctx_text = result["context"] if isinstance(result, dict) else result
-    assert "routed: mechanical" in ctx_text
+    assert "routed: mechanical → cheap" in ctx_text
     assert "Current model:" in ctx_text
 
 
-def test_judgment_turn_injects_premium_reason_when_enabled():
-    long_open_ended = (
-        "Think through the tradeoffs and recommend an approach with full reasoning. "
-        * 4
-    )
+def test_architecture_turn_routes_premium():
     with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
                return_value=True):
         result = registration.on_pre_llm_call(
-            user_message=long_open_ended, model="claude-sonnet-5", platform="cli",
+            user_message="design a system for multi-tenant routing across the fleet",
+            model="claude-sonnet-5", platform="cli",
         )
     ctx_text = result["context"] if isinstance(result, dict) else result
-    assert "routed: judgment" in ctx_text
+    assert "routed: architecture → premium" in ctx_text
 
 
-def test_uncertain_turn_fails_open_to_judgment_reason():
-    """An empty message is uncertain -> reason must be judgment (fail open),
-    never 'mechanical'."""
+def test_code_gen_turn_routes_premium():
+    """Code-gen -> premium (DeepSWE-grounded: keep coding on Claude)."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="implement the retry logic and open a PR",
+            model="claude-sonnet-5", platform="cli",
+        )
+    ctx_text = result["context"] if isinstance(result, dict) else result
+    assert "routed: code-gen → premium" in ctx_text
+
+
+def test_uncertain_turn_fails_open_to_premium_reason():
+    """An empty message is uncertain -> must route premium (fail open), never cheap."""
     with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
                return_value=True):
         result = registration.on_pre_llm_call(
             user_message="", model="claude-sonnet-5", platform="cli",
         )
     ctx_text = result["context"] if isinstance(result, dict) else result
-    assert "routed: mechanical" not in ctx_text
-    assert "routed: judgment" in ctx_text
+    assert "→ cheap" not in ctx_text
+    assert "→ premium" in ctx_text
+
+
+def test_public_facing_never_cheap_routed():
+    """Public-facing dominates: reason must show premium even if mechanical-shaped."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="grep the announcement", model="claude-sonnet-5",
+            platform="cli", is_public_facing=True,
+        )
+    ctx_text = result["context"] if isinstance(result, dict) else result
+    assert "→ premium" in ctx_text
+    assert "→ cheap" not in ctx_text
 
 
 def test_hook_never_raises_on_bad_input():
@@ -90,8 +113,8 @@ def test_hook_never_raises_on_bad_input():
     )
 
 
-def test_background_context_classified_mechanical():
-    """A non-interactive/background platform routes mechanical when enabled."""
+def test_background_context_classified_mechanical_cheap():
+    """A non-interactive/background platform routes mechanical → cheap when enabled."""
     with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
                return_value=True):
         result = registration.on_pre_llm_call(
@@ -99,4 +122,55 @@ def test_background_context_classified_mechanical():
             platform="cron",
         )
     ctx_text = result["context"] if isinstance(result, dict) else result
-    assert "routed: mechanical" in ctx_text
+    assert "routed: mechanical → cheap" in ctx_text
+
+
+# ------------------------------------- route override emission (actuation) ----
+
+def test_cheap_route_emits_route_override():
+    """A cheap-tier turn emits a `route` override targeting the configured cheap
+    model so the runtime can actuate the swap."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="grep for TODO", model="claude-sonnet-5", platform="cli",
+        )
+    assert isinstance(result, dict)
+    assert result.get("route") == {
+        "model": "deepseek/deepseek-v3.2", "provider": "openrouter",
+    }
+
+
+def test_premium_route_emits_no_override():
+    """A premium turn must NOT emit a route override (stay on the primary)."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="design a system for multi-tenant routing across the fleet",
+            model="claude-sonnet-5", platform="cli",
+        )
+    assert isinstance(result, dict)
+    assert "route" not in result
+
+
+def test_public_facing_emits_no_override():
+    """Public-facing never emits a cheap route override."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="grep the announcement", model="claude-sonnet-5",
+            platform="cli", is_public_facing=True,
+        )
+    assert "route" not in result
+
+
+def test_route_override_honors_config_target():
+    """The emitted override uses the per-agent configured cheap target."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True), \
+         patch("plugins.intelligent_routing.registration.cheap_tier_target",
+               return_value=("qwen/qwen-2.5", "ollama")):
+        result = registration.on_pre_llm_call(
+            user_message="grep for TODO", model="claude-sonnet-5", platform="cli",
+        )
+    assert result["route"] == {"model": "qwen/qwen-2.5", "provider": "ollama"}

--- a/tests/plugins/intelligent_routing/test_task_type.py
+++ b/tests/plugins/intelligent_routing/test_task_type.py
@@ -1,0 +1,163 @@
+"""Tests for task-TYPE classification + tier mapping (adopted from PR #43534).
+
+PR #43534 (model-task-router, closed on NousResearch/hermes-agent) routes by
+task TYPE — code-gen / hard-architecture / orchestration / research / mechanical
+— not a binary mechanical/judgment split, and grounds the mapping in DeepSWE
+reliability data (see plugins/intelligent_routing/references/deepswe-routing-data.md).
+
+We ADOPT its five task categories and its reliability principle, but ADAPT the
+tier mapping to OUR fleet's actual tiers (NOT #43534's GPT-5.4/5.5):
+
+    premium (Claude sonnet-5 / fable-5 / opus)   — hard-architecture, code-gen, research
+    cheap   (OpenRouter deepseek/deepseek-v3.2)   — orchestration, mechanical
+    local   (ollama qwen/glm)                     — floor, not auto-selected here
+
+Uncertain -> fail open to premium. Public-facing -> always premium.
+"""
+import pytest
+
+from plugins.intelligent_routing.classifier import (
+    classify_task_type,
+    tier_for_task_type,
+    route_task,
+    TurnSignals,
+    TASK_CODE_GEN,
+    TASK_ARCHITECTURE,
+    TASK_ORCHESTRATION,
+    TASK_RESEARCH,
+    TASK_MECHANICAL,
+    TASK_UNCERTAIN,
+    TIER_CHEAP,
+    TIER_PREMIUM,
+)
+
+
+# ------------------------------------------------- task-type classification ---
+
+def test_code_gen_detected():
+    for msg in (
+        "implement the retry logic in agent/chat_completion_helpers.py",
+        "fix the bug in the parser",
+        "refactor this module and open a PR",
+        "add a feature that writes the config file",
+    ):
+        assert classify_task_type(TurnSignals(user_message=msg)) == TASK_CODE_GEN, msg
+
+
+def test_architecture_detected():
+    for msg in (
+        "design a system for multi-tenant routing across the fleet",
+        "how would you structure the caching layer",
+        "do a security review of the auth flow",
+        "help with complex debugging of this distributed race condition",
+    ):
+        assert classify_task_type(TurnSignals(user_message=msg)) == TASK_ARCHITECTURE, msg
+
+
+def test_mechanical_detected():
+    for msg in (
+        "grep for TODO in the repo",
+        "run the tests",
+        "list all files in plugins/",
+        "mark card 42 done",
+    ):
+        assert classify_task_type(TurnSignals(user_message=msg)) == TASK_MECHANICAL, msg
+
+
+def test_background_job_is_mechanical_task():
+    sig = TurnSignals(user_message="nightly digest", is_background=True,
+                      is_interactive=False)
+    assert classify_task_type(sig) == TASK_MECHANICAL
+
+
+def test_kanban_triage_is_mechanical_task():
+    sig = TurnSignals(user_message="triage the backlog", is_kanban_triage=True)
+    assert classify_task_type(sig) == TASK_MECHANICAL
+
+
+def test_research_detected():
+    for msg in (
+        "research the tradeoffs between OpenRouter and z.ai",
+        "summarize this document for me",
+        "explain how the fallback chain works",
+        "look up the pricing for deepseek",
+    ):
+        assert classify_task_type(TurnSignals(user_message=msg)) == TASK_RESEARCH, msg
+
+
+def test_orchestration_is_the_catch_all():
+    """Tool/shell/nav/diagnostics/planning with no stronger signal -> orchestration."""
+    sig = TurnSignals(user_message="check the deploy status and tell me what's up")
+    assert classify_task_type(sig) == TASK_ORCHESTRATION
+
+
+def test_empty_message_is_uncertain_task():
+    assert classify_task_type(TurnSignals(user_message="")) == TASK_UNCERTAIN
+
+
+def test_code_gen_beats_mechanical_priority():
+    """Priority (per #43534): code-gen wins over a coincidental mechanical verb."""
+    # "run" is a mechanical verb but the task is implementing code.
+    sig = TurnSignals(user_message="implement and run the new migration script")
+    assert classify_task_type(sig) == TASK_CODE_GEN
+
+
+# ----------------------------------------------------------- tier mapping -----
+
+def test_architecture_maps_premium():
+    assert tier_for_task_type(TASK_ARCHITECTURE) == TIER_PREMIUM
+
+
+def test_code_gen_maps_premium():
+    """Code-gen -> premium: DeepSWE shows DeepSeek coding throughput directionally
+    lower; we keep multi-file code-gen on Claude for our fleet."""
+    assert tier_for_task_type(TASK_CODE_GEN) == TIER_PREMIUM
+
+
+def test_research_maps_premium():
+    assert tier_for_task_type(TASK_RESEARCH) == TIER_PREMIUM
+
+
+def test_orchestration_maps_cheap():
+    """Orchestration -> cheap: DeepSeek is competitive at CLI/tool orchestration
+    (Terminal-Bench 67.9% @ $0.87/1M) — the empirical basis for v3.2 here."""
+    assert tier_for_task_type(TASK_ORCHESTRATION) == TIER_CHEAP
+
+
+def test_mechanical_maps_cheap():
+    assert tier_for_task_type(TASK_MECHANICAL) == TIER_CHEAP
+
+
+def test_uncertain_maps_premium_fail_open():
+    assert tier_for_task_type(TASK_UNCERTAIN) == TIER_PREMIUM
+
+
+# --------------------------------------------------- route_task end-to-end ----
+
+def test_public_facing_forced_premium_even_if_mechanical_shaped():
+    """Public-facing dominates: never cheap-route a public-facing turn."""
+    sig = TurnSignals(user_message="run the announcement", is_public_facing=True)
+    assert route_task(sig) == TIER_PREMIUM
+
+
+def test_mechanical_turn_routes_cheap():
+    assert route_task(TurnSignals(user_message="grep for TODO")) == TIER_CHEAP
+
+
+def test_architecture_turn_routes_premium():
+    sig = TurnSignals(user_message="design the multi-tenant routing system")
+    assert route_task(sig) == TIER_PREMIUM
+
+
+def test_uncertain_turn_fails_open_premium():
+    assert route_task(TurnSignals(user_message="")) == TIER_PREMIUM
+
+
+def test_route_task_only_returns_known_tiers():
+    for msg in ("", "x", "implement foo", "grep bar", "design baz", "a" * 4000):
+        assert route_task(TurnSignals(user_message=msg)) in (TIER_CHEAP, TIER_PREMIUM)
+
+
+def test_task_type_classifier_is_deterministic():
+    sig = TurnSignals(user_message="refactor the parser and open a PR")
+    assert classify_task_type(sig) == classify_task_type(sig)


### PR DESCRIPTION
## ✅ Merge-readiness fix (round 3 — trivial-query-prefix leak)
The merge-readiness audit found a second judgment→cheap leak (different path): `_is_short_mechanical_ask` treated short messages opening with `what's / what is / how many / when is` as MECHANICAL → cheap, but those prefixes routinely front real judgment questions ("what's the best architecture for this?", "when is it worth adding a cache layer?").

**Fix:** dropped `_TRIVIAL_QUERY_PREFIXES` entirely — the short-mechanical path now requires a POSITIVE signal (a leading imperative verb). Question-shaped short asks fail open to premium. Added the 5 repro cases to the realistic-distribution PREMIUM batch (RED→GREEN). **102 plugin/override tests pass. CORE untouched (byte-identical to the audited-clean version).**


## ✅ Live-deploy fix (round 2 — catch-all-to-cheap leak)
A LIVE deploy on the cyborg agent (real image, plugin loaded, probed in-container) found the hook routed on the 5-way `classify_task_type`, whose catch-all default was `orchestration → cheap` — so hard architecture, multi-file code-gen, and hedged/uncertain asks ALL fell through to deepseek cheap. The `fail open to premium` guarantee was false in practice, and the safe binary `classify_turn` was dead code.

**Fix (simplified per Juniper's steer):** `decide_tier(sig)` now gates cheap on the CONSERVATIVE binary classifier — cheap ONLY when `classify_turn == MECHANICAL`, else PREMIUM. No catch-all-to-cheap; the default is premium. `classify_task_type` is now descriptive-only, out of the routing path. New `probe_route(message, **signals)` gives a config-free view of the decision for re-audit / re-live-test. New `test_realistic_distribution.py` feeds a representative batch through the FULL hook and asserts what actually routes (the missing regression). **96 plugin/override tests pass; no core-runtime change this round.**


**DRAFT — Stage 1 dogfood on our fork. Do not merge. Nothing submitted upstream** (NousResearch/hermes-agent) — Stage 2 needs Juniper's explicit go. Independently audited (audit round 1 complete — see "Audit response" below).

## The story: honoring how #43534 was closed
teknium1 closed upstream **PR #43534** (model-task-router) with a steer, not a merits rejection:
> *"If you do want it, please create a plugin. Happy to support adding to the plugin interface to make this work as one."*

This PR is **both halves** of that answer, built and dogfoodable on our fork:

1. **The plugin** (`plugins/intelligent_routing/`) — opt-in pre-turn cost routing.
2. **The interface extension he offered** (`agent/routing_override.py` + one call site in `agent/turn_context.py`) — a `pre_llm_call` result may now carry a `route` override the runtime **actuates** for the turn.

Motivated by `[intelligent-routing-cost]` (~\$1k/mo, no cheap rung in any cascade). Implements Phase 1 of `memory/specs/2026-07-09-intelligent-routing-toggle-design.md`.

## The interface extension (centerpiece — the ONLY core change)
`agent/routing_override.py` (new) + `agent/turn_context.py` (one call site right after `pre_llm_call` results are collected, before the turn's first API call assembles):

- `extract_routing_override(results)` — pull the first well-formed `{"route": {"model","provider"}}` from the hook results.
- `apply_routing_override(agent, override)` — actuate by delegating to the agent's existing, tested `switch_model` (atomic client rebuild + rollback), then **scope to the turn with a DEDICATED flag** (`_routing_override_active`), stashing the premium snapshot in `_routing_override_saved_primary`. It keeps `_primary_runtime == cheap` for the turn and does **not** touch `_fallback_activated`. `restore_primary_runtime` reverts next turn via a block that runs **before** both the `_fallback_activated` gate and the rate-limit cooldown gate.

**Why this shape is upstream-ready**: it generalizes (any `pre_llm_call` plugin can return a per-turn model/provider override), reuses `switch_model`, and is turn-scoped + fail-safe. Reactive fallback runs correctly UNDERNEATH a routed turn with the cheap runtime as its "primary".

## ✅ Audit response (round 1 — three CONFIRMED blockers, all fixed)
The first audit reproduced three bugs against the REAL runtime in error-adjacent paths. Root cause: the initial design overloaded reactive-fallback state (`_fallback_activated` + restoring the premium `_primary_runtime` snapshot) for turn-scoping. Fixed by switching to a dedicated flag and keeping `_primary_runtime == cheap` during the turn.

- **Blocker 1 (cheap model leaked past its turn under cooldown)** — `restore_primary_runtime`'s rate-limit cooldown early-return skipped restoration. Fixed: the override-revert block runs before that gate, so a routed turn always reverts. The auditor's `test_leak_case.py` is now a passing regression test (`test_routing_override_revert.py::test_routed_cheap_model_reverts_even_when_primary_in_cooldown`).
- **Major 2 (in-turn transient recovery jumped to premium)** — `_recover_from_transient_transport_error` rebuilds from `_primary_runtime`. Fixed: `_primary_runtime` now stays == cheap during the routed turn.
- **Major 3 (cheap 429 got no cooldown)** — pre-arming `_fallback_activated` corrupted `try_activate_fallback`'s cooldown accounting. Fixed: the override no longer touches `_fallback_activated`.

Both `restore_primary_runtime` gates are now guarded by `not _override_revert`, so **normal (non-routed) turns behave exactly as before** — confirmed by 93 passing existing restore/fallback regression tests (incl. `test_primary_runtime_restore`, `test_24996_fallback_exhaustion_cooldown`).

## The plugin (classifier is intentionally simple — not the contribution)
- Task-type classifier adopted from #43534 (code-gen / architecture / orchestration / research / mechanical), **adapted to our fleet tiers**: `mechanical|orchestration → cheap` (default `deepseek/deepseek-v3.2` via OpenRouter, configurable), else `→ premium`. Fail-open to premium; **public-facing never cheap-routed**.
- Cheap tier is **v3.2, not v4-Pro** — grounded in #43534's DeepSWE data (DeepSeek coding throughput directionally lower → code-gen stays on Claude; DeepSeek routed only to orchestration/mechanical where Terminal-Bench shows it competitive at \$0.87/1M). Light citation + the `deep-swe#21` correction in `references/prior-art.md` — deliberately NOT re-hosting the table.
- Extended model-awareness line: `[Current model: … — routed: mechanical → cheap]`.
- Per-agent toggle `routing.intelligent` (default **OFF**); `routing.mode`, `routing.cheap_model`, `routing.cheap_provider`.

## Tests (RGTDD, red→green) — accurate count
**78 new plugin/override tests** pass:
- `tests/plugins/intelligent_routing/` — classifier (14), task-type (21), config (11), registration (13), end-to-end actuation (4).
- `tests/agent/test_routing_override.py` (10) + `tests/agent/test_routing_override_revert.py` (5, drive the REAL `restore_primary_runtime`).

Plus **93 existing restore/fallback regression tests still green**, and 15 pre-existing `test_turn_context.py` still green. ruff clean.
*(Correction to the earlier body: the "88" figure incorrectly folded in 15 pre-existing `test_turn_context.py` tests. The new-test count is 78.)*

## Scope: DONE vs DEFERRED
**Done:** toggle + config; task-type classifier w/ fail-open; route-override emission; the interface extension that actuates the swap (turn-scoped via dedicated flag, fail-safe); the three audit fixes; full RGTDD incl. e2e + real-`restore_primary_runtime` revert tests.
**Deferred:** Phase 3 before/after token-spend measurement · Option B `llm-router` · HSM UI toggle (Phase 2) · richer signals · **live-agent E2E** (swap proven vs faithful fakes + the real `restore_primary_runtime`, NOT yet a real agent hitting OpenRouter).

## ⚠️ For the next audit round
The **only** core-runtime changes are `agent/routing_override.py` + `agent/turn_context.py` call site + the dedicated revert block in `restore_primary_runtime`. They touch the **model-selection path** and are **user-visible**. Everything else is plugin-local. Focus:
- Turn-scoping now proven against the REAL `restore_primary_runtime` (reverts before both gates).
- Proactive/reactive interaction: `_primary_runtime` stays cheap in-turn; reactive fallback engages with cheap as its "primary"; cooldown accounting intact.
- Fail-safe on a bad/unreachable cheap provider.
- **Still no live-agent run — required before fleet rollout.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)