### PR TITLE
fix(env-passthrough): correct config key in docstrings + test operator-config Notion passthrough

### DIFF
--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -105,6 +105,50 @@ class TestConfigPassthrough:
         assert "CONFIG_KEY" in all_pt
         assert "SKILL_KEY" in all_pt
 
+    def test_operator_config_survives_sandbox_scrub_without_skill_load(
+        self, tmp_path, monkeypatch
+    ):
+        """A third-party key named in ``terminal.env_passthrough`` reaches the
+        execute_code child even when the owning skill was never loaded.
+
+        This is the load-order-independent Notion fix: the model can run
+        ``execute_code`` that reads ``NOTION_API_KEY`` on the very first turn —
+        without first calling ``skill_view('notion')`` to register it — because
+        the operator declared it in config. It exercises the *real*
+        ``_scrub_child_env`` so the config path is verified against the actual
+        sandbox scrubber, not a reimplementation. A Hermes provider credential
+        added to the same list is still stripped (config must not override the
+        credential blocklist — GHSA-rhgp-j443-p4rf).
+        """
+        from tools.code_execution_tool import _scrub_child_env
+        from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+
+        blocked_var = next(iter(_HERMES_PROVIDER_ENV_BLOCKLIST))
+        config = {
+            "terminal": {"env_passthrough": ["NOTION_API_KEY", blocked_var]}
+        }
+        (tmp_path / "config.yaml").write_text(yaml.dump(config))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _ep_mod._config_passthrough = None
+
+        # No skill_view / register_env_passthrough call — config is the only source.
+        assert is_env_passthrough("NOTION_API_KEY")
+        # The provider credential must be filtered out of the config allowlist.
+        assert not is_env_passthrough(blocked_var)
+
+        child_env = _scrub_child_env(
+            {
+                "NOTION_API_KEY": "ntn_synthetic",
+                blocked_var: "synthetic-secret",
+                "PATH": "/usr/bin",
+            },
+            is_passthrough=is_env_passthrough,
+            is_windows=False,
+        )
+        assert child_env["NOTION_API_KEY"] == "ntn_synthetic"
+        assert blocked_var not in child_env
+        assert child_env["PATH"] == "/usr/bin"
+
 
 class TestExecuteCodeIntegration:
     """Verify that the passthrough is checked in execute_code's env filtering."""

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -122,7 +122,7 @@ def register_env_passthrough(var_names: Iterable[str]) -> None:
 
 
 def _load_config_passthrough() -> frozenset[str]:
-    """Load ``tools.env_passthrough`` from config.yaml (cached)."""
+    """Load ``terminal.env_passthrough`` from config.yaml (cached)."""
     global _config_passthrough
     if _config_passthrough is not None:
         return _config_passthrough
@@ -155,7 +155,7 @@ def _load_config_passthrough() -> frozenset[str]:
                     continue
                 result.add(name)
     except Exception as e:
-        logger.debug("Could not read tools.env_passthrough from config: %s", e)
+        logger.debug("Could not read terminal.env_passthrough from config: %s", e)
 
     _config_passthrough = frozenset(result)
     return _config_passthrough
@@ -165,7 +165,7 @@ def is_env_passthrough(var_name: str) -> bool:
     """Check whether *var_name* is allowed to pass through to sandboxes.
 
     Returns ``True`` if the variable was registered by a skill or listed in
-    the user's ``tools.env_passthrough`` config.
+    the user's ``terminal.env_passthrough`` config.
     """
     if var_name in _get_allowed():
         return True


### PR DESCRIPTION
## Summary

Fixes a misleading config-key reference in the env-passthrough docstrings and adds a regression test for the **load-order-independent Notion sandbox path**. Together these make the safe, opt-in mechanism for exposing `NOTION_API_KEY` to `execute_code` discoverable and durable.

## Background: the safe option already exists

im7's `execute_code` sandbox strips secrets (including `NOTION_API_KEY`) from model-generated code — **this is a security feature** and must not be weakened by blanket-passing secrets in. I evaluated the two options in the brief:

1. **Curated opt-in allowlist** — `terminal.env_passthrough` in `config.yaml`, defaults empty, gated by `_HERMES_PROVIDER_ENV_BLOCKLIST` so Hermes-managed provider credentials can never be exposed (GHSA-rhgp-j443-p4rf). Plus skills auto-register their declared vars on `skill_view`.
2. Gateway-mediated Notion MCP/tool.

**Recommendation: option 1 (the curated allowlist).** It already exists on `main`, is documented, security-reviewed, and is exactly the "opt-in, defaults-off, non-secret-leaking" shape the brief asks for. `NOTION_API_KEY` is not a Hermes provider credential, so once allowlisted it passes the scrub. Option 2 is a larger build with product decisions and is unnecessary given option 1 already covers the use case safely.

## Why the symptom (`KeyError` on `NOTION_API_KEY`) still happens

The skill-declared passthrough only registers when the Notion skill is loaded **in the same session before** `execute_code` runs. If the model writes Notion code without first `skill_view('notion')`, the key was never registered → `KeyError`. The **load-order-independent** fix is the operator config (`terminal.env_passthrough: [NOTION_API_KEY]`), which is always in effect. This PR pins that path with a test and fixes the docstring that would send an operator to the wrong key.

## Changes

- **Docstring fix** (`tools/env_passthrough.py`): three references said `tools.env_passthrough`, but the code reads — and the user docs document — `terminal.env_passthrough`. An operator following the docstring to expose `NOTION_API_KEY` would edit the wrong key and it would silently never pass through. Corrected to match the actual key. No behavior change.
- **Regression test** (`tests/tools/test_env_passthrough.py`): proves `NOTION_API_KEY` named in `terminal.env_passthrough` survives the **real** `_scrub_child_env` sandbox scrubber with **no skill ever loaded**, while a Hermes provider credential added to the same config list is still stripped (config must not override the credential blocklist).

## Deployment note

For im7 specifically: set `terminal.env_passthrough: [NOTION_API_KEY]` in its `config.yaml` (and rebuild if on a stale image). That makes Notion usable from `execute_code` on the first turn without leaking any Hermes-managed credential into the sandbox.

## Test status

`python -m pytest tests/tools/test_env_passthrough.py tests/tools/test_skill_env_passthrough.py` → **25 passed** (24 existing + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNWm54UtvqvjgopDoxm54R
