### PR TITLE
fix(routing): resolve provider endpoint on cross-provider route

### DIFF
--- a/agent/routing_override.py
+++ b/agent/routing_override.py
@@ -118,6 +118,38 @@ def apply_routing_override(agent: Any, override: Optional[dict]) -> bool:
     kwargs = {
         k: override[k] for k in _PASSTHROUGH_FIELDS if override.get(k)
     }
+    # When the route switches provider but the override carries no explicit
+    # base_url, resolve the new provider's canonical endpoint up front. Without
+    # this, switch_model()'s ``if base_url:`` guard keeps the CURRENT base_url,
+    # so the routed model is dispatched to the previous provider's endpoint —
+    # e.g. an OpenRouter model sent to api.anthropic.com/chat/completions → 404,
+    # silently cascading to the bottom of the fallback chain. Mirrors the
+    # reactive-fallback path in chat_completion_helpers. (cyborg routed-turn
+    # 404 regression.) Fail-safe: a resolve miss must never break the turn —
+    # fall through and let switch_model use provider defaults.
+    if (
+        "base_url" not in kwargs
+        and target_provider
+        and target_provider.strip().lower() != cur_provider.strip().lower()
+    ):
+        try:
+            from agent.auxiliary_client import resolve_provider_client
+
+            _client, _ = resolve_provider_client(target_provider, model=target_model)
+            if _client is not None:
+                _resolved_base = str(getattr(_client, "base_url", "") or "").strip()
+                if _resolved_base:
+                    kwargs["base_url"] = _resolved_base
+                if "api_key" not in kwargs:
+                    _resolved_key = getattr(_client, "api_key", None)
+                    if _resolved_key:
+                        kwargs["api_key"] = _resolved_key
+        except Exception:  # noqa: BLE001 — never break the turn on a resolve miss
+            logger.debug(
+                "intelligent_routing: could not pre-resolve endpoint for %s; "
+                "switch_model will fall back to provider defaults",
+                target_provider, exc_info=True,
+            )
     try:
         agent.switch_model(target_model, target_provider, **kwargs)
     except Exception as exc:  # noqa: BLE001 — a routing miss must never break the turn

--- a/tests/agent/test_routing_override.py
+++ b/tests/agent/test_routing_override.py
@@ -136,3 +136,113 @@ def test_apply_ignores_empty_override():
     assert apply_routing_override(agent, {}) is False
     assert apply_routing_override(agent, None) is False
     agent.switch_model.assert_not_called()
