### PR TITLE
test(skills): lock in macOS-only skill exclusion from discovery on Linux

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -307,6 +307,37 @@ class TestFindAllSkills:
         assert [s["name"] for s in skills] == ["knowledge-brain"]
         assert skills[0]["category"] == "linked"
 
+    def test_excludes_platform_incompatible_skill_on_linux(self, tmp_path):
+        """A ``platforms: [macos]`` skill on disk must be dropped from the
+        discovery listing when running on Linux, while a skill declaring no
+        platform requirement (and one that explicitly lists linux) still shows.
+
+        Regression guard for the im7-bot symptom: macOS-only skills
+        (apple-notes, imessage, findmy, apple-reminders) were probed on a
+        Linux container. ``skill_matches_platform`` is unit-tested in
+        isolation, but this asserts the *discovery integration* — that
+        ``_find_all_skills`` actually applies the predicate — so a future
+        refactor can't silently drop the filter and let macOS skills leak
+        into the model's context on Linux.
+        """
+        _make_skill(
+            tmp_path, "imessage", frontmatter_extra="platforms: [macos]\n"
+        )
+        _make_skill(
+            tmp_path, "notion", frontmatter_extra="platforms: [linux, macos]\n"
+        )
+        _make_skill(tmp_path, "generic")  # no platforms field → all platforms
+
+        with patch("agent.skill_utils.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+                skills = _find_all_skills()
+
+        names = {s["name"] for s in skills}
+        assert "imessage" not in names  # macOS-only, excluded on Linux
+        assert "notion" in names  # lists linux, included
+        assert "generic" in names  # no requirement, included
+
 
 # ---------------------------------------------------------------------------
 # skills_list


### PR DESCRIPTION
## Summary

Adds a regression test locking in that **macOS-only skills are excluded from skill discovery on Linux** — the behavior that keeps im7-bot (and any Linux container) from probing `apple-notes`, `apple-reminders`, `findmy`, and `imessage` and burning tool-loop iterations on "not supported on this platform".

## Important finding: the gating already works on `main`

I investigated the reported im7-bot symptom (Linux container probes macOS skills → each returns "not supported on this platform" → same-tool-failure warning trips at count 3–4). The platform gating the fix would add **already exists and is comprehensive on current `main`**:

- All four Apple skills declare `platforms: [macos]`.
- `skill_matches_platform` (`agent/skill_utils.py`) is the source-of-truth predicate and is unit-tested (`test_macos_on_linux` → `False`).
- It is applied at **every** surface that can name a skill to the model:
  - `skills_list` / `_find_all_skills` (`tools/skills_tool.py`)
  - the system-prompt skills index (`agent/prompt_builder.py`, snapshot + cold-scan + external-dir paths)
  - `skill_view` and `_serve_plugin_skill` (hard gate on load)
  - `scan_skill_commands` (slash-command scan)
  - the `/v1/skills` API endpoint, Discord autocomplete, and the `-s` preload path (all route through the above)

So on a Linux host these skills are structurally absent from the model's context. The only way the reported error is reachable is if the model calls `skill_view('imessage')` **from its own training/memory without listing first** — which a register-time filter can't prevent, because skills aren't registered as per-skill tools.

**Most likely cause of the live symptom: build staleness.** im7-bot is probably running an image that predates this gating. The durable fix is to **rebuild im7-bot on current `main`** (deployed agents are static until rebuilt).

## What this PR changes

The predicate is unit-tested in isolation, but there was **no test asserting the discovery integration** — that `_find_all_skills` actually drops a `platforms: [macos]` skill on a Linux host. This adds that regression guard:

- On a simulated Linux host, a `platforms: [macos]` skill is excluded from the listing, while a `platforms: [linux, macos]` skill and a skill with no `platforms` field remain.
- Verified it **fails** when the filter is sabotaged and **passes** when restored (it's a real guard, not a tautology).

No behavior change. Pure additive coverage so a future refactor can't silently let macOS skills leak into a Linux container's context.

## Test status

`python -m pytest tests/tools/test_skills_tool.py` → **90 passed** (89 existing + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNWm54UtvqvjgopDoxm54R
