### PR TITLE
fix(signal): respond to group @mentions delivered by the bot's own ACI

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -363,6 +363,13 @@ class SignalAdapter(BasePlatformAdapter):
         # Normalize account for self-message filtering
         self._account_normalized = self.account.strip()
 
+        # The bot's own ACI (Signal service id / UUID). Resolved once at
+        # connect() from the bot's own number. Stays None if resolution fails
+        # (fail-soft — mention/reply matching then falls back to phone only).
+        # Modern Signal delivers @mentions by ACI with no phone number, so the
+        # metadata mention-match needs this to recognize a mention of the bot.
+        self._own_uuid: Optional[str] = None
+
         # Track recently sent message timestamps to prevent echo-back loops
         # in Note to Self / self-chat mode and linked-device group sync-sents.
         # OrderedDict[timestamp_ms -> insertion_monotonic_seconds] gives us
@@ -451,6 +458,10 @@ class SignalAdapter(BasePlatformAdapter):
 
             # Resolve phone-number allowlists to UUIDs now that RPC is live.
             await self._resolve_allowlist_uuids()
+
+            # Resolve the bot's own ACI (needed to recognize @mentions that
+            # arrive by ACI/UUID rather than phone number). Fail-soft.
+            await self._resolve_own_uuid()
 
             # Auto-approve pre-existing groups the agent was added to without
             # an invite envelope (e.g. added at group creation). Best-effort.
@@ -979,8 +990,16 @@ class SignalAdapter(BasePlatformAdapter):
             mentioned_in_text = account_norm and (
                 f"@{account_norm}" in (text or "")
             )
+            # Match a mention by the bot's phone number OR its own ACI. Modern
+            # Signal delivers @mentions as metadata carrying only the ACI
+            # (a `uuid` with no `number`), so the own-ACI check is required for
+            # a genuine @mention to be recognized. _own_uuid may be None if
+            # resolution failed at connect() — then only the phone check applies.
+            own_uuid = self._own_uuid
             mentioned_in_metadata = any(
-                m.get("number") == account_norm or m.get("uuid") == account_norm
+                m.get("number") == account_norm
+                or m.get("uuid") == account_norm
+                or (own_uuid and m.get("uuid") == own_uuid)
                 for m in (data_message.get("mentions") or [])
             )
             if not mentioned_in_text and not mentioned_in_metadata:
@@ -988,7 +1007,11 @@ class SignalAdapter(BasePlatformAdapter):
                 is_reply_to_bot = False
                 quote_data = data_message.get("quote") or {}
                 if quote_data:
-                    bot_uuid = self._recipient_uuid_by_number.get(account_norm, "")
+                    bot_uuid = (
+                        self._recipient_uuid_by_number.get(account_norm, "")
+                        or self._own_uuid
+                        or ""
+                    )
                     quote_author = quote_data.get("authorNumber") or ""
                     quote_uuid = quote_data.get("authorUuid") or ""
                     is_reply_to_bot = (
@@ -1425,6 +1448,47 @@ class SignalAdapter(BasePlatformAdapter):
                 len(unresolved),
                 ", ".join(redact_phone(n) for n in unresolved),
             )
+
+    async def _resolve_own_uuid(self) -> None:
+        """Resolve the bot's own ACI (service id) from its own phone number.
+
+        Modern Signal delivers group @mentions as mention metadata carrying
+        only the mentioned party's ACI (a ``uuid``, often with no ``number``).
+        The metadata mention-match needs the bot's own ACI to recognize such a
+        mention. We resolve it once at connect() via ``getUserStatus`` — the
+        same RPC already used for allowlist resolution — on ``self.account``.
+
+        Fail-soft: on any error, or if only a PNI (not an ACI) comes back,
+        ``self._own_uuid`` stays ``None`` and all downstream behavior is
+        unchanged (mention/reply matching falls back to the phone number).
+        """
+        try:
+            statuses = await self._rpc("getUserStatus", {
+                "account": self.account,
+                "recipients": [self.account],
+            })
+        except Exception:
+            logger.debug("Signal: own-ACI resolution failed (getUserStatus)", exc_info=True)
+            return
+
+        if not isinstance(statuses, list):
+            return
+
+        for status in statuses:
+            if not isinstance(status, dict):
+                continue
+            sid = status.get("uuid") or status.get("serviceId")
+            # Only accept a bare ACI (UUID). A PNI:-prefixed id is not the ACI
+            # that mention metadata uses, so reject it and stay fail-soft.
+            if sid and _is_signal_service_id(sid) and not sid.startswith("PNI:"):
+                self._own_uuid = sid
+                # Also cache it as the number→UUID mapping so reply-to-bot and
+                # self-mention stripping can reuse it.
+                self._remember_recipient_identifiers(self._account_normalized, sid)
+                logger.info("Signal: resolved own ACI → %s", sid[:12])
+                return
+
+        logger.debug("Signal: own ACI unresolved (no bare service id from getUserStatus)")
 
     # ------------------------------------------------------------------
     # Profile Name Setting

