### PR TITLE
fix(session): Signal group session_key double-prefix + traversal false-positive

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -95,21 +95,24 @@ from .whatsapp_identity import (
 )
 from utils import atomic_replace
 
-# Session keys/ids flow into filesystem paths downstream (e.g.
+# session_id (not session_key) flows into filesystem paths downstream (e.g.
 # ``sessions_dir / f"{session_id}.json"`` in hermes_state, request-dump
-# filenames in agent_runtime_helpers). Any value that could escape the
-# sessions directory as a path must be rejected at the entry boundary.
-# Rejects: parent traversal (``..``), a path separator anywhere (``/`` or
-# ``\``, so a non-leading Windows separator can't slip through), and a
-# leading Windows drive letter (``C:``). Legitimate session keys are
-# colon-delimited multi-segment ids (``agent:main:<platform>:...``) and
-# never contain these, so there are no false positives in practice.
-def _is_path_unsafe(value: object) -> bool:
+# filenames in agent_runtime_helpers) — session_key is only ever used as a
+# dict key / JSON field, never interpolated into a path. Any value that
+# could escape the sessions directory as a path must be rejected at the
+# entry boundary. Rejects: parent traversal (``..``, always — both fields),
+# a path separator (``/`` or ``\``; ``/`` is allowed in session_key via
+# ``allow_forward_slash``, since platforms with base64 native chat ids
+# (Signal groups) legitimately produce a "/" there and it never reaches a
+# filesystem join), and a leading Windows drive letter (``C:``).
+def _is_path_unsafe(value: object, *, allow_forward_slash: bool = False) -> bool:
     """Return True if ``value`` could traverse outside the sessions dir."""
     if not value:
         return False
     s = str(value)
-    if ".." in s or "/" in s or "\\" in s:
+    if ".." in s or "\\" in s:
+        return True
+    if "/" in s and not allow_forward_slash:
         return True
     # Leading Windows drive path, e.g. "C:\..." or "d:/...". A bare "x:"
     # with no following separator isn't a usable absolute path, and the
@@ -741,9 +744,15 @@ class SessionEntry:
         session_key = data["session_key"]
         session_id = data["session_id"]
 
-        # Validate path-sensitive fields to prevent directory traversal (CWE-22)
-        for _field, _val in (("session_key", session_key), ("session_id", session_id)):
-            if _is_path_unsafe(_val):
+        # Validate path-sensitive fields to prevent directory traversal (CWE-22).
+        # session_key allows "/" (base64 native chat ids, e.g. Signal groups —
+        # never reaches a filesystem join); session_id stays strict since it
+        # is interpolated directly into transcript filenames.
+        for _field, _val, _allow_slash in (
+            ("session_key", session_key, True),
+            ("session_id", session_id, False),
+        ):
+            if _is_path_unsafe(_val, allow_forward_slash=_allow_slash):
                 raise ValueError(
                     f"Invalid {_field}: potential directory traversal detected"
                 )
