### PR TITLE
[WIP] B1.5: door-context bridging for the Letta brain (stacked on #96) — do not merge

### DIFF
--- a/gateway/letta_brain.py
+++ b/gateway/letta_brain.py
@@ -39,6 +39,41 @@ class LettaBrainError(Exception):
     """Raised when the Letta round-trip fails. Message is user-displayable."""
 
 
+def build_sender_tag(
+    sender: Optional[str] = None, group: Optional[str] = None
+) -> str:
+    """Build the compact door-context tag for a shared Letta brain (B1.5).
+
+    A shared Letta agent serves many senders across many groups but, over REST,
+    sees only the message text — Letta owns its own server-side history, so the
+    rich per-turn context the native loop builds never reaches it. Without a tag
+    the brain can't tell WHO is speaking or WHICH group it's in, and multiplayer
+    is broken. We prepend a one-line structured tag; Letta's history then
+    accumulates identity naturally, turn over turn.
+
+    Current sender + group label ONLY — deliberately NOT group transcripts
+    (spec B1.5). Returns "" when neither is known (so tagging is a no-op).
+
+    Validated live 2026-07-21: given ``[from Alice in #family] ...``, a
+    self-hosted Letta agent replied "Alice is messaging me from the group
+    #family." — the brain extracts both facts from the inline tag.
+    """
+    parts = []
+    if sender:
+        parts.append(f"from {sender}")
+    if group:
+        parts.append(f"in {group}")
+    return f"[{' '.join(parts)}]" if parts else ""
+
+
+def apply_sender_tag(
+    text: str, sender: Optional[str] = None, group: Optional[str] = None
+) -> str:
+    """Prepend the door-context tag to a message (no-op when no identity known)."""
+    tag = build_sender_tag(sender, group)
+    return f"{tag}\n{text}" if tag else text
+
+
 def _extract_assistant_text(payload: dict) -> Optional[str]:
     """Pull assistant_message content out of a Letta turn response.
 
@@ -69,16 +104,24 @@ def send_message(
     agent_id: str,
     text: str,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    sender: Optional[str] = None,
+    group: Optional[str] = None,
 ) -> str:
     """Send one user message to a Letta agent; return the assistant reply text.
 
     Blocking (urllib). Raises LettaBrainError with a clear, user-displayable
     message on any failure. Letta keeps its own conversation state server-side,
     so only the new message is sent — no history replay.
+
+    ``sender``/``group`` add the B1.5 door-context tag so a shared brain knows
+    who is speaking and where (see build_sender_tag). The URL has NO trailing
+    slash: ``/messages/`` 307-redirects and the POST body is dropped on the
+    redirect (confirmed live 2026-07-21).
     """
     url = f"{base_url.rstrip('/')}/v1/agents/{agent_id}/messages"
+    content = apply_sender_tag(text, sender, group)
     body = json.dumps(
-        {"messages": [{"role": "user", "content": text}]}
+        {"messages": [{"role": "user", "content": content}]}
     ).encode("utf-8")
     req = urllib.request.Request(
         url,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16289,10 +16289,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
 
+        # B1.5 door-context: a shared Letta brain sees only the message text, so
+        # tag it with who is speaking and (for multiplayer) which group. DMs get
+        # only the sender; group/channel/thread contexts also get a group label
+        # (prefer the human-readable chat_name, fall back to type:id). NOT a full
+        # transcript — just current-turn identity (spec B1.5).
+        _sender = source.user_name or None
+        _group = None
+        if source.chat_type and source.chat_type != "dm":
+            _group = source.chat_name or f"{source.chat_type}:{source.chat_id}"
+
         _start = time.time()
         try:
             reply = await asyncio.to_thread(
-                _letta_send, brain["base_url"], brain["agent_id"], message
+                _letta_send,
+                brain["base_url"],
+                brain["agent_id"],
+                message,
+                sender=_sender,
+                group=_group,
             )
         except LettaBrainError as e:
             logger.warning("Letta brain turn failed: %s", e)

--- a/tests/gateway/test_letta_brain.py
+++ b/tests/gateway/test_letta_brain.py
@@ -14,7 +14,12 @@ from unittest.mock import AsyncMock
 import pytest
 
 from gateway.config import Platform
-from gateway.letta_brain import LettaBrainError, send_message
+from gateway.letta_brain import (
+    LettaBrainError,
+    apply_sender_tag,
+    build_sender_tag,
+    send_message,
+)
 from gateway.session import SessionSource
 
 
@@ -80,6 +85,52 @@ def test_send_message_extracts_assistant_content(monkeypatch):
     assert seen["body"] == {"messages": [{"role": "user", "content": "hi there"}]}
 
 
+# ---------------------------------------------------------------------------
+# B1.5 door-context sender tagging
+# ---------------------------------------------------------------------------
+
+
+def test_build_sender_tag_sender_and_group():
+    # Matches the format validated live 2026-07-21 (agent extracted both facts).
+    assert build_sender_tag("Alice", "#family") == "[from Alice in #family]"
+
+
+def test_build_sender_tag_partial_and_empty():
+    assert build_sender_tag("Alice", None) == "[from Alice]"
+    assert build_sender_tag(None, "#family") == "[in #family]"
+    assert build_sender_tag(None, None) == ""
+
+
+def test_apply_sender_tag_prepends_on_its_own_line():
+    assert apply_sender_tag("hello", "Alice", "#family") == "[from Alice in #family]\nhello"
+
+
+def test_apply_sender_tag_is_noop_without_identity():
+    # No sender/group known → message text is forwarded verbatim.
+    assert apply_sender_tag("hello") == "hello"
+
+
+def test_send_message_forwards_the_tagged_content(monkeypatch):
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "ok", seen)
+
+    send_message("http://localhost:8283", "agent-1", "who am I?", sender="Alice", group="#family")
+
+    # The brain receives the door-context tag inline with the message.
+    assert seen["body"] == {
+        "messages": [{"role": "user", "content": "[from Alice in #family]\nwho am I?"}]
+    }
+
+
+def test_send_message_untagged_when_no_identity(monkeypatch):
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "ok", seen)
+
+    send_message("http://localhost:8283", "agent-1", "plain message")
+
+    assert seen["body"] == {"messages": [{"role": "user", "content": "plain message"}]}
+
+
 def test_send_message_unreachable_raises_clear_error(monkeypatch):
     def _boom(req, timeout=None):
         raise OSError("connection refused")
@@ -139,9 +190,61 @@ async def test_turn_routes_through_letta_delegation(monkeypatch):
     assert result["final_response"] == "the brain says hi"
     assert result["api_calls"] == 1
     assert seen["url"] == "http://localhost:8283/v1/agents/agent-abc/messages"
-    # Only the NEW message goes over the wire — Letta owns its own history.
-    assert seen["body"] == {"messages": [{"role": "user", "content": "hello brain"}]}
+    # Only the NEW message goes over the wire (Letta owns its own history), now
+    # carrying the B1.5 door-context tag: _make_source() is a group chat with
+    # user_name "tester" and no chat_name, so the group falls back to type:id.
+    assert seen["body"] == {
+        "messages": [
+            {"role": "user", "content": "[from tester in group:-100999]\nhello brain"}
+        ]
+    }
     adapter.send_typing.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dm_turn_tags_sender_only_no_group(monkeypatch):
+    """A DM has no group — the door-context tag carries just the sender."""
+    monkeypatch.setenv("LETTA_BRAIN_URL", "http://localhost:8283")
+    monkeypatch.setenv("LETTA_BRAIN_AGENT_ID", "agent-abc")
+    monkeypatch.delenv("GATEWAY_PROXY_URL", raising=False)
+
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "hi", seen)
+    runner, _adapter = _make_runner()
+
+    dm_source = SessionSource(
+        platform=Platform.TELEGRAM, user_id="7", chat_id="7",
+        user_name="Alice", chat_type="dm",
+    )
+    await runner._run_agent_inner(
+        message="hello", context_prompt="", history=[], source=dm_source, session_id="s",
+    )
+    assert seen["body"] == {
+        "messages": [{"role": "user", "content": "[from Alice]\nhello"}]
+    }
+
+
+@pytest.mark.asyncio
+async def test_group_turn_prefers_chat_name_for_group_label(monkeypatch):
+    """When the adapter supplies a human-readable chat_name, use it as the group."""
+    monkeypatch.setenv("LETTA_BRAIN_URL", "http://localhost:8283")
+    monkeypatch.setenv("LETTA_BRAIN_AGENT_ID", "agent-abc")
+    monkeypatch.delenv("GATEWAY_PROXY_URL", raising=False)
+
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "hi", seen)
+    runner, _adapter = _make_runner()
+
+    src = SessionSource(
+        platform=Platform.TELEGRAM, user_id="7", chat_id="-100999",
+        user_name="Alice", chat_type="group", chat_name="#family",
+    )
+    await runner._run_agent_inner(
+        message="hello", context_prompt="", history=[], source=src, session_id="s",
+    )
+    assert seen["body"] == {
+        "messages": [{"role": "user", "content": "[from Alice in #family]\nhello"}]
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Slice B1.5 of Swarm Map v1 — the door-context bridge (v1 spec §2 B1.5). **Stacked on #96** (the slice-0 prototype). Draft/do-not-merge.

## The gap (from #96)
A shared Letta brain sees only the message text over REST — Letta owns its own server-side history, so the rich per-turn context the native loop builds never reaches it. Without it the brain can't tell **who** is speaking or **which group** it's in, and multiplayer is broken.

## Decision (ratified): sender-tagged message text
Prepend a compact one-line tag to the forwarded message; Letta's history then accumulates identity turn over turn. Chosen over memory-sync (conflates transient routing context with durable memfs memory) and per-turn system-prefix (fights memfs's system prompt). Rationale + memfs grounding in the org decision memory.

- **`letta_brain.py`**: `build_sender_tag()` / `apply_sender_tag()` + `send_message()` gains `sender`/`group`. Documents the **no-trailing-slash** `/messages` requirement (learned live — `/messages/` 307-redirects and drops the POST body).
- **`run.py`**: `_run_agent_via_letta` derives `sender` (`user_name`) and `group` (`chat_name`, else `type:id`; `None` for DMs) from the `SessionSource`.

## Live-validated 2026-07-21
Stood up a self-hosted `letta/letta` server (Primo, torn down clean). Given `[from Alice in #family] ...`, the agent replied **"Alice is messaging me from the group #family."** — the inline tag conveys identity, no memory-sync needed. Same run confirmed the A2 create payload (`letta_v1_agent` + `system` accepted) and the A3 `/core-memory/blocks` path.

## Tests / lint
12/12 (8 new: tag construction across sender/group/empty, send-message forwarding, and DM vs group vs chat_name dispatch). ruff clean.

## Still ahead for full B1 (spec)
SSE streaming (reuse proxy mode's consumer) + per-agent message serialization (B3). This PR lands the door-context bridge that gated them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)