+
+
+# ---- base_url resolution on cross-provider routes (cyborg 404 regression) ----
+#
+# The plugin emits {"model": ..., "provider": ...} with NO base_url. switch_model
+# keeps the CURRENT base_url when none is supplied (its `if base_url:` guard), so
+# a route from an Anthropic primary to an OpenRouter model would dispatch the
+# OpenRouter model to api.anthropic.com/chat/completions → 404, silently
+# cascading to the bottom of the fallback chain. apply_routing_override must
+# resolve the new provider's canonical endpoint up front when the override omits
+# it AND the provider changes.
+
+
+class _FakeClient:
+    def __init__(self, base_url, api_key):
+        self.base_url = base_url
+        self.api_key = api_key
+
+
+def _stub_resolver(monkeypatch, fn):
+    """Inject a fake ``agent.auxiliary_client`` so the lazy
+    ``from agent.auxiliary_client import resolve_provider_client`` in
+    apply_routing_override picks up ``fn`` without importing the heavy real
+    module (and its runtime deps) at unit-test time."""
+    import sys
+    import types
+
+    mod = types.ModuleType("agent.auxiliary_client")
+    mod.resolve_provider_client = fn
+    monkeypatch.setitem(sys.modules, "agent.auxiliary_client", mod)
+
+
+def test_apply_resolves_base_url_when_provider_changes(monkeypatch):
+    agent = _fake_agent()  # primary: anthropic
+    seen = {}
+
+    def _resolve(provider, model=None, **kw):
+        seen["provider"] = provider
+        seen["model"] = model
+        return _FakeClient("https://openrouter.ai/api/v1/", "sk-or-test"), model
+
+    _stub_resolver(monkeypatch, _resolve)
+
+    ok = apply_routing_override(
+        agent, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}
+    )
+    assert ok is True
+    assert seen["provider"] == "openrouter"
+    _, kwargs = agent.switch_model.call_args
+    # The resolved endpoint (and key) must be forwarded so switch_model does NOT
+    # inherit the Anthropic primary's base_url.
+    assert kwargs.get("base_url") == "https://openrouter.ai/api/v1/"
+    assert kwargs.get("api_key") == "sk-or-test"
+
+
+def test_apply_does_not_resolve_when_provider_unchanged(monkeypatch):
+    """Same-provider route (e.g. anthropic sonnet → anthropic haiku) must not
+    inject base_url — switch_model correctly keeps the same-provider base_url
+    and re-derives api_mode. Forcing a resolve here is needless and risky."""
+    agent = _fake_agent()  # primary: anthropic
+
+    def _resolve(*a, **k):
+        raise AssertionError("resolve_provider_client should not be called")
+
+    _stub_resolver(monkeypatch, _resolve)
+
+    ok = apply_routing_override(
+        agent, {"model": "claude-haiku-4-5-20251001", "provider": "anthropic"}
+    )
+    assert ok is True
+    _, kwargs = agent.switch_model.call_args
+    assert "base_url" not in kwargs
+
+
+def test_apply_preserves_explicit_base_url(monkeypatch):
+    """An override that DOES carry base_url wins — no resolve, no overwrite."""
+    agent = _fake_agent()
+
+    def _resolve(*a, **k):
+        raise AssertionError("resolve_provider_client should not be called")
+
+    _stub_resolver(monkeypatch, _resolve)
+
+    apply_routing_override(
+        agent,
+        {
+            "model": "deepseek/deepseek-v3.2",
+            "provider": "openrouter",
+            "base_url": "https://custom.example/v1",
+        },
+    )
+    _, kwargs = agent.switch_model.call_args
+    assert kwargs["base_url"] == "https://custom.example/v1"
+
+
+def test_apply_resolve_failure_is_fail_safe(monkeypatch):
+    """A resolve miss must not break the turn — the swap still proceeds and
+    switch_model falls back to provider defaults."""
+    agent = _fake_agent()
+
+    def _resolve(*a, **k):
+        raise RuntimeError("registry down")
+
+    _stub_resolver(monkeypatch, _resolve)
+
+    ok = apply_routing_override(
+        agent, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}
+    )
+    assert ok is True
+    agent.switch_model.assert_called_once()


### PR DESCRIPTION
## Problem

cyborg (intelligent-router dogfood) was throwing on every "cheap/mechanical" routed turn:

```
provider=openrouter base_url=https://api.anthropic.com model=deepseek/deepseek-v3.2
404 Not Found for url 'https://api.anthropic.com/chat/completions'
→ Fallback activated: deepseek/deepseek-v3.2 → qwen3.5:9b (ollama)
```

An **OpenRouter model was being dispatched to Anthropic's host.** cyborg wasn't down — every cheap turn silently cascaded to the local qwen fallback instead of deepseek.

## Root cause

The `intelligent_routing` plugin emits a route override of just `{model, provider}` — **no `base_url`** (`plugins/intelligent_routing/registration.py`). `apply_routing_override` only forwarded endpoint fields present in the override:

```python
kwargs = {k: override[k] for k in _PASSTHROUGH_FIELDS if override.get(k)}  # → {} 
agent.switch_model(target_model, target_provider, **kwargs)               # base_url=None
```

`switch_model`'s `if base_url:` guard then **keeps the current (primary Anthropic) base_url**, so provider flips to `openrouter` and model to `deepseek` while the host stays `api.anthropic.com` → 404. The reactive-fallback path avoids this because it calls `resolve_provider_client()` first; the routing path did not.

## Fix

When a route switches provider and omits `base_url`, resolve the new provider's canonical endpoint (and api_key) via `resolve_provider_client` before `switch_model` — mirroring the reactive-fallback path. Fail-safe: a resolve miss falls through to provider defaults and never breaks the turn. Same-provider routes (e.g. anthropic sonnet→haiku) are untouched — `switch_model` already keeps the correct base and re-derives `api_mode`.

## Tests

`tests/agent/test_routing_override.py` (RGTDD, red→green):
- cross-provider route resolves + forwards base_url/api_key
- same-provider route does **not** inject base_url
- explicit override base_url preserved (no resolve)
- resolve failure is fail-safe (swap still proceeds)

Verified against the **real** provider registry in the running cyborg container: cross-provider now yields `https://openrouter.ai/api/v1/` + key; same-provider yields none.

## Blast radius

The router is default-off and enabled only on cyborg, so this bug was cyborg-only in production. Other agents' openrouter *reactive* fallbacks were unaffected (they resolve base_url correctly). This fix is prerequisite to enabling the router elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)