@@ -893,7 +902,16 @@ def build_session_key(
     key_parts = [ns, platform, source.chat_type]
 
     if source.chat_id:
-        key_parts.append(source.chat_id)
+        # Some adapters (Signal: gateway/platforms/signal.py) already bake
+        # the chat_type into chat_id itself ("group:<id>"). Strip a
+        # redundant leading "<chat_type>:" so the key doesn't double up
+        # ("signal:group:group:<id>") — chat_type above already supplies
+        # that segment once.
+        chat_id_for_key = source.chat_id
+        _type_prefix = f"{source.chat_type}:"
+        if chat_id_for_key.startswith(_type_prefix):
+            chat_id_for_key = chat_id_for_key[len(_type_prefix):]
+        key_parts.append(chat_id_for_key)
     if source.thread_id:
         key_parts.append(source.thread_id)
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock
 from gateway.config import Platform, HomeChannel, GatewayConfig, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import (
+    SessionEntry,
     SessionSource,
     SessionStore,
     build_session_context,
@@ -1186,13 +1187,22 @@ class TestSessionEntryFromDictTraversalValidation:
             SessionEntry.from_dict(self._entry(session_id="D:\\path\\to\\file"))
 
     def test_session_id_non_leading_separator_raises(self):
-        """A path separator anywhere — not just leading — must be rejected,
-        since a non-leading backslash is still a Windows traversal vector."""
+        """A path separator anywhere in session_id — not just leading — must
+        be rejected, since a non-leading backslash is still a Windows
+        traversal vector. session_id is interpolated directly into
+        transcript filenames (unlike session_key — see
+        TestSessionKeyPathSafety), so it stays fully strict."""
         from gateway.session import SessionEntry
         with pytest.raises(ValueError, match="session_id"):
             SessionEntry.from_dict(self._entry(session_id="good\\..\\bad"))
+
+    def test_session_key_backslash_raises(self):
+        """Unlike '/' (see TestSessionKeyPathSafety — legitimate for
+        base64 native chat ids like Signal groups), a backslash in
+        session_key is never legitimate and must still be rejected."""
+        from gateway.session import SessionEntry
         with pytest.raises(ValueError, match="session_key"):
-            SessionEntry.from_dict(self._entry(session_key="agent:main:good/sub"))
+            SessionEntry.from_dict(self._entry(session_key="agent:main:good\\sub"))
 
 
 class TestEnsureLoadedSkipsInvalidEntries:
@@ -1580,3 +1590,77 @@ class TestGatewaySessionDbRecovery:
         assert reset.session_id != entry.session_id
         assert reset.was_auto_reset is True
         assert reset.auto_reset_reason == "idle"
+
+
+class TestSignalGroupSessionKey:
+    """Regression: signal.py sets ``chat_id = f"group:{group_id}"`` for
+    groups (gateway/platforms/signal.py:973) — build_session_key must not
+    also prepend chat_type ("group"), or Signal group keys come out
+    double-prefixed ("agent:main:signal:group:group:<id>") instead of the
+    single-prefixed form every other platform produces."""
+
+    def test_signal_group_key_has_single_group_prefix(self):
+        source = SessionSource(
+            platform=Platform.SIGNAL,
+            chat_id="group:f1Ikxzkk8/rr8D4qXG20PyyvqxdLz1ATvwAfr5zunWw=",
+            chat_type="group",
+            user_name="mare",
+        )
+        key = build_session_key(source, group_sessions_per_user=False)
+        assert key == (
+            "agent:main:signal:group:f1Ikxzkk8/rr8D4qXG20PyyvqxdLz1ATvwAfr5zunWw="
+        )
+
+    def test_signal_dm_key_unaffected(self):
+        """DMs don't go through the chat_type/chat_id group branch at all —
+        confirm the fix doesn't touch them."""
+        source = SessionSource(
+            platform=Platform.SIGNAL,
+            chat_id="+13046886277",
+            chat_type="dm",
+        )
+        assert build_session_key(source) == "agent:main:signal:dm:+13046886277"
+
+
+class TestSessionKeyPathSafety:
+    """session_key legitimately contains ``/`` for platforms whose native
+    chat ids are base64 (Signal groups). session_key is never interpolated
+    into a filesystem path — only session_id is (see the comment above
+    ``_is_path_unsafe`` in gateway/session.py) — so it must not be rejected
+    as a directory-traversal attempt. session_id, which *is* used to build
+    ``sessions_dir / f"{session_id}.json"``, must stay strict."""
+
+    def _base_data(self, **overrides):
+        data = {
+            "session_key": "agent:main:signal:dm:+13046886277",
+            "session_id": "20260718_000000_deadbeef",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+        }
+        data.update(overrides)
+        return data
+
+    def test_from_dict_accepts_slash_in_session_key(self):
+        data = self._base_data(
+            session_key=(
+                "agent:main:signal:group:"
+                "f1Ikxzkk8/rr8D4qXG20PyyvqxdLz1ATvwAfr5zunWw="
+            )
+        )
+        entry = SessionEntry.from_dict(data)
+        assert entry.session_key == data["session_key"]
+
+    def test_from_dict_still_rejects_dotdot_in_session_key(self):
+        data = self._base_data(session_key="agent:main:signal:group:../../etc/passwd")
+        with pytest.raises(ValueError, match="traversal"):
+            SessionEntry.from_dict(data)
+
+    def test_from_dict_still_rejects_slash_in_session_id(self):
+        data = self._base_data(session_id="abc/def")
+        with pytest.raises(ValueError, match="traversal"):
+            SessionEntry.from_dict(data)
+
+    def test_from_dict_still_rejects_dotdot_in_session_id(self):
+        data = self._base_data(session_id="../../etc/passwd")
+        with pytest.raises(ValueError, match="traversal"):
+            SessionEntry.from_dict(data)


### PR DESCRIPTION
## Summary
- `build_session_key` no longer double-prefixes Signal group session keys (`signal:group:group:<id>` → `signal:group:<id>`) — Signal's `chat_id` already carries the `group:` prefix (`gateway/platforms/signal.py:973`), and `chat_type` was adding a second one.
- `_is_path_unsafe`'s directory-traversal guard was rejecting any `/` in `session_key`, which every Signal group id (base64) legitimately contains. That dropped every Signal group session from the `sessions.json` load index on every gateway restart, logged as `Invalid session_key: potential directory traversal detected`, silently resetting persisted metadata (cost tracking, `suspended`/`resume_pending`, `model_override`). Verified by grep that `session_key` is never interpolated into a filesystem path — only `session_id` is (`sessions_dir / f"{session_id}.json"`) — so `session_key` now allows `/` while `session_id` stays fully strict (still rejects `..`, `\`, drive letters).
- Updated one pre-existing regression test (`test_session_id_non_leading_separator_raises`) that asserted `session_key` + `/` must raise, since that assumption was the root cause; split it into a session_id-only test plus a new `test_session_key_backslash_raises` covering the separator that's still rejected in `session_key`.

Found while live-verifying the intelligent-routing user-directive fleet rollout — a real Signal group ("mare/cyborg experiment") tripped this warning on gateway boot.

**Not Signal-specific**: the double-prefix root cause (an adapter pre-baking `chat_type` into `chat_id`, e.g. `f"group:{id}"`) also affects `gateway/platforms/yuanbao.py:1518` (confirmed reachable via `build_session_key`) and would affect `plugins/platforms/simplex/adapter.py` and `gateway/platforms/webhook.py` if their session-key construction routed through the same path. This PR fixes the general case, so it silently corrects the same live bug for yuanbao too — flagging here so it's not misattributed later. (Found during independent review.)

## Test plan
- [x] New tests (`TestSignalGroupSessionKey`, `TestSessionKeyPathSafety`) written first, watched fail (RED) against the unfixed code
- [x] `tests/gateway/test_session.py` — 102 passed
- [x] `tests/gateway/` full suite — 8805 passed, 8 failed; all 8 failures reproduced independently against unmodified `main` (sandboxed-subprocess + suite-order flakiness), none touch session-key logic
- [x] Independent CTO-level audit (fresh-context review agent, no involvement in the original fix): grepped all `session_key` usages repo-wide for path/SQL construction (none found — session_id is the only field interpolated into filesystem paths), traced the SQLite peer-recovery path confirming old sessions survive the key-format change, verified negative-case test coverage. Verdict: **MERGE**, risk **LOW**, no blocking issues.