### PR TITLE
fix(routing): strip group [sender] attribution before classifying

### DIFF
--- a/plugins/intelligent_routing/registration.py
+++ b/plugins/intelligent_routing/registration.py
@@ -30,6 +30,7 @@ different axis; reactive escalation still applies underneath the chosen tier.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Optional
 
 from .classifier import (
@@ -47,6 +48,23 @@ logger = logging.getLogger(__name__)
 # signal fires. Kept as a small, explicit set rather than guessing.
 _NON_INTERACTIVE_PLATFORMS = frozenset({"cron", "background", "scheduler", "batch"})
 
+# Shared multi-user (group) sessions prepend a sender attribution to the message
+# before it reaches pre_llm_call — gateway/run.py emits ``f"[{user_name}] {text}"``.
+# Left in place, that "[mare] " prefix makes the classifier's leading-imperative
+# check read "[mare]" instead of the real first word ("list"), so EVERY group
+# turn fails the mechanical test and routes premium — the router goes inert in
+# exactly the place agents live. Peel a SINGLE leading "[token] " attribution
+# (one line, bounded length, no nested "]") so the classifier sees the real ask.
+# Deliberately conservative: only one leading token, and the peeled remainder
+# still runs the full conservative classifier (fails open to premium on anything
+# non-mechanical), so an over-peel can never wrongly cheap-route real work.
+_SENDER_PREFIX_RE = re.compile(r"^\[[^\]\n]{1,64}\]\s+")
+
+
+def _strip_sender_prefix(message: str) -> str:
+    """Peel one leading ``[sender] `` group-attribution prefix, if present."""
+    return _SENDER_PREFIX_RE.sub("", message, count=1)
+
 
 def _signals_from_kwargs(**kwargs: Any) -> TurnSignals:
     """Derive cheap ``TurnSignals`` from the ``pre_llm_call`` kwargs.
@@ -60,6 +78,8 @@ def _signals_from_kwargs(**kwargs: Any) -> TurnSignals:
     message = kwargs.get("user_message") or ""
     if not isinstance(message, str):
         message = str(message)
+    # Peel the group sender-attribution prefix before classifying (see above).
+    message = _strip_sender_prefix(message)
     platform = (kwargs.get("platform") or "")
     platform = platform.strip().lower() if isinstance(platform, str) else ""
     is_background = platform in _NON_INTERACTIVE_PLATFORMS

--- a/tests/plugins/intelligent_routing/test_registration.py
+++ b/tests/plugins/intelligent_routing/test_registration.py
@@ -181,3 +181,56 @@ def test_route_override_honors_config_target():
             user_message="grep for TODO", model="claude-sonnet-5", platform="cli",
         )
     assert result["route"] == {"model": "qwen/qwen-2.5", "provider": "ollama"}
+
+
+# ---- group [sender] attribution prefix (Signal/group classifier bug) ---------
+#
+# In a shared multi-user (group) session the gateway prepends "[sender] " to the
+# message before it reaches pre_llm_call (gateway/run.py: `[{user_name}] {text}`).
+# That prefix made the classifier's leading-imperative-verb check see "[mare]"
+# instead of "list", so EVERY group turn failed the mechanical test and routed
+# premium — the intelligent router was inert in exactly the place agents live.
+# _signals_from_kwargs must strip a leading "[sender] " attribution before
+# classifying, without over-triggering on genuine judgment content.
+
+
+def test_group_prefixed_mechanical_turn_routes_cheap():
+    """A mechanical ask carrying a "[sender] " group prefix still routes cheap."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="[mare] list the numbers one to five",
+            model="claude-sonnet-5", platform="signal",
+        )
+    assert isinstance(result, dict)
+    assert result.get("route") == {
+        "model": "deepseek/deepseek-v3.2", "provider": "openrouter",
+    }
+
+
+def test_group_prefix_probe_matches_unprefixed():
+    """probe_route: the "[sender] " prefix must not change the tier vs. the bare
+    message — the classifier decides on the real content, not the attribution."""
+    bare = registration.probe_route("grep for TODO in the repo")
+    prefixed = registration.probe_route("[oz] grep for TODO in the repo")
+    assert prefixed["tier"] == bare["tier"] == "cheap"
+
+
+def test_group_prefix_does_not_make_judgment_cheap():
+    """Stripping the prefix must NOT over-trigger: a judgment ask that happens to
+    carry a group prefix still routes premium (no route override)."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="[mare] what should we prioritize next quarter and why?",
+            model="claude-sonnet-5", platform="signal",
+        )
+    assert "route" not in result
+
+
+def test_group_prefix_strip_is_single_leading_token_only():
+    """Only ONE leading bracketed attribution token is stripped; a second bracket
+    in the body is left intact (the strip is an attribution peel, not a cleaner)."""
+    # After peeling "[mare] ", the remaining "grep [WIP] logs" still leads with a
+    # verb → cheap. This pins that we peel exactly one leading token.
+    assert registration.probe_route("[mare] grep [WIP] logs")["tier"] == "cheap"


### PR DESCRIPTION
## Problem

The intelligent router was **inert in group chats** — exactly where the fleet agents live. Live evidence from cyborg on a Signal group ping:

```
conversation turn: model=claude-sonnet-4-6 provider=anthropic ... msg='[mare] list the numbers one to five'
API call #1: model=claude-sonnet-4-6 provider=anthropic
```

No `intelligent_routing: routed` line — it stayed on the Anthropic premium tier instead of routing the mechanical ask to deepseek.

## Root cause

In a shared multi-user (group) session, the gateway prepends a sender attribution before the message reaches `pre_llm_call`:

```python
# gateway/run.py
if _is_shared_multi_user and source.user_name:
    message_text = f"[{source.user_name}] {message_text}"
```

The classifier's mechanical test keys on **the first word being an imperative verb**. With the prefix, it sees `[mare]`, not `list`, so every group turn fails the mechanical check and fails open to premium. Proven in-container:

```
decide_tier("list the numbers one to five")        → cheap
decide_tier("[mare] list the numbers one to five") → premium
```

## Fix

`_signals_from_kwargs` peels a single leading `[token] ` attribution prefix before classifying. Conservative by construction:
- **one** leading token only, bounded length (≤64), single line (`^\[[^\]\n]{1,64}\]\s+`)
- the peeled remainder still runs the **full fail-open classifier**, so an over-peel can never wrongly cheap-route real work (a judgment ask with a prefix still routes premium).

## Tests

`tests/plugins/intelligent_routing/test_registration.py` (RGTDD, red→green):
- group-prefixed mechanical turn routes cheap + emits the route override
- `probe_route` tier is identical prefixed vs. bare
- prefix does **not** make a judgment ask cheap (no over-trigger)
- exactly one leading token is peeled

Full routing suite (91 tests) green.

## Context

Follow-up to #81 (base_url resolution) — that fixed *where* a routed turn goes; this fixes *whether the router fires at all* in groups. With both, the next mechanical group turn on cyborg routes to deepseek live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)