### PR TITLE
fix(slack): heal 'Session is closed' stuck reconnect loop (fleet reliability)

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -497,6 +497,20 @@ class SlackAdapter(BasePlatformAdapter):
         )
         _apply_slack_proxy(self._handler.client, self._proxy_url)
 
+        # Guard: if the new SocketModeClient's aiohttp session is already closed
+        # (can happen in rare race conditions during teardown), replace it with a
+        # fresh one. Without this, SocketModeClient.connect() enters an infinite
+        # retry loop — "RuntimeError: Session is closed" every ping_interval seconds.
+        sm_client = getattr(self._handler, "client", None)
+        if sm_client is not None:
+            session = getattr(sm_client, "aiohttp_client_session", None)
+            if session is not None and getattr(session, "closed", False):
+                logger.warning(
+                    "[Slack] New SocketModeClient has a closed aiohttp session; "
+                    "replacing with a fresh one to avoid stuck reconnect loop"
+                )
+                sm_client.aiohttp_client_session = aiohttp.ClientSession(trust_env=True)
+
         task = asyncio.create_task(self._handler.start_async())
         self._socket_mode_task = task
         task.add_done_callback(self._on_socket_mode_task_done)
@@ -590,6 +604,19 @@ class SlackAdapter(BasePlatformAdapter):
                 if task.done():
                     await self._restart_socket_mode("socket task stopped")
                     continue
+
+                # Detect the "Session is closed" stuck state: the task is still
+                # running (start_async sleeps forever) but ws_connect() is looping
+                # forever on a closed aiohttp session — neither done() nor
+                # transport_connected() catches this.
+                handler = self._handler
+                if handler is not None:
+                    sm_client = getattr(handler, "client", None)
+                    if sm_client is not None:
+                        session = getattr(sm_client, "aiohttp_client_session", None)
+                        if session is not None and getattr(session, "closed", False):
+                            await self._restart_socket_mode("aiohttp session closed")
+                            continue
 
                 connected = await self._socket_transport_connected()
                 if connected is False:

