### PR TITLE
feat(plugin): bestiary token intelligence plugin

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -472,4 +472,8 @@ def _positive_int(value: Any, default: int) -> int:
 
 
 def _sha256(value: str) -> str:
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+    # surrogatepass: tool results scraped from the web can carry unpaired
+    # UTF-16 surrogates (e.g. half of a mathematical-bold pair); a strict
+    # encode raises and takes down the whole conversation loop. The hash only
+    # needs deterministic bytes, not valid UTF-8.
+    return hashlib.sha256(value.encode("utf-8", "surrogatepass")).hexdigest()

--- a/plugins/bestiary/__init__.py
+++ b/plugins/bestiary/__init__.py
@@ -1,0 +1,14 @@
+from plugins.bestiary.tools import (
+    BESTIARY_RESOLVE_SCHEMA, _handle_bestiary_resolve, _check_bestiary_available,
+    BESTIARY_SIGNALS_SCHEMA, _handle_bestiary_signals,
+    BESTIARY_HEALTH_SCHEMA, _handle_bestiary_health,
+)
+
+
+def register(ctx) -> None:
+    ctx.register_tool("bestiary_resolve", toolset="bestiary", schema=BESTIARY_RESOLVE_SCHEMA,
+                      handler=_handle_bestiary_resolve, check_fn=_check_bestiary_available, emoji="🔍")
+    ctx.register_tool("bestiary_signals", toolset="bestiary", schema=BESTIARY_SIGNALS_SCHEMA,
+                      handler=_handle_bestiary_signals, check_fn=_check_bestiary_available, emoji="📊")
+    ctx.register_tool("bestiary_health", toolset="bestiary", schema=BESTIARY_HEALTH_SCHEMA,
+                      handler=_handle_bestiary_health, check_fn=_check_bestiary_available, emoji="💚")

--- a/plugins/bestiary/plugin.yaml
+++ b/plugins/bestiary/plugin.yaml
@@ -1,0 +1,9 @@
+name: bestiary
+version: 1.0.0
+description: "Crypto token intelligence via the Bestiary data substrate — resolve tokens by any identifier, check social signal aggregates, and verify connectivity. Set BESTIARY_URL to point at your bestiary API instance."
+author: nimbleco
+kind: backend
+provides_tools:
+  - bestiary_resolve
+  - bestiary_signals
+  - bestiary_health