--- a/tests/gateway/test_signal_group_reconcile.py
+++ b/tests/gateway/test_signal_group_reconcile.py
@@ -318,6 +318,7 @@ class TestReconcileWiredIntoConnect:
 
         # Replace the network-touching collaborators so connect() stays local.
         monkeypatch.setattr(adapter, "_resolve_allowlist_uuids", AsyncMock())
+        monkeypatch.setattr(adapter, "_resolve_own_uuid", AsyncMock())
         monkeypatch.setattr(adapter, "_set_profile_name", AsyncMock())
         monkeypatch.setattr(adapter, "_sse_listener", AsyncMock())
         monkeypatch.setattr(adapter, "_health_monitor", AsyncMock())

--- a/tests/gateway/test_signal_mention_own_aci.py
+++ b/tests/gateway/test_signal_mention_own_aci.py
@@ -1,0 +1,195 @@
+"""Regression tests for the Signal group @mention-by-ACI bug.
+
+Production failure: in a Signal GROUP with require_mention=true, the bot did
+NOT respond to genuine @mentions delivered by ACI/UUID. Modern Signal delivers
+@mentions as a mention-metadata entry carrying only the mentioned party's ACI
+(a ``uuid``, often with no ``number``). The mention-match code compared
+``m.get("uuid") == account_norm`` where ``account_norm`` is the bot's *phone*
+number — the bot's own ACI was never resolved, so a real @mention never matched
+and the message fell through to observe_only (agent stayed silent).
+
+Fix under test (additive):
+- Resolve the bot's own ACI once at connect() and store it on ``_own_uuid``.
+- A metadata mention matches if ``m.get("uuid")`` equals the bot's own ACI in
+  addition to the existing ``== account_norm`` (phone) check.
+- The reply-to-bot ``bot_uuid`` fallback falls back to ``_own_uuid``.
+
+Conventions follow tests/gateway/test_signal_aci_reresolve.py.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+BOT_PHONE = "+15551234567"
+BOT_ACI = "5eca7c21-1111-2222-3333-000000000099"
+GROUP_ID = "dGVzdC1ncm91cC1pZA=="  # opaque base64-ish group id
+OTHER_ACI = "9f0d3e42-dddd-eeee-ffff-000000000002"
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _isolate_signal_env(monkeypatch):
+    for var in (
+        "SIGNAL_ALLOWED_USERS",
+        "SIGNAL_GROUP_ALLOWED_USERS",
+        "SIGNAL_ALLOW_ALL_USERS",
+        "SIGNAL_REQUIRE_MENTION",
+        "SIGNAL_OBSERVE_UNMENTIONED",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_signal_adapter(monkeypatch, account=BOT_PHONE, **extra):
+    """Create a real SignalAdapter with test defaults."""
+    monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", extra.pop("group_allowed", "*"))
+    from gateway.platforms.signal import SignalAdapter
+    config = PlatformConfig()
+    config.enabled = True
+    config.extra = {
+        "http_url": "http://localhost:8080",
+        "account": account,
+        "require_mention": True,
+        **extra,
+    }
+    return SignalAdapter(config)
+
+
+def _group_envelope(mentions=None, text="hello", timestamp=1750000000000):
+    """A group dataMessage envelope from an OTHER member, optionally @mentioning."""
+    data_message = {
+        "message": text,
+        "timestamp": timestamp,
+        "groupV2": {"id": GROUP_ID},
+    }
+    if mentions is not None:
+        data_message["mentions"] = mentions
+    return {
+        "envelope": {
+            "sourceUuid": OTHER_ACI,
+            "source": OTHER_ACI,
+            "sourceName": "Someone",
+            "timestamp": timestamp,
+            "dataMessage": data_message,
+        }
+    }
+
+
+async def _dispatch(adapter, envelope):
+    """Run _handle_envelope with handle_message mocked; return the event or None."""
+    captured = {}
+
+    async def _capture(event):
+        captured["event"] = event
+
+    adapter.handle_message = AsyncMock(side_effect=_capture)
+    await adapter._handle_envelope(envelope)
+    return captured.get("event")
+
+
+# ---------------------------------------------------------------------------
+# Test A — the fix: a metadata @mention by the bot's own ACI is honored
+# ---------------------------------------------------------------------------
+
+class TestGroupMentionByOwnAci:
+
+    @pytest.mark.asyncio
+    async def test_aci_mention_is_dispatched_not_observe_only(self, monkeypatch):
+        """mentions=[{"uuid": <bot ACI>}] (no number) ⇒ NOT observe_only."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._own_uuid = BOT_ACI  # resolved at connect() in production
+
+        event = await _dispatch(
+            adapter, _group_envelope(mentions=[{"uuid": BOT_ACI}])
+        )
+
+        assert event is not None
+        assert event.observe_only is False
+
+
+# ---------------------------------------------------------------------------
+# Test B — no regression: a phone-based mention still matches
+# ---------------------------------------------------------------------------
+
+class TestGroupMentionByPhoneStillWorks:
+
+    @pytest.mark.asyncio
+    async def test_phone_mention_still_matches(self, monkeypatch):
+        """mentions=[{"number": <bot phone>}] ⇒ NOT observe_only (unchanged)."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._own_uuid = BOT_ACI
+
+        event = await _dispatch(
+            adapter, _group_envelope(mentions=[{"number": BOT_PHONE}])
+        )
+
+        assert event is not None
+        assert event.observe_only is False
+
+    @pytest.mark.asyncio
+    async def test_phone_mention_matches_even_without_own_uuid(self, monkeypatch):
+        """Phone-mention path must not depend on ACI resolution succeeding."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._own_uuid = None  # ACI resolution failed at connect()
+
+        event = await _dispatch(
+            adapter, _group_envelope(mentions=[{"number": BOT_PHONE}])
+        )
+
+        assert event is not None
+        assert event.observe_only is False
+
+
+# ---------------------------------------------------------------------------
+# Test C — no regression: an un-mentioned group message stays observe_only
+# ---------------------------------------------------------------------------
+
+class TestGroupNoMentionStaysSilent:
+
+    @pytest.mark.asyncio
+    async def test_no_mention_is_observe_only(self, monkeypatch):
+        """No mention at all ⇒ observe_only (agent stays silent)."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._own_uuid = BOT_ACI
+
+        event = await _dispatch(adapter, _group_envelope(mentions=None))
+
+        assert event is not None
+        assert event.observe_only is True
+
+    @pytest.mark.asyncio
+    async def test_someone_elses_aci_mention_stays_silent(self, monkeypatch):
+        """A mention of a DIFFERENT ACI must not wake the bot."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._own_uuid = BOT_ACI
+
+        event = await _dispatch(
+            adapter, _group_envelope(mentions=[{"uuid": OTHER_ACI}])
+        )
+
+        assert event is not None
+        assert event.observe_only is True
+
+    @pytest.mark.asyncio
+    async def test_aci_mention_without_own_uuid_stays_silent(self, monkeypatch):
+        """If own ACI is unresolved, an ACI-only mention cannot match ⇒ silent.
+
+        This documents the pre-fix behavior for the fail-soft path: with
+        _own_uuid=None the ACI mention still won't match (no false positive),
+        matching the constraint 'do NOT change default behavior when own ACI
+        can't be resolved'.
+        """
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._own_uuid = None
+
+        event = await _dispatch(
+            adapter, _group_envelope(mentions=[{"uuid": BOT_ACI}])
+        )
+
+        assert event is not None
+        assert event.observe_only is True


