### PR TITLE
[PROTOTYPE] Letta-backed turn delegation (slice 0) — do not merge

### DIFF
--- a/gateway/letta_brain.py
+++ b/gateway/letta_brain.py
@@ -1,0 +1,121 @@
+"""Letta-backed turn delegation — SLICE-0 THROWAWAY PROTOTYPE (Swarm Map v1, B1).
+
+A Hermes gateway stays the messaging "door" (surfaces, pairing/group approval,
+audit, budget — all untouched upstream of _run_agent), but instead of running
+the native AIAgent loop for a turn, it forwards the user message to a bound
+Letta agent over REST and returns Letta's assistant reply.
+
+Endpoints (validated live 2026-07-19 against a self-hosted Letta on :8283):
+    POST /v1/agents/{agent_id}/messages
+        body: {"messages": [{"role": "user", "content": "..."}]}
+        resp: {"messages": [{"message_type": "assistant_message",
+                             "content": "..."}, ...], ...}
+
+Deliberately stdlib-only (urllib) — the gateway's aiohttp import is optional
+(see _run_agent_via_proxy), so the brain client must not add a hard dep. The
+sync call is bridged onto the event loop with asyncio.to_thread at the call
+site in gateway/run.py.
+
+TODO(slice-4, real B1):
+  - per-Letta-agent message serialization (Letta processes an agent's
+    messages sequentially; concurrent group messages need a queue — spec B3)
+  - streaming (Letta has an SSE endpoint; this blocks for the full turn)
+  - auth header for Letta Cloud / secured servers
+  - surface reasoning_message content somewhere (audit log?)
+"""
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 120.0
+
+
+class LettaBrainError(Exception):
+    """Raised when the Letta round-trip fails. Message is user-displayable."""
+
+
+def _extract_assistant_text(payload: dict) -> Optional[str]:
+    """Pull assistant_message content out of a Letta turn response.
+
+    Letta returns a typed message list (reasoning_message, tool_call_message,
+    assistant_message, ...). We join all assistant_message contents; content
+    may be a plain string or a list of {"type": "text", "text": ...} parts.
+    """
+    parts = []
+    for msg in payload.get("messages", []):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("message_type") != "assistant_message":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, list):
+            for piece in content:
+                if isinstance(piece, dict) and isinstance(piece.get("text"), str):
+                    parts.append(piece["text"])
+    if not parts:
+        return None
+    return "\n\n".join(p for p in parts if p)
+
+
+def send_message(
+    base_url: str,
+    agent_id: str,
+    text: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    """Send one user message to a Letta agent; return the assistant reply text.
+
+    Blocking (urllib). Raises LettaBrainError with a clear, user-displayable
+    message on any failure. Letta keeps its own conversation state server-side,
+    so only the new message is sent — no history replay.
+    """
+    url = f"{base_url.rstrip('/')}/v1/agents/{agent_id}/messages"
+    body = json.dumps(
+        {"messages": [{"role": "user", "content": text}]}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            detail = e.read().decode("utf-8", errors="replace")[:300]
+        except Exception:
+            pass
+        raise LettaBrainError(
+            f"Letta brain error ({e.code}) from {url}: {detail or e.reason}"
+        ) from e
+    except Exception as e:
+        raise LettaBrainError(
+            f"Letta brain unreachable at {base_url} "
+            f"(is the Letta server running?): {e}"
+        ) from e
+
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except Exception as e:
+        raise LettaBrainError(f"Letta brain returned non-JSON response: {e}") from e
+
+    reply = _extract_assistant_text(payload)
+    if reply is None:
+        # A turn can legitimately end without an assistant_message (e.g. the
+        # agent only ran tools). For the prototype, treat as an error so the
+        # user sees *something* — TODO(slice-4): decide real semantics.
+        raise LettaBrainError(
+            "Letta brain returned no assistant_message in its reply "
+            f"(message_types: {[m.get('message_type') for m in payload.get('messages', []) if isinstance(m, dict)]})"
+        )
+    return reply

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16222,6 +16222,125 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return url.rstrip("/")
         return None
 
+    # ------------------------------------------------------------------
+    # Letta brain mode: delegate turns to a bound Letta agent (PROTOTYPE)
+    # ------------------------------------------------------------------
+
+    def _get_letta_brain(self) -> Optional[Dict[str, str]]:
+        """Return {"base_url", "agent_id"} if Letta-brain mode is configured.
+
+        SLICE-0 PROTOTYPE (Swarm Map v1 B1). Mirrors _get_proxy_url's
+        convention: env vars first (LETTA_BRAIN_URL + LETTA_BRAIN_AGENT_ID —
+        convenient for Docker; Swarm Map's deploy path injects these), then
+        ``gateway.letta_brain.{base_url, agent_id}`` in config.yaml.
+        """
+        base_url = os.getenv("LETTA_BRAIN_URL", "").strip()
+        agent_id = os.getenv("LETTA_BRAIN_AGENT_ID", "").strip()
+        if base_url and agent_id:
+            return {"base_url": base_url.rstrip("/"), "agent_id": agent_id}
+        cfg = _load_gateway_config()
+        brain = (cfg.get("gateway") or {}).get("letta_brain") or {}
+        if isinstance(brain, dict):
+            base_url = str(brain.get("base_url") or "").strip()
+            agent_id = str(brain.get("agent_id") or "").strip()
+            if base_url and agent_id:
+                return {"base_url": base_url.rstrip("/"), "agent_id": agent_id}
+        return None
+
+    async def _run_agent_via_letta(
+        self,
+        message: str,
+        source: "SessionSource",
+        session_id: str,
+        history: List[Dict[str, Any]],
+        session_key: str = None,
+        run_generation: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Forward one turn to the bound Letta agent and return its reply.
+
+        SLICE-0 PROTOTYPE. The Hermes gateway remains the messaging door —
+        everything upstream of _run_agent (pairing, group approval, budget,
+        audit) already ran; everything downstream (reply delivery, session
+        persistence) consumes the same result-dict shape as proxy mode.
+
+        Unlike proxy mode we send ONLY the new message: Letta keeps its own
+        conversation state server-side (agents are Postgres rows), so history
+        replay would duplicate context.
+
+        TODO(slice-4): per-agent serialization queue (spec B3), streaming,
+        interrupt handling, media/attachment forwarding.
+        """
+        from gateway.letta_brain import LettaBrainError, send_message as _letta_send
+
+        brain = self._get_letta_brain()
+        if not brain:
+            return {
+                "final_response": "⚠️ Letta brain not configured (LETTA_BRAIN_URL + LETTA_BRAIN_AGENT_ID)",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+            }
+
+        # Typing indicator — best-effort, same as proxy mode.
+        _adapter = self.adapters.get(source.platform)
+        if _adapter:
+            try:
+                await _adapter.send_typing(source.chat_id)
+            except Exception:
+                pass
+
+        _start = time.time()
+        try:
+            reply = await asyncio.to_thread(
+                _letta_send, brain["base_url"], brain["agent_id"], message
+            )
+        except LettaBrainError as e:
+            logger.warning("Letta brain turn failed: %s", e)
+            return {
+                "final_response": f"⚠️ {e}",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+            }
+
+        # Staleness guard (same contract as proxy mode): a newer message for
+        # this session may have superseded this run while we were blocked.
+        if run_generation is not None and session_key and not self._is_session_run_current(
+            session_key, run_generation
+        ):
+            logger.info(
+                "Discarding stale Letta brain result for %s — generation %d is no longer current",
+                session_key or "?",
+                run_generation or 0,
+            )
+            return {
+                "final_response": "",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+                "history_offset": len(history),
+                "session_id": session_id,
+                "response_previewed": False,
+            }
+
+        logger.info(
+            "letta brain response: url=%s agent=%s session=%s time=%.1fs response=%d chars",
+            brain["base_url"], brain["agent_id"][:16],
+            (session_id or "")[:20], time.time() - _start, len(reply),
+        )
+        return {
+            "final_response": reply or "(No response from Letta brain)",
+            "messages": [
+                {"role": "user", "content": message},
+                {"role": "assistant", "content": reply},
+            ],
+            "api_calls": 1,
+            "tools": [],
+            "history_offset": len(history),
+            "session_id": session_id,
+            "response_previewed": False,
+        }
+
     async def _run_agent_via_proxy(
         self,
         message: str,
@@ -16606,6 +16725,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         This is run in a thread pool to not block the event loop.
         Supports interruption via new messages.
         """
+        # ---- Letta brain mode (SLICE-0 PROTOTYPE): delegate the turn to a
+        # bound Letta agent over REST. Checked before proxy mode — if both are
+        # configured, the more specific brain binding wins. ----
+        if self._get_letta_brain():
+            return await self._run_agent_via_letta(
+                message=message,
+                source=source,
+                session_id=session_id,
+                history=history,
+                session_key=session_key,
+                run_generation=run_generation,
+            )
+
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
             return await self._run_agent_via_proxy(

--- a/tests/gateway/test_letta_brain.py
+++ b/tests/gateway/test_letta_brain.py
@@ -1,0 +1,169 @@
+"""Tests for Letta-backed turn delegation (SLICE-0 PROTOTYPE, Swarm Map v1 B1).
+
+A gateway with LETTA_BRAIN_URL + LETTA_BRAIN_AGENT_ID configured must route
+an inbound turn to the Letta agent's REST endpoint instead of the native
+AIAgent loop, and return Letta's assistant_message content through the normal
+result-dict shape.
+"""
+
+import io
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.letta_brain import LettaBrainError, send_message
+from gateway.session import SessionSource
+
+
+def _letta_turn_response(reply: str) -> dict:
+    """Shape validated live against a self-hosted Letta server (2026-07-19)."""
+    return {
+        "messages": [
+            {
+                "id": "message-1",
+                "message_type": "reasoning_message",
+                "reasoning": "thinking about it",
+            },
+            {
+                "id": "message-2",
+                "message_type": "assistant_message",
+                "content": reply,
+            },
+        ],
+        "usage": {"completion_tokens": 10},
+        "stop_reason": "end_turn",
+    }
+
+
+class _FakeUrlopenResponse:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _install_fake_urlopen(monkeypatch, reply: str, seen: dict):
+    def _fake_urlopen(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["body"] = json.loads(req.data.decode("utf-8"))
+        seen["timeout"] = timeout
+        return _FakeUrlopenResponse(
+            json.dumps(_letta_turn_response(reply)).encode("utf-8")
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+def test_send_message_extracts_assistant_content(monkeypatch):
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "hello from letta", seen)
+
+    reply = send_message("http://localhost:8283", "agent-123", "hi there")
+
+    assert reply == "hello from letta"
+    assert seen["url"] == "http://localhost:8283/v1/agents/agent-123/messages"
+    assert seen["body"] == {"messages": [{"role": "user", "content": "hi there"}]}
+
+
+def test_send_message_unreachable_raises_clear_error(monkeypatch):
+    def _boom(req, timeout=None):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+
+    with pytest.raises(LettaBrainError) as excinfo:
+        send_message("http://localhost:8283", "agent-123", "hi")
+    assert "unreachable" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Gateway routing
+# ---------------------------------------------------------------------------
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    adapter = SimpleNamespace(send_typing=AsyncMock())
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    return runner, adapter
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="42",
+        chat_id="-100999",
+        user_name="tester",
+        chat_type="group",
+    )
+
+
+@pytest.mark.asyncio
+async def test_turn_routes_through_letta_delegation(monkeypatch):
+    """With a Letta brain bound, _run_agent_inner never touches the native
+    AIAgent loop — the turn goes to Letta and its reply comes back."""
+    monkeypatch.setenv("LETTA_BRAIN_URL", "http://localhost:8283")
+    monkeypatch.setenv("LETTA_BRAIN_AGENT_ID", "agent-abc")
+    monkeypatch.delenv("GATEWAY_PROXY_URL", raising=False)
+
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "the brain says hi", seen)
+
+    runner, adapter = _make_runner()
+
+    result = await runner._run_agent_inner(
+        message="hello brain",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="sess-1",
+    )
+
+    assert result["final_response"] == "the brain says hi"
+    assert result["api_calls"] == 1
+    assert seen["url"] == "http://localhost:8283/v1/agents/agent-abc/messages"
+    # Only the NEW message goes over the wire — Letta owns its own history.
+    assert seen["body"] == {"messages": [{"role": "user", "content": "hello brain"}]}
+    adapter.send_typing.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_letta_failure_returns_clear_error_not_crash(monkeypatch):
+    monkeypatch.setenv("LETTA_BRAIN_URL", "http://localhost:8283")
+    monkeypatch.setenv("LETTA_BRAIN_AGENT_ID", "agent-abc")
+
+    def _boom(req, timeout=None):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+
+    runner, _adapter = _make_runner()
+
+    result = await runner._run_agent_inner(
+        message="hello brain",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="sess-1",
+    )
+
+    assert result["final_response"].startswith("⚠️")
+    assert "unreachable" in result["final_response"]
+    assert result["api_calls"] == 0


### PR DESCRIPTION
**Throwaway prototype — do not merge.** Swarm Map v1 spec §2B / §3 slice 0: built to answer ONE question empirically — *what shape does the Hermes-front proxy (B1) want to be: plugin, config-driven mode, or turn-loop fork?*

## Answer: config-driven mode, at the existing remote-brain seam

`_run_agent_inner` (gateway/run.py) already begins with a delegation check: proxy mode (`GATEWAY_PROXY_URL` → `_run_agent_via_proxy`) hands the whole turn to a remote OpenAI-compatible server while keeping platform I/O, auth/group-approval, session persistence, and the reply path local. That is *exactly* the Hermes-front shape, already tested (`tests/gateway/test_proxy_mode.py`). This prototype adds a sibling check: `LETTA_BRAIN_URL` + `LETTA_BRAIN_AGENT_ID` (or `gateway.letta_brain.{base_url,agent_id}` in config.yaml) routes the turn to `_run_agent_via_letta` instead.

Rejected shapes:
- **Plugin (`pre_gateway_dispatch`)** — fires *before* auth/pairing (defeats policy inheritance, the whole point of Hermes-front), hooks are sync, and a `skip` action would force the plugin to re-implement reply delivery/session persistence.
- **Turn-loop fork (`agent/conversation_loop.py`, 5k lines)** — drags in tool-loop machinery Letta doesn't need; the delegation happens two layers above it anyway.

## What's here
- `gateway/letta_brain.py` — stdlib-urllib client: `send_message(base_url, agent_id, text) -> str`, extracts `assistant_message` content, `LettaBrainError` with user-displayable messages. Endpoints per the validated spike (`POST /v1/agents/{id}/messages`).
- `gateway/run.py` — `_get_letta_brain()` (mirrors `_get_proxy_url` convention), `_run_agent_via_letta()` (typing indicator, `asyncio.to_thread`, proxy-shaped result dict, staleness guard), dispatch check at the top of `_run_agent_inner`.
- `tests/gateway/test_letta_brain.py` — 4 tests (client parse, unreachable error, end-to-end routing with faked HTTP, failure path). All pass; ruff + ty clean; neighboring proxy/dispatch tests still pass (27/27).

## Known gaps (deliberate — slice 4 work)
- No per-Letta-agent serialization queue (spec B3) — Letta processes an agent's messages sequentially; concurrent group messages will interleave badly.
- No streaming (Letta has SSE; this blocks for the full turn — no incremental preview).
- Only the new message is sent (Letta owns its own history) — which means Hermes' `context_prompt` (channel context, sender identity, group metadata) is **dropped on the floor**. Slice 4 must decide how door-context reaches the brain (system-message prefix? memory block sync?).
- No auth header for secured Letta servers, no media forwarding, no interrupt handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