--- a/plugins/bestiary/tools.py
+++ b/plugins/bestiary/tools.py
@@ -1,0 +1,107 @@
+"""Bestiary tools — HTTP calls via stdlib urllib only (zero extra deps)."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+from tools.registry import tool_error, tool_result
+
+_BESTIARY_URL = lambda: os.environ.get("BESTIARY_URL", "http://localhost:8787").rstrip("/")
+
+
+def _check_bestiary_available() -> bool:
+    try:
+        urllib.request.urlopen(f"{_BESTIARY_URL()}/health", timeout=5)
+        return True
+    except Exception:
+        return False
+
+
+def _handle_bestiary_resolve(args: dict, **kw) -> str:
+    query = args.get("query", "")
+    body = json.dumps({"input": query}).encode()
+    req = urllib.request.Request(
+        f"{_BESTIARY_URL()}/v0/resolve",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            if resp.status < 200 or resp.status >= 300:
+                return tool_error(f"bestiary resolve failed: {resp.status}")
+            return tool_result(json.loads(resp.read()))
+    except urllib.error.HTTPError as exc:
+        return tool_error(f"bestiary resolve failed: {exc.code}")
+    except Exception as exc:
+        return tool_error(f"bestiary resolve error: {exc}")
+
+
+def _handle_bestiary_signals(args: dict, **kw) -> str:
+    canonical_token_id = args.get("canonical_token_id", "")
+    window_days = int(args.get("window_days") or 30)
+    url = f"{_BESTIARY_URL()}/v0/tokens/{canonical_token_id}/signals?windowDays={window_days}"
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            if resp.status < 200 or resp.status >= 300:
+                return tool_error(f"bestiary signals failed: {resp.status}")
+            return tool_result(json.loads(resp.read()))
+    except urllib.error.HTTPError as exc:
+        return tool_error(f"bestiary signals failed: {exc.code}")
+    except Exception as exc:
+        return tool_error(f"bestiary signals error: {exc}")
+
+
+def _handle_bestiary_health(args: dict, **kw) -> str:
+    try:
+        with urllib.request.urlopen(f"{_BESTIARY_URL()}/health", timeout=5) as resp:
+            return tool_result(json.loads(resp.read()))
+    except Exception as exc:
+        return tool_error(f"bestiary health check failed: {exc}")
+
+
+BESTIARY_RESOLVE_SCHEMA = {
+    "name": "bestiary_resolve",
+    "description": "Resolve a crypto token by any identifier and return its canonical data from the Bestiary substrate.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "The token to look up: a symbol (e.g. 'WETH'), EVM address (e.g. '0x...'), or coingecko_id (e.g. 'weth').",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+BESTIARY_SIGNALS_SCHEMA = {
+    "name": "bestiary_signals",
+    "description": "Fetch windowed social signal aggregates for a token from the Bestiary substrate.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "canonical_token_id": {
+                "type": "string",
+                "description": "The canonical token ID as returned by bestiary_resolve.",
+            },
+            "window_days": {
+                "type": "integer",
+                "description": "Number of days to look back for signals.",
+            },
+        },
+        "required": ["canonical_token_id"],
+    },
+}
+
+BESTIARY_HEALTH_SCHEMA = {
+    "name": "bestiary_health",
+    "description": "Health check for the Bestiary API — confirms the service is reachable.",
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -256,3 +256,24 @@ def test_reset_for_turn_clears_bounded_guardrail_state():
 
     assert controller.before_call("web_search", {"query": "same"}).action == "allow"
     assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+
+def test_after_call_survives_lone_surrogates_in_result_and_args():
+    # Scraped web/social text can contain unpaired UTF-16 surrogates (e.g. the
+    # first half of a mathematical-bold pair, '\ud835'). str.encode('utf-8')
+    # rejects them, and the result hasher crashed the whole conversation loop
+    # (live outage: "Outer loop error in API call #34 ... surrogates not
+    # allowed"). Weird text must never take down the loop.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, exact_failure_block_after=2, no_progress_block_after=2)
+    )
+    dirty = "price \ud835 update"
+
+    decision = controller.after_call("web_search", {"query": dirty}, dirty, failed=False)
+    assert decision.action in {"allow", "warn"}
+
+    # hashing stays deterministic: the same dirty failure twice still trips
+    # the exact-failure guard, proving the hash is stable across calls
+    controller.after_call("web_search", {"query": dirty}, '{"error":"\ud835 boom"}', failed=True)
+    controller.after_call("web_search", {"query": dirty}, '{"error":"\ud835 boom"}', failed=True)
+    assert controller.before_call("web_search", {"query": dirty}).action == "block"


### PR DESCRIPTION
## Summary

- Adds a new `bestiary` plugin with 3 tools: `bestiary_resolve`, `bestiary_signals`, and `bestiary_health`
- Zero new dependencies — all HTTP calls use Python's stdlib `urllib.request`
- Tools gate on `_check_bestiary_available()` so they register cleanly even when the service is unreachable

## Tools

| Tool | Endpoint | Purpose |
|------|----------|---------|
| `bestiary_resolve` | `POST /v0/resolve` | Resolve any token identifier (symbol, EVM address, coingecko_id) to canonical data |
| `bestiary_signals` | `GET /v0/tokens/:id/signals?windowDays=N` | Fetch windowed social signal aggregates for a token |
| `bestiary_health` | `GET /health` | Confirm the bestiary service is reachable |

## Configuration

\`BESTIARY_URL\` defaults to \`http://localhost:8787\`. For deployed agents, add \`BESTIARY_URL=http://{host}:8787\` to the agent's env vars via the HSM key vault.

## Test plan

- [ ] Confirm plugin loads on agent startup (\`hermes tools\` shows \`bestiary_resolve\`, \`bestiary_signals\`, \`bestiary_health\`)
- [ ] \`bestiary_health\` returns 200 when bestiary is running on Mini
- [ ] \`bestiary_resolve\` with \`{"query": "WETH"}\` returns canonical token data
- [ ] \`bestiary_signals\` with a known \`canonical_token_id\` returns signal aggregates
- [ ] Tools return a clean error (not a crash) when \`BESTIARY_URL\` is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)