### PR DESCRIPTION
## Problem

In a Signal **group** with `require_mention` on, the agent did **not** respond to genuine @mentions that arrive by ACI/UUID.

Root cause (`gateway/platforms/signal.py`, ~L976–991): the mention-metadata match compared `m["uuid"] == account_norm`, where `account_norm` is the bot's **phone number**. The bot's own **ACI** was never resolved (no whoami/getSelf anywhere). Modern Signal delivers @mentions by ACI (a `uuid`, usually with no `number`), so a genuine @mention never matched → the message fell through to `observe_only` → the agent stayed silent.

## Fix (additive, fail-soft)

1. **Resolve the bot's own ACI once at `connect()`** via `getUserStatus` on the bot's own number (`self.account`) — the same JSON-RPC method already used by `_resolve_allowlist_uuids()` for phone→UUID resolution. Stored on `self._own_uuid` as a bare ACI (PNI-prefixed ids are rejected). Any failure leaves `_own_uuid = None` and changes nothing.
2. **Metadata mention-match** now also matches `m["uuid"] == self._own_uuid`, **in addition to** the existing `== account_norm` (phone), `@{phone}`-in-text, reply-to-bot, and `/command` paths — all left intact.
3. **reply-to-bot `bot_uuid`** falls back to `self._own_uuid` when the contact-cache lookup is empty.

When the bot's own ACI can't be resolved, behavior is byte-for-byte identical to before.

## TDD

New `tests/gateway/test_signal_mention_own_aci.py`, following `test_signal_aci_reresolve.py` conventions:

- **A (the fix):** group inbound with `mentions=[{"uuid": <bot ACI>}]` (no number), `require_mention=true` → dispatched (`observe_only=False`). **Failed before, passes after.**
- **B (no regression):** `mentions=[{"number": <bot phone>}]` still matches (and still matches even when `_own_uuid` is None).
- **C (no regression):** no-mention stays `observe_only`; a *different* ACI mention stays silent; an ACI mention with `_own_uuid=None` stays silent (no false positive).

`320 passed` across the full signal suite (`tests/gateway/test_signal*.py`), no regressions. One existing connect() test (`test_signal_group_reconcile.py`) gained a one-line mock of the new `_resolve_own_uuid` to keep `connect()` network-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)