### PR TITLE
feat(routing): user model directive — 'use fable for this' overrides classifier

### DIFF
--- a/plugins/intelligent_routing/registration.py
+++ b/plugins/intelligent_routing/registration.py
@@ -48,6 +48,36 @@ logger = logging.getLogger(__name__)
 # signal fires. Kept as a small, explicit set rather than guessing.
 _NON_INTERACTIVE_PLATFORMS = frozenset({"cron", "background", "scheduler", "batch"})
 
+# --- User model directive ("use fable for this") ---
+# A user can explicitly request a model by name. The directive short-circuits
+# the classifier entirely — fires BEFORE the mechanical/judgment split.
+# Critical: "use" IS in _IMPERATIVE_VERBS, so without this early intercept
+# a bare "use fable" would be classified mechanical → cheap → deepseek.
+#
+# Map: lowercase keyword → (model_id, provider). None means "stay on primary".
+_USER_MODEL_MAP = {
+    "fable": ("claude-fable-5", "anthropic"),
+    "opus": ("claude-opus-4-8", "anthropic"),
+    "sonnet": ("claude-sonnet-4-6", "anthropic"),
+    "haiku": ("claude-haiku-4-5-20251001", "anthropic"),
+    "deepseek": ("deepseek/deepseek-v3.2", "openrouter"),
+    "claude": None,  # "use claude" = stay on configured primary
+}
+_DIRECTIVE_RE = re.compile(
+    r"\buse\s+({models})\b".format(models="|".join(re.escape(k) for k in _USER_MODEL_MAP)),
+    re.IGNORECASE,
+)
+# Sentinel: "no directive found" — separate from None ("use claude" / no override).
+_NO_DIRECTIVE = object()
+
+
+def _parse_model_directive(message: str) -> object:
+    """Return (model, provider), None (stay on primary), or ``_NO_DIRECTIVE``."""
+    m = _DIRECTIVE_RE.search(message)
+    if not m:
+        return _NO_DIRECTIVE
+    return _USER_MODEL_MAP.get(m.group(1).lower(), _NO_DIRECTIVE)
+
 # Shared multi-user (group) sessions prepend a sender attribution to the message
 # before it reaches pre_llm_call — gateway/run.py emits ``f"[{user_name}] {text}"``.
 # Left in place, that "[mare] " prefix makes the classifier's leading-imperative
@@ -134,6 +164,28 @@ def on_pre_llm_call(**kwargs: Any) -> Optional[dict]:
         if not is_intelligent_routing_enabled():
             return None
 
+        # Strip sender prefix before any further parsing (group-chat attribution).
+        raw_message = kwargs.get("user_message") or ""
+        if not isinstance(raw_message, str):
+            raw_message = str(raw_message)
+        stripped = _strip_sender_prefix(raw_message)
+
+        # ── User model directive ("use fable for this") ───────────────────────
+        # Check BEFORE the classifier. "use" is in _IMPERATIVE_VERBS so without
+        # this intercept "use fable" would be classified mechanical → deepseek.
+        directive = _parse_model_directive(stripped)
+        if directive is not _NO_DIRECTIVE:
+            if directive is None:
+                # "use claude" — stay on configured primary; inject a context note.
+                reason = "user-requested → primary"
+                line = _reason_line(kwargs.get("model"), kwargs.get("provider"), reason)
+                return {"context": line}
+            model, provider = directive
+            reason = f"user-requested → {model.split('/')[0] if '/' in model else model}"
+            line = _reason_line(kwargs.get("model"), kwargs.get("provider"), reason)
+            return {"route": {"model": model, "provider": provider}, "context": line}
+
+        # ── Heuristic classifier (no explicit directive) ───────────────────────
         sig = _signals_from_kwargs(**kwargs)
 
         # THE routing decision — deliberately SIMPLE (the classifier is not the

--- a/tests/plugins/intelligent_routing/test_registration.py
+++ b/tests/plugins/intelligent_routing/test_registration.py
@@ -234,3 +234,96 @@ def test_group_prefix_strip_is_single_leading_token_only():
     # After peeling "[mare] ", the remaining "grep [WIP] logs" still leads with a
     # verb → cheap. This pins that we peel exactly one leading token.
     assert registration.probe_route("[mare] grep [WIP] logs")["tier"] == "cheap"
