### PR TITLE
fix(gateway): event-loop freeze watchdog — self-heal + diagnose silent hangs

### DIFF
--- a/gateway/event_loop_watchdog.py
+++ b/gateway/event_loop_watchdog.py
@@ -1,0 +1,190 @@
+"""Event-loop freeze watchdog — last-resort detection + self-heal.
+
+A hung *synchronous* call anywhere on the gateway's event-loop thread (a
+blocking socket read, a stuck subprocess, a lock held by another process)
+silently stalls every coroutine at once — SSE listeners, health monitors,
+message handling, the housekeeping thread's scheduled work — with near-zero
+CPU, since the process is blocked on I/O rather than spinning. Nothing else
+in the gateway can detect this: the SSE-specific health monitor
+(``gateway.platforms.signal._health_monitor`` and its per-platform
+equivalents) only notices when *its own* task stops running, which never
+happens because the freeze is upstream of it too.
+
+This module is a coarse, platform-agnostic safety net: periodically prove
+the loop is still processing a trivial coroutine, and if it stays
+unresponsive past a threshold, dump every thread's current stack (this
+works even while the loop itself is frozen — ``faulthandler`` reads thread
+state directly via the C level, it doesn't need the loop's cooperation)
+and hard-exit. The gateway runs under s6 supervision in production
+(``s6-supervise gateway-default``, auto-restart on crash), so a hard exit
+restores service automatically instead of the process staying dead for
+hours with nothing in the logs to explain why.
+
+This does not fix the underlying freeze — it only bounds how long the
+gateway stays dead once one happens, and captures the evidence needed to
+root-cause it next time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import faulthandler
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CHECK_INTERVAL = 30.0
+DEFAULT_UNRESPONSIVE_THRESHOLD = 90.0
+DEFAULT_PROBE_TIMEOUT = 15.0
+
+
+def probe_loop_responsive(loop: asyncio.AbstractEventLoop, timeout: float) -> bool:
+    """Return True if *loop* processes a trivial coroutine within *timeout* seconds.
+
+    Called from a different thread than the loop itself — that's the whole
+    point: a frozen loop can't answer its own liveness check.
+    """
+    coro = asyncio.sleep(0)
+    try:
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+    except RuntimeError:
+        # Loop isn't running / already closed — nothing to watch. Close the
+        # coroutine explicitly: run_coroutine_threadsafe raised before
+        # scheduling it, so it would otherwise never be awaited or closed.
+        coro.close()
+        return False
+    try:
+        future.result(timeout=timeout)
+        return True
+    except concurrent.futures.TimeoutError:
+        future.cancel()
+        return False
+    except Exception:
+        return False
+
+
+def dump_diagnostics(dump_path: Path) -> None:
+    """Write an all-thread stack dump to *dump_path*.
+
+    Uses ``faulthandler.dump_traceback``, not ``traceback``/``sys._current_frames``
+    wrapped in asyncio helpers — those would themselves need the frozen loop
+    to cooperate. ``faulthandler`` reads thread state directly and works
+    regardless of what any individual thread is blocked on.
+    """
+    dump_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(dump_path, "w") as fh:
+        fh.write(
+            f"Event loop freeze detected at "
+            f"{datetime.now(timezone.utc).isoformat()}\n\n"
+        )
+        faulthandler.dump_traceback(file=fh, all_threads=True)
+
+
+def _default_dump_path() -> Path:
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return get_hermes_home() / "logs" / f"event_loop_freeze_{ts}.log"
+
+
+class EventLoopWatchdog:
+    """Detects a fully-frozen event loop and self-heals by exiting the process.
+
+    The decision logic (:meth:`check_once`) is pure/injectable so it can be
+    tested without real threads, real sleeps, or an actual process exit —
+    see ``tests/gateway/test_event_loop_watchdog.py``. :meth:`run` is the
+    thin real-world wrapper meant to be started on its own daemon thread.
+    """
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        check_interval: float = DEFAULT_CHECK_INTERVAL,
+        unresponsive_threshold: float = DEFAULT_UNRESPONSIVE_THRESHOLD,
+        probe_timeout: float = DEFAULT_PROBE_TIMEOUT,
+        probe_fn: Callable[[asyncio.AbstractEventLoop, float], bool] = probe_loop_responsive,
+        dump_fn: Callable[[Path], None] = dump_diagnostics,
+        dump_path_fn: Callable[[], Path] = _default_dump_path,
+        exit_fn: Callable[[int], None] = lambda code: os._exit(code),
+        clock_fn: Callable[[], float] = time.monotonic,
+    ):
+        self._loop = loop
+        self._check_interval = check_interval
+        self._unresponsive_threshold = unresponsive_threshold
+        self._probe_timeout = probe_timeout
+        self._probe_fn = probe_fn
+        self._dump_fn = dump_fn
+        self._dump_path_fn = dump_path_fn
+        self._exit_fn = exit_fn
+        self._clock_fn = clock_fn
+        self._first_unresponsive_at: Optional[float] = None
+
+    def check_once(self) -> bool:
+        """Run one probe cycle.
+
+        Returns True if a freeze was declared (dump + exit were invoked) —
+        callers should stop looping once this returns True.
+        """
+        now = self._clock_fn()
+        if self._probe_fn(self._loop, self._probe_timeout):
+            self._first_unresponsive_at = None
+            return False
+
+        if self._first_unresponsive_at is None:
+            self._first_unresponsive_at = now
+            logger.warning("Event loop watchdog: probe unresponsive, starting freeze timer")
+            return False
+
+        stalled_for = now - self._first_unresponsive_at
+        if stalled_for < self._unresponsive_threshold:
+            return False
+
+        dump_path = self._dump_path_fn()
+        logger.critical(
+            "Event loop watchdog: loop unresponsive for %.0fs (threshold %.0fs) — "
+            "dumping thread stacks to %s and exiting so the supervisor restarts us",
+            stalled_for, self._unresponsive_threshold, dump_path,
+        )
+        try:
+            self._dump_fn(dump_path)
+        except Exception:
+            logger.exception("Event loop watchdog: diagnostic dump failed")
+        self._exit_fn(1)
+        return True
+
+    def run(self, stop_event: threading.Event) -> None:
+        """Blocking loop — run this on its own daemon thread."""
+        logger.info(
+            "Event loop watchdog started (check_interval=%.0fs, unresponsive_threshold=%.0fs)",
+            self._check_interval, self._unresponsive_threshold,
+        )
+        while not stop_event.is_set():
+            if self.check_once():
+                return
+            stop_event.wait(timeout=self._check_interval)
+        logger.info("Event loop watchdog stopped")
+
+
+def start_event_loop_watchdog(
+    loop: asyncio.AbstractEventLoop,
+    stop_event: threading.Event,
+    **kwargs,
+) -> threading.Thread:
+    """Create, start, and return the watchdog's daemon thread."""
+    watchdog = EventLoopWatchdog(loop, **kwargs)
+    thread = threading.Thread(
+        target=watchdog.run,
+        args=(stop_event,),
+        daemon=True,
+        name="event-loop-watchdog",
+    )
+    thread.start()
+    return thread

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20326,7 +20326,20 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         name="gateway-housekeeping",
     )
     housekeeping_thread.start()