--- a/tests/gateway/test_slack_socket_reconnect_heal.py
+++ b/tests/gateway/test_slack_socket_reconnect_heal.py
@@ -1,0 +1,234 @@
+"""
+Tests for Slack Socket Mode 'Session is closed' self-healing.
+
+Covers the stuck-reconnect scenario where slack_sdk's SocketModeClient
+enters an infinite retry loop on a closed aiohttp.ClientSession.
+The adapter must detect and recover from this state.
+"""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Mock the slack-bolt package if it's not installed
+# ---------------------------------------------------------------------------
+
+
+def _ensure_slack_mock():
+    """Install mock slack modules so SlackAdapter can be imported."""
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return  # Real library installed
+
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        (
+            "slack_bolt.adapter.socket_mode.async_handler",
+            slack_bolt.adapter.socket_mode.async_handler,
+        ),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+    sys.modules.setdefault("aiohttp", MagicMock())
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+from gateway.config import PlatformConfig  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def adapter():
+    config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+    a = SlackAdapter(config)
+    a._app = MagicMock()
+    a._app_token = "xapp-fake"
+    a._proxy_url = None
+    a._running = True
+    a.handle_message = AsyncMock()
+    return a
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSlackSocketSessionClosedHeal:
+    """Verify the adapter detects and recovers from a closed aiohttp session."""
+
+    @pytest.mark.asyncio
+    async def test_start_handler_replaces_closed_aiohttp_session(self, adapter):
+        """_start_socket_mode_handler must replace a closed aiohttp_client_session.
+
+        Reproduces: RuntimeError('Session is closed') stuck loop.
+        The new AsyncSocketModeHandler's SocketModeClient has a closed session
+        (simulates the race condition). The adapter must swap it for a fresh one
+        before the start_async task begins.
+        """
+        closed_session = MagicMock()
+        closed_session.closed = True
+
+        fresh_session = MagicMock()
+        fresh_session.closed = False
+
+        mock_client = MagicMock()
+        mock_client.aiohttp_client_session = closed_session
+
+        mock_handler = MagicMock()
+        mock_handler.client = mock_client
+
+        fake_task = MagicMock()
+        fake_task.add_done_callback = MagicMock()
+
+        with (
+            patch(
+                "plugins.platforms.slack.adapter.AsyncSocketModeHandler",
+                return_value=mock_handler,
+            ),
+            patch("plugins.platforms.slack.adapter.aiohttp") as mock_aiohttp,
+            patch("asyncio.create_task", return_value=fake_task),
+        ):
+            mock_aiohttp.ClientSession.return_value = fresh_session
+            adapter._start_socket_mode_handler()
+
+        # The closed session must have been replaced with a fresh one
+        assert mock_client.aiohttp_client_session is fresh_session, (
+            "_start_socket_mode_handler must replace a closed aiohttp_client_session "
+            "with a fresh one to avoid the 'Session is closed' stuck-loop"
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_handler_leaves_open_session_alone(self, adapter):
+        """_start_socket_mode_handler must NOT replace an already-open session."""
+        open_session = MagicMock()
+        open_session.closed = False
+
+        mock_client = MagicMock()
+        mock_client.aiohttp_client_session = open_session
+
+        mock_handler = MagicMock()
+        mock_handler.client = mock_client
+
+        fake_task = MagicMock()
+        fake_task.add_done_callback = MagicMock()
+
+        with (
+            patch(
+                "plugins.platforms.slack.adapter.AsyncSocketModeHandler",
+                return_value=mock_handler,
+            ),
+            patch("plugins.platforms.slack.adapter.aiohttp") as mock_aiohttp,
+            patch("asyncio.create_task", return_value=fake_task),
+        ):
+            adapter._start_socket_mode_handler()
+            mock_aiohttp.ClientSession.assert_not_called()
+
+        assert mock_client.aiohttp_client_session is open_session
+
+    @pytest.mark.asyncio
+    async def test_watchdog_triggers_restart_on_closed_session(self, adapter):
+        """Watchdog must trigger restart when handler's aiohttp session is closed.
+
+        Reproduces: task.done() == False (start_async is sleeping),
+        is_connected() returns None (indeterminate), but session is closed.
+        Without the fix, watchdog never calls _restart_socket_mode.
+        """
+        closed_session = MagicMock()
+        closed_session.closed = True
+
+        mock_client = MagicMock()
+        mock_client.aiohttp_client_session = closed_session
+
+        mock_handler = MagicMock()
+        mock_handler.client = mock_client
+        adapter._handler = mock_handler
+
+        mock_task = MagicMock()
+        mock_task.done.return_value = False  # task is running (not done)
+        adapter._socket_mode_task = mock_task
+
+        restart_calls: list[str] = []
+
+        async def _fake_restart(reason: str) -> None:
+            restart_calls.append(reason)
+            adapter._running = False  # stop the loop after first restart
+
+        adapter._restart_socket_mode = _fake_restart
+        # Transport probe returns None (indeterminate) — this path must NOT trigger restart
+        adapter._socket_transport_connected = AsyncMock(return_value=None)
+        adapter._socket_watchdog_interval_s = 0.01
+
+        await adapter._socket_watchdog_loop()
+
+        assert restart_calls, (
+            "Watchdog must call _restart_socket_mode when aiohttp session is closed"
+        )
+        assert "aiohttp session closed" in restart_calls[0], (
+            f"Expected restart reason 'aiohttp session closed', got: {restart_calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_watchdog_does_not_restart_when_session_open(self, adapter):
+        """Watchdog must NOT restart when task is running and session is open."""
+        open_session = MagicMock()
+        open_session.closed = False
+
+        mock_client = MagicMock()
+        mock_client.aiohttp_client_session = open_session
+
+        mock_handler = MagicMock()
+        mock_handler.client = mock_client
+        adapter._handler = mock_handler
+
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        adapter._socket_mode_task = mock_task
+
+        restart_calls: list[str] = []
+
+        async def _fake_restart(reason: str) -> None:
+            restart_calls.append(reason)
+
+        adapter._restart_socket_mode = _fake_restart
+
+        async def _stop_after_one_iteration():
+            await asyncio.sleep(0.02)
+            adapter._running = False
+
+        adapter._socket_transport_connected = AsyncMock(return_value=None)
+        adapter._socket_watchdog_interval_s = 0.01
+
+        stopper = asyncio.ensure_future(_stop_after_one_iteration())
+        await adapter._socket_watchdog_loop()
+        stopper.cancel()
+
+        assert not restart_calls, (
+            f"Watchdog must not restart when session is open. Got: {restart_calls}"
+        )


### PR DESCRIPTION
## Root cause

chur-bot's Slack went offline for ~3h and never self-healed until a container restart. The production logs showed `RuntimeError("Session is closed")` retried every ~10s forever:

```
slack_sdk/socket_mode/aiohttp/__init__.py:377  →  aiohttp/client.py:529
```

`slack_sdk`'s `SocketModeClient.connect()` runs a `while True: … except Exception: sleep(ping_interval)` loop. When it calls `aiohttp_client_session.ws_connect()` on an `aiohttp.ClientSession` that has been **closed**, aiohttp raises `RuntimeError("Session is closed")`. That exception is swallowed by the broad `except`, logged, and retried on the **same closed session** every ~10s — indefinitely.

The stuck state was invisible to every existing recovery path in our adapter:

- The `start_async` task keeps running (it sits at `await asyncio.sleep(float("inf"))`), so **`_on_socket_mode_task_done` never fires**.
- The watchdog's **`task.done()` check passes** (the task is alive), and `_socket_transport_connected()` can return an indeterminate value while `connect()` is mid-loop.

The session gets closed under a race: `_stop_socket_mode_handler()` calls `handler.close_async()` → `SocketModeClient.close()` → `aiohttp_client_session.close()`, while `monitor_current_session` (a slack_sdk subtask) is concurrently calling `connect()` on that same session.

## Fix

Two small, defensive changes in `plugins/platforms/slack/adapter.py` — we can't patch `slack_sdk`, so we heal at the adapter level:

1. **`_start_socket_mode_handler`** — after constructing the new `AsyncSocketModeHandler`, check whether its `SocketModeClient.aiohttp_client_session` is already closed and, if so, swap in a fresh `aiohttp.ClientSession(trust_env=True)` before the task starts. This prevents ever handing a closed session to `connect()`.

2. **`_socket_watchdog_loop`** — add an explicit check for `handler.client.aiohttp_client_session.closed`. This is the **only** observable signal that uniquely identifies the stuck state when `task.done()` is `False`. When detected, the watchdog calls `_restart_socket_mode("aiohttp session closed")`, which tears down the dead handler and builds a fresh one (new `SocketModeClient`, new aiohttp session, new WS) — breaking the loop.

Both use `getattr` with fallbacks so they degrade safely across slack_sdk versions and against mocked handlers.

### Why this approach

The task called for either (a) detect the closed-session condition and rebuild a fresh session before reconnecting, or (b) a bounded watchdog that re-instantiates the handler. This PR does **both**, at complementary points: prevention at handler-start, and detection-and-recovery in the ongoing watchdog. It's minimal and consistent with the adapter's existing self-healing machinery (`_restart_socket_mode`, `_socket_watchdog_loop`) — no unrelated refactoring.

## Tests

New `tests/gateway/test_slack_socket_reconnect_heal.py` (4 tests), reproducing the stuck-session condition by simulating a `SocketModeClient` whose `aiohttp_client_session.closed` is `True`:

- `test_start_handler_replaces_closed_aiohttp_session` — a closed session at handler-start is replaced with a fresh one.
- `test_start_handler_leaves_open_session_alone` — an already-open session is left untouched (no needless churn).
- `test_watchdog_triggers_restart_on_closed_session` — with `task.done() == False` and an indeterminate transport probe, the watchdog still calls `_restart_socket_mode("aiohttp session closed")`.
- `test_watchdog_does_not_restart_when_session_open` — a healthy running session does not trigger a restart.

Test status: **4/4 new pass; 216/216 existing `tests/gateway/test_slack.py` pass — zero regressions.** (Verified independently on Python 3.11 / pytest-asyncio strict mode.)

## Impact

This affects **all Slack-connected agents**, not just chur-bot — the `SocketModeClient` reconnect loop is shared by every Slack Socket Mode connection in the fleet. This is a fleet-wide reliability fix that removes the "silent Slack outage until manual container restart" failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNWm54UtvqvjgopDoxm54R