+
+
+# ---- user model directive ("use fable for this") ----------------------------
+#
+# A user can explicitly request a model tier mid-message. The directive wins
+# over the classifier: "use fable" routes to Fable even if the turn looks
+# mechanical; "use deepseek" routes cheap even if the classifier would go
+# premium. The parse fires BEFORE the classifier so "use fable" isn't
+# misread as an imperative verb → mechanical → cheap route to deepseek
+# (which is what would happen without the directive intercept — "use" IS in
+# _IMPERATIVE_VERBS, so a bare "use fable" would currently route deepseek).
+
+
+def test_user_directive_fable_routes_to_fable():
+    """'use fable' overrides the classifier and routes to claude-fable-5."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="hey can you use fable for this task?",
+            model="claude-sonnet-5", platform="signal",
+        )
+    assert isinstance(result, dict)
+    assert result["route"] == {"model": "claude-fable-5", "provider": "anthropic"}
+    assert "user-requested" in result["context"]
+
+
+def test_user_directive_deepseek_routes_cheap():
+    """'use deepseek' routes to the cheap deepseek tier even on a judgment-shaped ask."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="design the multi-tenant auth system, use deepseek",
+            model="claude-sonnet-5", platform="cli",
+        )
+    assert isinstance(result, dict)
+    assert result["route"] == {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}
+
+
+def test_user_directive_opus_routes_to_opus():
+    """'use opus' routes to claude-opus-4-8 / anthropic."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="use opus — this needs max reasoning",
+            model="claude-sonnet-5", platform="cli",
+        )
+    assert isinstance(result, dict)
+    assert result["route"]["model"] == "claude-opus-4-8"
+    assert result["route"]["provider"] == "anthropic"
+
+
+def test_user_directive_group_prefix_plus_model():
+    """Directive still fires when a group [sender] prefix is present."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="[mare] use fable for this please",
+            model="claude-sonnet-5", platform="signal",
+        )
+    assert isinstance(result, dict)
+    assert result["route"] == {"model": "claude-fable-5", "provider": "anthropic"}
+
+
+def test_user_directive_wins_over_mechanical_classifier():
+    """'use fable' on a mechanical-shaped message routes to fable, NOT deepseek.
+
+    Without directive intercept, 'use' is in _IMPERATIVE_VERBS so a message
+    starting with 'use fable' would be classified mechanical → cheap → deepseek.
+    The directive must short-circuit the classifier and route to fable instead.
+    """
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="use fable",
+            model="claude-sonnet-5", platform="cli",
+        )
+    assert isinstance(result, dict)
+    route = result.get("route", {})
+    assert route.get("model") == "claude-fable-5", (
+        f"'use fable' must route to fable, not deepseek; got route={route}"
+    )
+
+
+def test_no_directive_falls_through_to_classifier():
+    """Without a model directive the classifier runs normally."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="grep for TODO in the repo",
+            model="claude-sonnet-5", platform="cli",
+        )
+    assert isinstance(result, dict)
+    assert result.get("route") == {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}


### PR DESCRIPTION
## Summary

- Adds user-explicit model routing: `use fable`, `use opus`, `use deepseek`, etc. overrides the heuristic classifier for that turn
- Directive check fires **before** the mechanical/judgment split — critical because `use` is in `_IMPERATIVE_VERBS` and a bare `"use fable"` would otherwise be classified mechanical → cheap → deepseek
- Supported: `fable` (claude-fable-5), `opus` (claude-opus-4-8), `sonnet` (claude-sonnet-4-6), `haiku` (claude-haiku-4-5-20251001), `deepseek` (deepseek/deepseek-v3.2 / openrouter), `claude` (stay on primary / no override)
- Works through the existing `routing_override` interface — same turn-scoped, fail-safe path as the classifier

## Test plan

- [x] `use fable for this task` → routes claude-fable-5/anthropic
- [x] `use deepseek` on a judgment-shaped message → routes cheap (overrides classifier)
- [x] `use opus` → routes claude-opus-4-8/anthropic
- [x] `[mare] use fable for this please` (group prefix + directive) → strips group prefix, then routes fable
- [x] bare `use fable` → fable (NOT deepseek — this is the anti-regression pin for the IMPERATIVE_VERBS collision)
- [x] no directive → classifier runs normally (grep → cheap, architecture → premium)
- [x] 111 routing tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)