-    
+
+    # Last-resort safety net: a hung synchronous call anywhere on the loop
+    # thread silently stalls every coroutine at once (SSE listeners, health
+    # monitors, message handling) with near-zero CPU, and nothing else in
+    # the gateway can detect it since the freeze is upstream of their own
+    # tasks too. Dumps all-thread stacks and hard-exits so s6 restarts the
+    # gateway instead of it staying dead for hours with no explanation in
+    # the logs. See gateway/event_loop_watchdog.py.
+    try:
+        from gateway.event_loop_watchdog import start_event_loop_watchdog
+        start_event_loop_watchdog(asyncio.get_running_loop(), cron_stop)
+    except Exception:
+        logger.warning("Event loop watchdog failed to start (non-fatal)", exc_info=True)
+
     # Wait for shutdown
     await runner.wait_for_shutdown()
 

--- a/tests/gateway/test_event_loop_watchdog.py
+++ b/tests/gateway/test_event_loop_watchdog.py
@@ -1,0 +1,247 @@
+"""Tests for gateway.event_loop_watchdog — freeze detection + self-heal."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from gateway import event_loop_watchdog as elw
+
+
+# ---------------------------------------------------------------------------
+# probe_loop_responsive — real background loop, no mocks. This is the actual
+# boundary-crossing mechanism the whole module depends on, so it's worth
+# proving against a genuine event loop rather than only unit-testing the
+# decision logic around it.
+# ---------------------------------------------------------------------------
+
+class TestProbeLoopResponsive:
+    @pytest.fixture
+    def running_loop(self):
+        """A real asyncio loop spinning on its own background thread."""
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, daemon=True)
+        thread.start()
+        # Give the loop a moment to actually start running.
+        for _ in range(50):
+            if loop.is_running():
+                break
+            time.sleep(0.01)
+        yield loop
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=2)
+        loop.close()
+
+    def test_true_for_a_responsive_loop(self, running_loop):
+        assert elw.probe_loop_responsive(running_loop, timeout=2.0) is True
+
+    def test_false_for_a_genuinely_blocked_loop(self, running_loop):
+        # Wedge the loop with real blocking work: call_soon_threadsafe
+        # callbacks run in-line on the loop thread, so a synchronous sleep
+        # here genuinely blocks every other coroutine — the actual failure
+        # mode this module exists to detect, not a simulation of it.
+        def _block_the_loop():
+            time.sleep(1.0)
+
+        running_loop.call_soon_threadsafe(_block_the_loop)
+        assert elw.probe_loop_responsive(running_loop, timeout=0.2) is False
+
+    def test_false_for_a_loop_that_is_not_running(self):
+        loop = asyncio.new_event_loop()
+        # Never started — run_coroutine_threadsafe raises RuntimeError.
+        assert elw.probe_loop_responsive(loop, timeout=1.0) is False
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# dump_diagnostics
+# ---------------------------------------------------------------------------
+
+class TestDumpDiagnostics:
+    def test_writes_a_file_with_thread_stack_content(self, tmp_path):
+        dump_path = tmp_path / "nested" / "freeze.log"
+        elw.dump_diagnostics(dump_path)
+        assert dump_path.exists()
+        content = dump_path.read_text()
+        assert "Event loop freeze detected" in content
+        # faulthandler.dump_traceback output includes "Thread" or "Current thread"
+        assert "Thread" in content or "thread" in content
+
+    def test_creates_parent_directories(self, tmp_path):
+        dump_path = tmp_path / "a" / "b" / "c" / "freeze.log"
+        elw.dump_diagnostics(dump_path)
+        assert dump_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# EventLoopWatchdog.check_once — pure decision logic, fully injected.
+# ---------------------------------------------------------------------------
+
+class FakeClock:
+    def __init__(self, start=0.0):
+        self.now = start
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def _make_watchdog(responsive_sequence, clock=None, threshold=90.0):
+    """Build a watchdog whose probe_fn pops from `responsive_sequence` each call."""
+    seq = list(responsive_sequence)
+    calls = {"dump": [], "exit": []}
+
+    def probe_fn(loop, timeout):
+        return seq.pop(0)
+
+    def dump_fn(path):
+        calls["dump"].append(path)
+
+    def exit_fn(code):
+        calls["exit"].append(code)
+
+    watchdog = elw.EventLoopWatchdog(
+        loop=None,  # never touched — probe_fn is faked
+        unresponsive_threshold=threshold,
+        probe_fn=probe_fn,
+        dump_fn=dump_fn,
+        dump_path_fn=lambda: Path("/tmp/fake-dump.log"),
+        exit_fn=exit_fn,
+        clock_fn=clock or FakeClock(),
+    )
+    return watchdog, calls
+
+
+class TestCheckOnce:
+    def test_responsive_probe_never_fires(self):
+        watchdog, calls = _make_watchdog([True, True, True])
+        for _ in range(3):
+            assert watchdog.check_once() is False
+        assert calls["dump"] == []
+        assert calls["exit"] == []
+
+    def test_first_unresponsive_probe_does_not_fire_immediately(self):
+        watchdog, calls = _make_watchdog([False])
+        assert watchdog.check_once() is False
+        assert calls["dump"] == []
+        assert calls["exit"] == []
+
+    def test_unresponsive_under_threshold_does_not_fire(self):
+        clock = FakeClock()
+        watchdog, calls = _make_watchdog(
+            [False, False, False], clock=clock, threshold=90.0
+        )
+        watchdog.check_once()  # t=0, starts the timer
+        clock.advance(30)
+        watchdog.check_once()  # t=30, stalled_for=30 < 90
+        clock.advance(30)
+        watchdog.check_once()  # t=60, stalled_for=60 < 90
+        assert calls["dump"] == []
+        assert calls["exit"] == []
+
+    def test_unresponsive_past_threshold_fires_dump_and_exit(self):
+        clock = FakeClock()
+        watchdog, calls = _make_watchdog(
+            [False, False, False], clock=clock, threshold=90.0
+        )
+        watchdog.check_once()  # t=0, starts the timer
+        clock.advance(45)
+        watchdog.check_once()  # t=45, stalled_for=45 < 90
+        clock.advance(50)
+        result = watchdog.check_once()  # t=95, stalled_for=95 >= 90
+        assert result is True
+        assert calls["dump"] == [Path("/tmp/fake-dump.log")]
+        assert calls["exit"] == [1]
+
+    def test_a_responsive_probe_resets_the_freeze_timer(self):
+        clock = FakeClock()
+        watchdog, calls = _make_watchdog(
+            [False, True, False, False], clock=clock, threshold=90.0
+        )
+        watchdog.check_once()  # t=0, unresponsive — starts timer
+        clock.advance(80)
+        watchdog.check_once()  # t=80, responsive — resets timer
+        clock.advance(80)
+        watchdog.check_once()  # t=160, unresponsive again — timer restarts here
+        clock.advance(80)
+        result = watchdog.check_once()  # stalled_for=80 < 90 since reset
+        assert result is False
+        assert calls["dump"] == []
+        assert calls["exit"] == []
+
+    def test_dump_failure_does_not_prevent_exit(self):
+        clock = FakeClock()
+        seq = [False, False]
+        exits = []
+
+        def probe_fn(loop, timeout):
+            return seq.pop(0)
+
+        def dump_fn(path):
+            raise OSError("disk full")
+
+        watchdog = elw.EventLoopWatchdog(
+            loop=None,
+            unresponsive_threshold=10.0,
+            probe_fn=probe_fn,
+            dump_fn=dump_fn,
+            dump_path_fn=lambda: Path("/tmp/fake-dump.log"),
+            exit_fn=lambda code: exits.append(code),
+            clock_fn=clock,
+        )
+        watchdog.check_once()
+        clock.advance(20)
+        result = watchdog.check_once()
+        assert result is True
+        assert exits == [1]
+
+
+# ---------------------------------------------------------------------------
+# EventLoopWatchdog.run — the real-world threading wrapper
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    def test_stops_when_stop_event_is_set(self):
+        watchdog, calls = _make_watchdog([True] * 1000)
+        stop_event = threading.Event()
+        watchdog._check_interval = 0.01
+
+        thread = threading.Thread(target=watchdog.run, args=(stop_event,))
+        thread.start()
+        time.sleep(0.05)
+        stop_event.set()
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+        assert calls["exit"] == []
+
+    def test_stops_early_once_a_freeze_is_declared(self):
+        clock = FakeClock()
+        watchdog, calls = _make_watchdog(
+            [False] * 1000, clock=clock, threshold=5.0
+        )
+        watchdog._check_interval = 0.01
+        stop_event = threading.Event()
+
+        # Advance the fake clock in step with real time so check_once
+        # eventually crosses the threshold without a real 5-second wait.
+        def _clock_ticker():
+            for _ in range(200):
+                clock.advance(1.0)
+                time.sleep(0.005)
+                if calls["exit"]:
+                    return
+
+        ticker = threading.Thread(target=_clock_ticker, daemon=True)
+        ticker.start()
+
+        thread = threading.Thread(target=watchdog.run, args=(stop_event,))
+        thread.start()
+        thread.join(timeout=3)
+        assert not thread.is_alive()
+        assert calls["exit"] == [1]


### PR DESCRIPTION
## Summary

`hermes-cryptids` went completely unresponsive for ~13 hours (2026-07-17 11:39 UTC onward) — no DMs, no group messages, mentioned or not — with **zero exceptions logged** and the process sitting at 0.49% CPU the whole time. Container never restarted, never crashed, no operator visibility into why until someone noticed and manually restarted it via HSM.

Root cause of *that specific freeze* is unidentified — the process was already restarted before this investigation started, destroying the live evidence (what the loop was actually blocked on). What's clear from tracing the existing reconnect machinery: nothing in the gateway would have caught it. Signal's own SSE health monitor (`gateway/platforms/signal.py::_health_monitor`) and the gateway-level `_platform_reconnect_watcher` both only notice when *their own* task stops running — which never happens when the freeze is a synchronous blocking call *upstream* of them. A single blocking call anywhere on the loop thread silently stalls every coroutine at once (SSE listeners, health monitors, message handling) with nothing to log, because nothing raised.

## What this adds

`gateway/event_loop_watchdog.py` — a coarse, platform-agnostic safety net, not a fix for the unknown root cause:

- From a separate thread, periodically proves the event loop is still processing a trivial coroutine (`asyncio.run_coroutine_threadsafe(asyncio.sleep(0), loop)` with a timeout).
- If the loop stays unresponsive past a threshold (default 90s), dumps every thread's current stack via `faulthandler.dump_traceback(all_threads=True)` — this works **even while the loop itself is frozen**, since it reads thread state directly and needs no cooperation from the stuck thread — then hard-exits (`os._exit`).
- The gateway runs under s6 supervision in production (auto-restart on crash), so the hard exit **restores service automatically** instead of staying dead for hours, and leaves a stack dump behind (`~/.hermes/logs/event_loop_freeze_<ts>.log`) so the *next* occurrence gets root-caused for real instead of another blind postmortem.

Wired into `gateway/run.py` alongside the existing cron/housekeeping threads, sharing their `stop_event`.

## Design notes

- `EventLoopWatchdog.check_once()` — the freeze-declaration decision logic — is fully dependency-injected (probe/dump/exit/clock functions), so it's unit-tested without real threads, real sleeps, or an actual process exit.
- `probe_loop_responsive()` also has a real-loop integration test that genuinely wedges a background event loop with a blocking call and confirms detection — not just mocked behavior standing in for the mechanism it's supposed to prove.

## Test plan

- [x] 13 new tests in `tests/gateway/test_event_loop_watchdog.py` — all green
- [x] Full `tests/gateway/` suite: 8863 passed, 7 pre-existing failures (Telegram markdown-escaping + one `shutdown_forensics` subprocess test) reproduce identically on `main` — confirmed unrelated via `git stash`
- [ ] Manual: watch for a stack dump + auto-recovery the next time any harness genuinely freezes (can't force-repro the specific hang safely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)