### PR TITLE
feat(letta-brain): B1 — Letta-backed agent mode (Hermes-front bridge, production)

### DIFF
--- a/gateway/letta_brain.py
+++ b/gateway/letta_brain.py
@@ -1,0 +1,121 @@
+"""Letta-backed turn delegation — SLICE-0 THROWAWAY PROTOTYPE (Swarm Map v1, B1).
+
+A Hermes gateway stays the messaging "door" (surfaces, pairing/group approval,
+audit, budget — all untouched upstream of _run_agent), but instead of running
+the native AIAgent loop for a turn, it forwards the user message to a bound
+Letta agent over REST and returns Letta's assistant reply.
+
+Endpoints (validated live 2026-07-19 against a self-hosted Letta on :8283):
+    POST /v1/agents/{agent_id}/messages
+        body: {"messages": [{"role": "user", "content": "..."}]}
+        resp: {"messages": [{"message_type": "assistant_message",
+                             "content": "..."}, ...], ...}
+
+Deliberately stdlib-only (urllib) — the gateway's aiohttp import is optional
+(see _run_agent_via_proxy), so the brain client must not add a hard dep. The
+sync call is bridged onto the event loop with asyncio.to_thread at the call
+site in gateway/run.py.
+
+TODO(slice-4, real B1):
+  - per-Letta-agent message serialization (Letta processes an agent's
+    messages sequentially; concurrent group messages need a queue — spec B3)
+  - streaming (Letta has an SSE endpoint; this blocks for the full turn)
+  - auth header for Letta Cloud / secured servers
+  - surface reasoning_message content somewhere (audit log?)
+"""
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 120.0
+
+
+class LettaBrainError(Exception):
+    """Raised when the Letta round-trip fails. Message is user-displayable."""
+
+
+def _extract_assistant_text(payload: dict) -> Optional[str]:
+    """Pull assistant_message content out of a Letta turn response.
+
+    Letta returns a typed message list (reasoning_message, tool_call_message,
+    assistant_message, ...). We join all assistant_message contents; content
+    may be a plain string or a list of {"type": "text", "text": ...} parts.
+    """
+    parts = []
+    for msg in payload.get("messages", []):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("message_type") != "assistant_message":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, list):
+            for piece in content:
+                if isinstance(piece, dict) and isinstance(piece.get("text"), str):
+                    parts.append(piece["text"])
+    if not parts:
+        return None
+    return "\n\n".join(p for p in parts if p)
+
+
+def send_message(
+    base_url: str,
+    agent_id: str,
+    text: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    """Send one user message to a Letta agent; return the assistant reply text.
+
+    Blocking (urllib). Raises LettaBrainError with a clear, user-displayable
+    message on any failure. Letta keeps its own conversation state server-side,
+    so only the new message is sent — no history replay.
+    """
+    url = f"{base_url.rstrip('/')}/v1/agents/{agent_id}/messages"
+    body = json.dumps(
+        {"messages": [{"role": "user", "content": text}]}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            detail = e.read().decode("utf-8", errors="replace")[:300]
+        except Exception:
+            pass
+        raise LettaBrainError(
+            f"Letta brain error ({e.code}) from {url}: {detail or e.reason}"
+        ) from e
+    except Exception as e:
+        raise LettaBrainError(
+            f"Letta brain unreachable at {base_url} "
+            f"(is the Letta server running?): {e}"
+        ) from e
+
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except Exception as e:
+        raise LettaBrainError(f"Letta brain returned non-JSON response: {e}") from e
+
+    reply = _extract_assistant_text(payload)
+    if reply is None:
+        # A turn can legitimately end without an assistant_message (e.g. the
+        # agent only ran tools). For the prototype, treat as an error so the
+        # user sees *something* — TODO(slice-4): decide real semantics.
+        raise LettaBrainError(
+            "Letta brain returned no assistant_message in its reply "
+            f"(message_types: {[m.get('message_type') for m in payload.get('messages', []) if isinstance(m, dict)]})"
+        )
+    return reply

--- a/gateway/letta_brain.py
+++ b/gateway/letta_brain.py
@@ -39,6 +39,41 @@ class LettaBrainError(Exception):
     """Raised when the Letta round-trip fails. Message is user-displayable."""
 
 
+def build_sender_tag(
+    sender: Optional[str] = None, group: Optional[str] = None
+) -> str:
+    """Build the compact door-context tag for a shared Letta brain (B1.5).
+
+    A shared Letta agent serves many senders across many groups but, over REST,
+    sees only the message text — Letta owns its own server-side history, so the
+    rich per-turn context the native loop builds never reaches it. Without a tag
+    the brain can't tell WHO is speaking or WHICH group it's in, and multiplayer
+    is broken. We prepend a one-line structured tag; Letta's history then
+    accumulates identity naturally, turn over turn.
+
+    Current sender + group label ONLY — deliberately NOT group transcripts
+    (spec B1.5). Returns "" when neither is known (so tagging is a no-op).
+
+    Validated live 2026-07-21: given ``[from Alice in #family] ...``, a
+    self-hosted Letta agent replied "Alice is messaging me from the group
+    #family." — the brain extracts both facts from the inline tag.
+    """
+    parts = []
+    if sender:
+        parts.append(f"from {sender}")
+    if group:
+        parts.append(f"in {group}")
+    return f"[{' '.join(parts)}]" if parts else ""
+
+
+def apply_sender_tag(
+    text: str, sender: Optional[str] = None, group: Optional[str] = None
+) -> str:
+    """Prepend the door-context tag to a message (no-op when no identity known)."""
+    tag = build_sender_tag(sender, group)
+    return f"{tag}\n{text}" if tag else text
+
+
 def _extract_assistant_text(payload: dict) -> Optional[str]:
     """Pull assistant_message content out of a Letta turn response.
 
@@ -69,16 +104,24 @@ def send_message(
     agent_id: str,
     text: str,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    sender: Optional[str] = None,
+    group: Optional[str] = None,
 ) -> str:
     """Send one user message to a Letta agent; return the assistant reply text.
 
     Blocking (urllib). Raises LettaBrainError with a clear, user-displayable
     message on any failure. Letta keeps its own conversation state server-side,
     so only the new message is sent — no history replay.
+
+    ``sender``/``group`` add the B1.5 door-context tag so a shared brain knows
+    who is speaking and where (see build_sender_tag). The URL has NO trailing
+    slash: ``/messages/`` 307-redirects and the POST body is dropped on the
+    redirect (confirmed live 2026-07-21).
     """
     url = f"{base_url.rstrip('/')}/v1/agents/{agent_id}/messages"
+    content = apply_sender_tag(text, sender, group)
     body = json.dumps(
-        {"messages": [{"role": "user", "content": text}]}
+        {"messages": [{"role": "user", "content": content}]}
     ).encode("utf-8")
     req = urllib.request.Request(
         url,

--- a/gateway/letta_brain.py
+++ b/gateway/letta_brain.py
@@ -1,34 +1,35 @@
-"""Letta-backed turn delegation — SLICE-0 THROWAWAY PROTOTYPE (Swarm Map v1, B1).
+"""Letta-backed turn delegation (Swarm Map v1, B1 — the Hermes-front bridge).
 
 A Hermes gateway stays the messaging "door" (surfaces, pairing/group approval,
 audit, budget — all untouched upstream of _run_agent), but instead of running
 the native AIAgent loop for a turn, it forwards the user message to a bound
 Letta agent over REST and returns Letta's assistant reply.
 
-Endpoints (validated live 2026-07-19 against a self-hosted Letta on :8283):
+Endpoints (blocking path validated live 2026-07-19 against a self-hosted
+Letta on :8283):
     POST /v1/agents/{agent_id}/messages
         body: {"messages": [{"role": "user", "content": "..."}]}
         resp: {"messages": [{"message_type": "assistant_message",
                              "content": "..."}, ...], ...}
+    POST /v1/agents/{agent_id}/messages/stream   (SSE; stream_message below)
 
-Deliberately stdlib-only (urllib) — the gateway's aiohttp import is optional
-(see _run_agent_via_proxy), so the brain client must not add a hard dep. The
-sync call is bridged onto the event loop with asyncio.to_thread at the call
-site in gateway/run.py.
+The blocking client is deliberately stdlib-only (urllib) — the gateway's
+aiohttp import is optional (see _run_agent_via_proxy), so the fallback path
+must not add a hard dep. The sync call is bridged onto the event loop with
+asyncio.to_thread at the call site in gateway/run.py. The streaming client
+uses aiohttp when available; callers fall back to the blocking path on any
+streaming failure (defensive: the SSE surface is less battle-tested than the
+blocking endpoint we validated live).
 
-TODO(slice-4, real B1):
-  - per-Letta-agent message serialization (Letta processes an agent's
-    messages sequentially; concurrent group messages need a queue — spec B3)
-  - streaming (Letta has an SSE endpoint; this blocks for the full turn)
-  - auth header for Letta Cloud / secured servers
-  - surface reasoning_message content somewhere (audit log?)
+Grown out of the slice-0 prototype (agent-mt#96) per the v1 spec: "real B1 =
+productionize the prototype + reuse proxy mode's streaming consumer."
 """
 
 import json
 import logging
 import urllib.error
 import urllib.request
-from typing import Optional
+from typing import AsyncIterator, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,19 @@ DEFAULT_TIMEOUT_SECONDS = 120.0
 
 
 class LettaBrainError(Exception):
-    """Raised when the Letta round-trip fails. Message is user-displayable."""
+    """Raised when the Letta round-trip fails. Message is user-displayable.
+
+    ``retryable`` is True only when the failure is provably pre-delivery
+    (connection never established, endpoint absent, client dep missing) — the
+    Letta server cannot have processed the message, so the caller may safely
+    retry via the blocking client. Ambiguous failures (5xx, mid-stream drops)
+    stay non-retryable: Letta owns server-side history, and a blind retry
+    would make the brain process the turn twice.
+    """
+
+    def __init__(self, message: str, retryable: bool = False):
+        super().__init__(message)
+        self.retryable = retryable
 
 
 def build_sender_tag(
@@ -99,6 +112,14 @@ def _extract_assistant_text(payload: dict) -> Optional[str]:
     return "\n\n".join(p for p in parts if p)
 
 
+def _request_headers(api_key: Optional[str] = None) -> dict:
+    """Common request headers; Bearer auth for Letta Cloud / secured servers."""
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
 def send_message(
     base_url: str,
     agent_id: str,
@@ -106,6 +127,7 @@ def send_message(
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
     sender: Optional[str] = None,
     group: Optional[str] = None,
+    api_key: Optional[str] = None,
 ) -> str:
     """Send one user message to a Letta agent; return the assistant reply text.
 
@@ -126,7 +148,7 @@ def send_message(
     req = urllib.request.Request(
         url,
         data=body,
-        headers={"Content-Type": "application/json"},
+        headers=_request_headers(api_key),
         method="POST",
     )
     try:
@@ -154,11 +176,113 @@ def send_message(
 
     reply = _extract_assistant_text(payload)
     if reply is None:
-        # A turn can legitimately end without an assistant_message (e.g. the
-        # agent only ran tools). For the prototype, treat as an error so the
-        # user sees *something* — TODO(slice-4): decide real semantics.
-        raise LettaBrainError(
-            "Letta brain returned no assistant_message in its reply "
-            f"(message_types: {[m.get('message_type') for m in payload.get('messages', []) if isinstance(m, dict)]})"
+        # A turn can legitimately end without an assistant_message — the agent
+        # only ran tools and chose not to speak. Production semantics: a quiet
+        # empty reply (delivery is suppressed downstream), never an error the
+        # user sees. The message_types are logged for audit (spec B4).
+        logger.info(
+            "Letta brain turn ended without assistant_message (tool-only turn); "
+            "message_types=%s",
+            [
+                m.get("message_type")
+                for m in payload.get("messages", [])
+                if isinstance(m, dict)
+            ],
         )
+        return ""
     return reply
+
+
+def parse_stream_line(line: str) -> Optional[str]:
+    """Parse one SSE line from ``/v1/agents/{id}/messages/stream``.
+
+    Returns the assistant-text delta the line carries, or None for everything
+    else — non-data lines, keepalive comments, the ``[DONE]`` terminator,
+    non-assistant message types (reasoning/tool chunks), and unparseable JSON.
+    Deliberately forgiving: the streaming surface is less battle-tested than
+    the blocking endpoint, so unknown shapes are skipped, never fatal.
+    """
+    line = line.strip()
+    if not line.startswith("data: "):
+        return None
+    data = line[6:].strip()
+    if not data or data == "[DONE]":
+        return None
+    try:
+        obj = json.loads(data)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(obj, dict) or obj.get("message_type") != "assistant_message":
+        return None
+    content = obj.get("content")
+    if isinstance(content, str):
+        return content or None
+    if isinstance(content, list):
+        parts = [
+            piece["text"]
+            for piece in content
+            if isinstance(piece, dict) and isinstance(piece.get("text"), str)
+        ]
+        return "".join(parts) or None
+    return None
+
+
+async def stream_message(
+    base_url: str,
+    agent_id: str,
+    text: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    sender: Optional[str] = None,
+    group: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> AsyncIterator[str]:
+    """Stream one turn from a Letta agent, yielding assistant-text deltas.
+
+    SSE against ``POST /v1/agents/{id}/messages/stream`` with
+    ``stream_tokens: true``, mirroring proxy mode's consumer loop. Raises
+    LettaBrainError if aiohttp is unavailable or the request fails before any
+    delta arrives — callers fall back to the validated blocking send_message.
+    A mid-stream error after deltas have been yielded also raises; the caller
+    decides whether the partial text is deliverable.
+    """
+    try:
+        from aiohttp import ClientConnectorError, ClientSession, ClientTimeout
+    except ImportError as e:
+        raise LettaBrainError("Letta streaming requires aiohttp", retryable=True) from e
+
+    url = f"{base_url.rstrip('/')}/v1/agents/{agent_id}/messages/stream"
+    content = apply_sender_tag(text, sender, group)
+    body = {
+        "messages": [{"role": "user", "content": content}],
+        "stream_tokens": True,
+    }
+    try:
+        client_timeout = ClientTimeout(total=0, sock_read=timeout)
+        async with ClientSession(timeout=client_timeout) as session:
+            async with session.post(
+                url, json=body, headers=_request_headers(api_key)
+            ) as resp:
+                if resp.status != 200:
+                    detail = (await resp.text())[:300]
+                    raise LettaBrainError(
+                        f"Letta brain stream error ({resp.status}) from {url}: {detail}",
+                        # 404/405 = the stream route doesn't exist on this
+                        # server — the message was never accepted for a turn.
+                        retryable=resp.status in (404, 405),
+                    )
+                buffer = ""
+                async for chunk in resp.content.iter_any():
+                    buffer += chunk.decode("utf-8", errors="replace")
+                    while "\n" in buffer:
+                        line, buffer = buffer.split("\n", 1)
+                        delta = parse_stream_line(line)
+                        if delta:
+                            yield delta
+    except LettaBrainError:
+        raise
+    except Exception as e:
+        raise LettaBrainError(
+            f"Letta brain stream failed against {base_url}: {e}",
+            # Connection never established → Letta never saw the message.
+            retryable=isinstance(e, (ClientConnectorError, ConnectionRefusedError)),
+        ) from e

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17689,6 +17689,125 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return url.rstrip("/")
         return None
 
+    # ------------------------------------------------------------------
+    # Letta brain mode: delegate turns to a bound Letta agent (PROTOTYPE)
+    # ------------------------------------------------------------------
+
+    def _get_letta_brain(self) -> Optional[Dict[str, str]]:
+        """Return {"base_url", "agent_id"} if Letta-brain mode is configured.
+
+        SLICE-0 PROTOTYPE (Swarm Map v1 B1). Mirrors _get_proxy_url's
+        convention: env vars first (LETTA_BRAIN_URL + LETTA_BRAIN_AGENT_ID —
+        convenient for Docker; Swarm Map's deploy path injects these), then
+        ``gateway.letta_brain.{base_url, agent_id}`` in config.yaml.
+        """
+        base_url = os.getenv("LETTA_BRAIN_URL", "").strip()
+        agent_id = os.getenv("LETTA_BRAIN_AGENT_ID", "").strip()
+        if base_url and agent_id:
+            return {"base_url": base_url.rstrip("/"), "agent_id": agent_id}
+        cfg = _load_gateway_config()
+        brain = (cfg.get("gateway") or {}).get("letta_brain") or {}
+        if isinstance(brain, dict):
+            base_url = str(brain.get("base_url") or "").strip()
+            agent_id = str(brain.get("agent_id") or "").strip()
+            if base_url and agent_id:
+                return {"base_url": base_url.rstrip("/"), "agent_id": agent_id}
+        return None
+
+    async def _run_agent_via_letta(
+        self,
+        message: str,
+        source: "SessionSource",
+        session_id: str,
+        history: List[Dict[str, Any]],
+        session_key: str = None,
+        run_generation: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Forward one turn to the bound Letta agent and return its reply.
+
+        SLICE-0 PROTOTYPE. The Hermes gateway remains the messaging door —
+        everything upstream of _run_agent (pairing, group approval, budget,
+        audit) already ran; everything downstream (reply delivery, session
+        persistence) consumes the same result-dict shape as proxy mode.
+
+        Unlike proxy mode we send ONLY the new message: Letta keeps its own
+        conversation state server-side (agents are Postgres rows), so history
+        replay would duplicate context.
+
+        TODO(slice-4): per-agent serialization queue (spec B3), streaming,
+        interrupt handling, media/attachment forwarding.
+        """
+        from gateway.letta_brain import LettaBrainError, send_message as _letta_send
+
+        brain = self._get_letta_brain()
+        if not brain:
+            return {
+                "final_response": "⚠️ Letta brain not configured (LETTA_BRAIN_URL + LETTA_BRAIN_AGENT_ID)",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+            }
+
+        # Typing indicator — best-effort, same as proxy mode.
+        _adapter = self.adapters.get(source.platform)
+        if _adapter:
+            try:
+                await _adapter.send_typing(source.chat_id)
+            except Exception:
+                pass
+
+        _start = time.time()
+        try:
+            reply = await asyncio.to_thread(
+                _letta_send, brain["base_url"], brain["agent_id"], message
+            )
+        except LettaBrainError as e:
+            logger.warning("Letta brain turn failed: %s", e)
+            return {
+                "final_response": f"⚠️ {e}",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+            }
+
+        # Staleness guard (same contract as proxy mode): a newer message for
+        # this session may have superseded this run while we were blocked.
+        if run_generation is not None and session_key and not self._is_session_run_current(
+            session_key, run_generation
+        ):
+            logger.info(
+                "Discarding stale Letta brain result for %s — generation %d is no longer current",
+                session_key or "?",
+                run_generation or 0,
+            )
+            return {
+                "final_response": "",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+                "history_offset": len(history),
+                "session_id": session_id,
+                "response_previewed": False,
+            }
+
+        logger.info(
+            "letta brain response: url=%s agent=%s session=%s time=%.1fs response=%d chars",
+            brain["base_url"], brain["agent_id"][:16],
+            (session_id or "")[:20], time.time() - _start, len(reply),
+        )
+        return {
+            "final_response": reply or "(No response from Letta brain)",
+            "messages": [
+                {"role": "user", "content": message},
+                {"role": "assistant", "content": reply},
+            ],
+            "api_calls": 1,
+            "tools": [],
+            "history_offset": len(history),
+            "session_id": session_id,
+            "response_previewed": False,
+        }
+
     async def _run_agent_via_proxy(
         self,
         message: str,
@@ -18166,6 +18285,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         This is run in a thread pool to not block the event loop.
         Supports interruption via new messages.
         """
+        # ---- Letta brain mode (SLICE-0 PROTOTYPE): delegate the turn to a
+        # bound Letta agent over REST. Checked before proxy mode — if both are
+        # configured, the more specific brain binding wins. ----
+        if self._get_letta_brain():
+            return await self._run_agent_via_letta(
+                message=message,
+                source=source,
+                session_id=session_id,
+                history=history,
+                session_key=session_key,
+                run_generation=run_generation,
+            )
+
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
             return await self._run_agent_via_proxy(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17690,29 +17690,140 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return None
 
     # ------------------------------------------------------------------
-    # Letta brain mode: delegate turns to a bound Letta agent (PROTOTYPE)
+    # Letta brain mode: delegate turns to a bound Letta agent (Swarm Map v1 B1)
     # ------------------------------------------------------------------
 
     def _get_letta_brain(self) -> Optional[Dict[str, str]]:
-        """Return {"base_url", "agent_id"} if Letta-brain mode is configured.
+        """Return {"base_url", "agent_id", "api_key"} if Letta-brain mode is
+        configured (api_key may be "" for unsecured self-hosted servers).
 
-        SLICE-0 PROTOTYPE (Swarm Map v1 B1). Mirrors _get_proxy_url's
-        convention: env vars first (LETTA_BRAIN_URL + LETTA_BRAIN_AGENT_ID —
-        convenient for Docker; Swarm Map's deploy path injects these), then
-        ``gateway.letta_brain.{base_url, agent_id}`` in config.yaml.
+        Mirrors _get_proxy_url's convention: env vars first (LETTA_BRAIN_URL +
+        LETTA_BRAIN_AGENT_ID + optional LETTA_BRAIN_API_KEY — convenient for
+        Docker; Swarm Map's deploy path injects these), then
+        ``gateway.letta_brain.{base_url, agent_id, api_key}`` in config.yaml.
         """
+        env_key = os.getenv("LETTA_BRAIN_API_KEY", "").strip()
         base_url = os.getenv("LETTA_BRAIN_URL", "").strip()
         agent_id = os.getenv("LETTA_BRAIN_AGENT_ID", "").strip()
         if base_url and agent_id:
-            return {"base_url": base_url.rstrip("/"), "agent_id": agent_id}
+            return {
+                "base_url": base_url.rstrip("/"),
+                "agent_id": agent_id,
+                "api_key": env_key,
+            }
         cfg = _load_gateway_config()
         brain = (cfg.get("gateway") or {}).get("letta_brain") or {}
         if isinstance(brain, dict):
             base_url = str(brain.get("base_url") or "").strip()
             agent_id = str(brain.get("agent_id") or "").strip()
             if base_url and agent_id:
-                return {"base_url": base_url.rstrip("/"), "agent_id": agent_id}
+                return {
+                    "base_url": base_url.rstrip("/"),
+                    "agent_id": agent_id,
+                    "api_key": str(brain.get("api_key") or "").strip() or env_key,
+                }
         return None
+
+    def _letta_agent_lock(self, agent_key: str) -> "asyncio.Lock":
+        """Per-Letta-agent serialization lock (spec B3).
+
+        Letta processes an agent's messages sequentially — concurrent group
+        messages must queue, never overlap in flight. One lock per bound
+        agent (keyed base_url|agent_id), created lazily.
+        """
+        locks = getattr(self, "_letta_brain_locks", None)
+        if locks is None:
+            locks = {}
+            self._letta_brain_locks = locks
+        lock = locks.get(agent_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            locks[agent_key] = lock
+        return lock
+
+    def _setup_platform_stream_consumer(
+        self,
+        source: "SessionSource",
+        event_message_id: Optional[str],
+        run_still_current,
+    ):
+        """Build the platform stream consumer the remote-brain modes share.
+
+        Extracted verbatim from proxy mode so Letta-brain mode reuses the same
+        platform nuances (Telegram typing-pause + fresh-final, Matrix
+        buffer-only, edit-capability detection). Returns
+        ``(consumer_or_None, thread_metadata)`` — consumer is None when
+        streaming is disabled for the platform or setup fails (callers fall
+        back to non-streamed delivery).
+        """
+        _stream_consumer = None
+        _scfg = getattr(getattr(self, "config", None), "streaming", None)
+        if _scfg is None:
+            from gateway.config import StreamingConfig
+            _scfg = StreamingConfig()
+
+        platform_key = _platform_config_key(source.platform)
+        user_config = _load_gateway_config()
+        from gateway.display_config import resolve_display_setting
+        _plat_streaming = resolve_display_setting(
+            user_config, platform_key, "streaming"
+        )
+        _streaming_enabled = (
+            _scfg.enabled and _scfg.transport != "off"
+            if _plat_streaming is None
+            else bool(_plat_streaming)
+        )
+
+        _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
+
+        if _streaming_enabled:
+            try:
+                from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+                _adapter = self._adapter_for_source(source)
+                if _adapter:
+                    _pause_typing_before_finalize = None
+                    if source.platform == Platform.TELEGRAM and hasattr(_adapter, "pause_typing_for_chat"):
+                        def _pause_typing_before_finalize(
+                            _adapter=_adapter,
+                            _chat_id=source.chat_id,
+                        ) -> None:
+                            _adapter.pause_typing_for_chat(_chat_id)
+                    _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
+                    _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
+                    _buffer_only = False
+                    if source.platform == Platform.MATRIX:
+                        _effective_cursor = ""
+                        _buffer_only = True
+                    # Fresh-final applies to Telegram only — other
+                    # platforms either edit in place cheaply (Discord,
+                    # Slack) or don't have the timestamp-on-edit
+                    # problem.  (Ported from openclaw/openclaw#72038.)
+                    _fresh_final_secs = (
+                        float(getattr(_scfg, "fresh_final_after_seconds", 0.0) or 0.0)
+                        if source.platform == Platform.TELEGRAM
+                        else 0.0
+                    )
+                    _consumer_cfg = StreamConsumerConfig(
+                        edit_interval=_scfg.edit_interval,
+                        buffer_threshold=_scfg.buffer_threshold,
+                        cursor=_effective_cursor,
+                        buffer_only=_buffer_only,
+                        fresh_final_after_seconds=_fresh_final_secs,
+                        transport=_scfg.transport or "edit",
+                        chat_type=getattr(source, "chat_type", "") or "",
+                    )
+                    _stream_consumer = GatewayStreamConsumer(
+                        adapter=_adapter,
+                        chat_id=source.chat_id,
+                        config=_consumer_cfg,
+                        metadata=_thread_metadata,
+                        on_before_finalize=_pause_typing_before_finalize,
+                        initial_reply_to_id=event_message_id,
+                        run_still_current=run_still_current,
+                    )
+            except Exception as _sc_err:
+                logger.debug("Remote-brain: could not set up stream consumer: %s", _sc_err)
+        return _stream_consumer, _thread_metadata
 
     async def _run_agent_via_letta(
         self,
@@ -17722,22 +17833,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         history: List[Dict[str, Any]],
         session_key: str = None,
         run_generation: Optional[int] = None,
+        event_message_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Forward one turn to the bound Letta agent and return its reply.
 
-        SLICE-0 PROTOTYPE. The Hermes gateway remains the messaging door —
-        everything upstream of _run_agent (pairing, group approval, budget,
-        audit) already ran; everything downstream (reply delivery, session
-        persistence) consumes the same result-dict shape as proxy mode.
+        Swarm Map v1 B1 — the Hermes-front bridge. The Hermes gateway remains
+        the messaging door — everything upstream of _run_agent (pairing, group
+        approval, budget, audit) already ran; everything downstream (reply
+        delivery, session persistence) consumes the same result-dict shape as
+        proxy mode.
 
         Unlike proxy mode we send ONLY the new message: Letta keeps its own
         conversation state server-side (agents are Postgres rows), so history
         replay would duplicate context.
 
-        TODO(slice-4): per-agent serialization queue (spec B3), streaming,
-        interrupt handling, media/attachment forwarding.
+        Turns are serialized per bound Letta agent (spec B3): Letta processes
+        an agent's messages sequentially, so concurrent group messages queue
+        on a per-agent lock rather than overlapping in flight. When the
+        platform supports it the reply streams from Letta's SSE endpoint
+        through the same GatewayStreamConsumer proxy mode uses; the
+        live-validated blocking client is the fallback, taken only when the
+        stream provably failed pre-delivery (LettaBrainError.retryable — a
+        blind retry would make the brain process the turn twice).
+        LETTA_BRAIN_STREAMING=off forces the blocking path.
         """
-        from gateway.letta_brain import LettaBrainError, send_message as _letta_send
+        from gateway.letta_brain import (
+            LettaBrainError,
+            send_message as _letta_send,
+            stream_message as _letta_stream,
+        )
 
         brain = self._get_letta_brain()
         if not brain:
@@ -17747,14 +17871,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "api_calls": 0,
                 "tools": [],
             }
+        _api_key = brain.get("api_key") or None
 
-        # Typing indicator — best-effort, same as proxy mode.
-        _adapter = self.adapters.get(source.platform)
-        if _adapter:
-            try:
-                await _adapter.send_typing(source.chat_id)
-            except Exception:
-                pass
+        def _run_still_current() -> bool:
+            if run_generation is None or not session_key:
+                return True
+            return self._is_session_run_current(session_key, run_generation)
+
+        def _stale_result(where: str) -> Dict[str, Any]:
+            logger.info(
+                "Discarding stale Letta brain turn (%s) for %s — generation %d is no longer current",
+                where, session_key or "?", run_generation or 0,
+            )
+            return {
+                "final_response": "",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+                "history_offset": len(history),
+                "session_id": session_id,
+                "response_previewed": False,
+            }
 
         # B1.5 door-context: a shared Letta brain sees only the message text, so
         # tag it with who is speaking and (for multiplayer) which group. DMs get
@@ -17767,51 +17904,118 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _group = source.chat_name or f"{source.chat_type}:{source.chat_id}"
 
         _start = time.time()
-        try:
-            reply = await asyncio.to_thread(
-                _letta_send,
-                brain["base_url"],
-                brain["agent_id"],
-                message,
-                sender=_sender,
-                group=_group,
-            )
-        except LettaBrainError as e:
-            logger.warning("Letta brain turn failed: %s", e)
-            return {
-                "final_response": f"⚠️ {e}",
-                "messages": [],
-                "api_calls": 0,
-                "tools": [],
-            }
+        _lock = self._letta_agent_lock(f"{brain['base_url']}|{brain['agent_id']}")
+        async with _lock:
+            # B3: a newer message for this session may have superseded this
+            # run while it queued behind another turn for the same agent.
+            if not _run_still_current():
+                return _stale_result("queued")
+
+            # Platform stream consumer — same machinery as proxy mode. Fully
+            # defensive: any setup failure just means no streaming this turn.
+            _stream_consumer = None
+            _thread_metadata = None
+            _streaming_pref = os.getenv("LETTA_BRAIN_STREAMING", "").strip().lower()
+            if _streaming_pref not in {"off", "0", "false", "no"}:
+                try:
+                    _stream_consumer, _thread_metadata = (
+                        self._setup_platform_stream_consumer(
+                            source, event_message_id, _run_still_current
+                        )
+                    )
+                except Exception as _sc_err:
+                    logger.debug("Letta brain: stream consumer unavailable: %s", _sc_err)
+
+            # Typing indicator — best-effort, same as proxy mode.
+            _adapter = self.adapters.get(source.platform)
+            if _adapter:
+                try:
+                    await _adapter.send_typing(source.chat_id)
+                except Exception:
+                    pass
+
+            reply: Optional[str] = None
+            streamed = False
+            if _stream_consumer is not None:
+                stream_task = asyncio.create_task(_stream_consumer.run())
+                _partial = ""
+                try:
+                    async for _delta in _letta_stream(
+                        brain["base_url"],
+                        brain["agent_id"],
+                        message,
+                        sender=_sender,
+                        group=_group,
+                        api_key=_api_key,
+                    ):
+                        if not _run_still_current():
+                            return _stale_result("mid-stream")
+                        _partial += _delta
+                        _stream_consumer.on_delta(_delta)
+                    reply = _partial
+                    streamed = bool(_partial)
+                except LettaBrainError as e:
+                    if _partial:
+                        # Text already reached the platform — deliver the
+                        # partial rather than retrying (double-turn risk).
+                        logger.warning(
+                            "Letta brain stream broke mid-turn (%s); delivering partial", e
+                        )
+                        reply = _partial
+                        streamed = True
+                    elif e.retryable:
+                        logger.info(
+                            "Letta brain streaming unavailable (%s); falling back to blocking client", e
+                        )
+                    else:
+                        logger.warning("Letta brain stream turn failed: %s", e)
+                        return {
+                            "final_response": f"⚠️ {e}",
+                            "messages": [],
+                            "api_calls": 0,
+                            "tools": [],
+                        }
+                finally:
+                    _stream_consumer.finish()
+                    try:
+                        await asyncio.wait_for(stream_task, timeout=5.0)
+                    except (asyncio.TimeoutError, asyncio.CancelledError):
+                        stream_task.cancel()
+
+            if reply is None:
+                try:
+                    reply = await asyncio.to_thread(
+                        _letta_send,
+                        brain["base_url"],
+                        brain["agent_id"],
+                        message,
+                        sender=_sender,
+                        group=_group,
+                        api_key=_api_key,
+                    )
+                except LettaBrainError as e:
+                    logger.warning("Letta brain turn failed: %s", e)
+                    return {
+                        "final_response": f"⚠️ {e}",
+                        "messages": [],
+                        "api_calls": 0,
+                        "tools": [],
+                    }
 
         # Staleness guard (same contract as proxy mode): a newer message for
         # this session may have superseded this run while we were blocked.
-        if run_generation is not None and session_key and not self._is_session_run_current(
-            session_key, run_generation
-        ):
-            logger.info(
-                "Discarding stale Letta brain result for %s — generation %d is no longer current",
-                session_key or "?",
-                run_generation or 0,
-            )
-            return {
-                "final_response": "",
-                "messages": [],
-                "api_calls": 0,
-                "tools": [],
-                "history_offset": len(history),
-                "session_id": session_id,
-                "response_previewed": False,
-            }
+        if not _run_still_current():
+            return _stale_result("post-turn")
 
         logger.info(
-            "letta brain response: url=%s agent=%s session=%s time=%.1fs response=%d chars",
+            "letta brain response: url=%s agent=%s session=%s time=%.1fs response=%d chars streamed=%s",
             brain["base_url"], brain["agent_id"][:16],
-            (session_id or "")[:20], time.time() - _start, len(reply),
+            (session_id or "")[:20], time.time() - _start, len(reply), streamed,
         )
+        # An empty reply is a legitimate tool-only turn (the brain acted but
+        # chose not to speak) — deliver nothing rather than an error string.
         return {
-            "final_response": reply or "(No response from Letta brain)",
+            "final_response": reply,
             "messages": [
                 {"role": "user", "content": message},
                 {"role": "assistant", "content": reply},
@@ -17820,7 +18024,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "tools": [],
             "history_offset": len(history),
             "session_id": session_id,
-            "response_previewed": False,
+            "response_previewed": streamed,
         }
 
     async def _run_agent_via_proxy(
@@ -17909,74 +18113,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "stream": True,
         }
 
-        # Set up platform streaming if available -------------------------
-        _stream_consumer = None
-        _scfg = getattr(getattr(self, "config", None), "streaming", None)
-        if _scfg is None:
-            from gateway.config import StreamingConfig
-            _scfg = StreamingConfig()
-
-        platform_key = _platform_config_key(source.platform)
-        user_config = _load_gateway_config()
-        from gateway.display_config import resolve_display_setting
-        _plat_streaming = resolve_display_setting(
-            user_config, platform_key, "streaming"
+        # Set up platform streaming if available (shared with Letta-brain mode)
+        _stream_consumer, _thread_metadata = self._setup_platform_stream_consumer(
+            source, event_message_id, _run_still_current
         )
-        _streaming_enabled = (
-            _scfg.enabled and _scfg.transport != "off"
-            if _plat_streaming is None
-            else bool(_plat_streaming)
-        )
-
-        _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
-
-        if _streaming_enabled:
-            try:
-                from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
-                _adapter = self._adapter_for_source(source)
-                if _adapter:
-                    _pause_typing_before_finalize = None
-                    if source.platform == Platform.TELEGRAM and hasattr(_adapter, "pause_typing_for_chat"):
-                        def _pause_typing_before_finalize(
-                            _adapter=_adapter,
-                            _chat_id=source.chat_id,
-                        ) -> None:
-                            _adapter.pause_typing_for_chat(_chat_id)
-                    _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
-                    _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
-                    _buffer_only = False
-                    if source.platform == Platform.MATRIX:
-                        _effective_cursor = ""
-                        _buffer_only = True
-                    # Fresh-final applies to Telegram only — other
-                    # platforms either edit in place cheaply (Discord,
-                    # Slack) or don't have the timestamp-on-edit
-                    # problem.  (Ported from openclaw/openclaw#72038.)
-                    _fresh_final_secs = (
-                        float(getattr(_scfg, "fresh_final_after_seconds", 0.0) or 0.0)
-                        if source.platform == Platform.TELEGRAM
-                        else 0.0
-                    )
-                    _consumer_cfg = StreamConsumerConfig(
-                        edit_interval=_scfg.edit_interval,
-                        buffer_threshold=_scfg.buffer_threshold,
-                        cursor=_effective_cursor,
-                        buffer_only=_buffer_only,
-                        fresh_final_after_seconds=_fresh_final_secs,
-                        transport=_scfg.transport or "edit",
-                        chat_type=getattr(source, "chat_type", "") or "",
-                    )
-                    _stream_consumer = GatewayStreamConsumer(
-                        adapter=_adapter,
-                        chat_id=source.chat_id,
-                        config=_consumer_cfg,
-                        metadata=_thread_metadata,
-                        on_before_finalize=_pause_typing_before_finalize,
-                        initial_reply_to_id=event_message_id,
-                        run_still_current=_run_still_current,
-                    )
-            except Exception as _sc_err:
-                logger.debug("Proxy: could not set up stream consumer: %s", _sc_err)
 
         # Run the stream consumer task in the background
         stream_task = None
@@ -18300,7 +18440,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         This is run in a thread pool to not block the event loop.
         Supports interruption via new messages.
         """
-        # ---- Letta brain mode (SLICE-0 PROTOTYPE): delegate the turn to a
+        # ---- Letta brain mode (Swarm Map v1 B1): delegate the turn to a
         # bound Letta agent over REST. Checked before proxy mode — if both are
         # configured, the more specific brain binding wins. ----
         if self._get_letta_brain():
@@ -18311,6 +18451,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 history=history,
                 session_key=session_key,
                 run_generation=run_generation,
+                event_message_id=event_message_id,
             )
 
         # ---- Proxy mode: delegate to remote API server ----

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17756,10 +17756,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
 
+        # B1.5 door-context: a shared Letta brain sees only the message text, so
+        # tag it with who is speaking and (for multiplayer) which group. DMs get
+        # only the sender; group/channel/thread contexts also get a group label
+        # (prefer the human-readable chat_name, fall back to type:id). NOT a full
+        # transcript — just current-turn identity (spec B1.5).
+        _sender = source.user_name or None
+        _group = None
+        if source.chat_type and source.chat_type != "dm":
+            _group = source.chat_name or f"{source.chat_type}:{source.chat_id}"
+
         _start = time.time()
         try:
             reply = await asyncio.to_thread(
-                _letta_send, brain["base_url"], brain["agent_id"], message
+                _letta_send,
+                brain["base_url"],
+                brain["agent_id"],
+                message,
+                sender=_sender,
+                group=_group,
             )
         except LettaBrainError as e:
             logger.warning("Letta brain turn failed: %s", e)

--- a/tests/gateway/test_letta_brain.py
+++ b/tests/gateway/test_letta_brain.py
@@ -14,7 +14,12 @@ from unittest.mock import AsyncMock
 import pytest
 
 from gateway.config import Platform
-from gateway.letta_brain import LettaBrainError, send_message
+from gateway.letta_brain import (
+    LettaBrainError,
+    apply_sender_tag,
+    build_sender_tag,
+    send_message,
+)
 from gateway.session import SessionSource
 
 
@@ -80,6 +85,52 @@ def test_send_message_extracts_assistant_content(monkeypatch):
     assert seen["body"] == {"messages": [{"role": "user", "content": "hi there"}]}
 
 
+# ---------------------------------------------------------------------------
+# B1.5 door-context sender tagging
+# ---------------------------------------------------------------------------
+
+
+def test_build_sender_tag_sender_and_group():
+    # Matches the format validated live 2026-07-21 (agent extracted both facts).
+    assert build_sender_tag("Alice", "#family") == "[from Alice in #family]"
+
+
+def test_build_sender_tag_partial_and_empty():
+    assert build_sender_tag("Alice", None) == "[from Alice]"
+    assert build_sender_tag(None, "#family") == "[in #family]"
+    assert build_sender_tag(None, None) == ""
+
+
+def test_apply_sender_tag_prepends_on_its_own_line():
+    assert apply_sender_tag("hello", "Alice", "#family") == "[from Alice in #family]\nhello"
+
+
+def test_apply_sender_tag_is_noop_without_identity():
+    # No sender/group known → message text is forwarded verbatim.
+    assert apply_sender_tag("hello") == "hello"
+
+
+def test_send_message_forwards_the_tagged_content(monkeypatch):
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "ok", seen)
+
+    send_message("http://localhost:8283", "agent-1", "who am I?", sender="Alice", group="#family")
+
+    # The brain receives the door-context tag inline with the message.
+    assert seen["body"] == {
+        "messages": [{"role": "user", "content": "[from Alice in #family]\nwho am I?"}]
+    }
+
+
+def test_send_message_untagged_when_no_identity(monkeypatch):
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "ok", seen)
+
+    send_message("http://localhost:8283", "agent-1", "plain message")
+
+    assert seen["body"] == {"messages": [{"role": "user", "content": "plain message"}]}
+
+
 def test_send_message_unreachable_raises_clear_error(monkeypatch):
     def _boom(req, timeout=None):
         raise OSError("connection refused")
@@ -139,9 +190,61 @@ async def test_turn_routes_through_letta_delegation(monkeypatch):
     assert result["final_response"] == "the brain says hi"
     assert result["api_calls"] == 1
     assert seen["url"] == "http://localhost:8283/v1/agents/agent-abc/messages"
-    # Only the NEW message goes over the wire — Letta owns its own history.
-    assert seen["body"] == {"messages": [{"role": "user", "content": "hello brain"}]}
+    # Only the NEW message goes over the wire (Letta owns its own history), now
+    # carrying the B1.5 door-context tag: _make_source() is a group chat with
+    # user_name "tester" and no chat_name, so the group falls back to type:id.
+    assert seen["body"] == {
+        "messages": [
+            {"role": "user", "content": "[from tester in group:-100999]\nhello brain"}
+        ]
+    }
     adapter.send_typing.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dm_turn_tags_sender_only_no_group(monkeypatch):
+    """A DM has no group — the door-context tag carries just the sender."""
+    monkeypatch.setenv("LETTA_BRAIN_URL", "http://localhost:8283")
+    monkeypatch.setenv("LETTA_BRAIN_AGENT_ID", "agent-abc")
+    monkeypatch.delenv("GATEWAY_PROXY_URL", raising=False)
+
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "hi", seen)
+    runner, _adapter = _make_runner()
+
+    dm_source = SessionSource(
+        platform=Platform.TELEGRAM, user_id="7", chat_id="7",
+        user_name="Alice", chat_type="dm",
+    )
+    await runner._run_agent_inner(
+        message="hello", context_prompt="", history=[], source=dm_source, session_id="s",
+    )
+    assert seen["body"] == {
+        "messages": [{"role": "user", "content": "[from Alice]\nhello"}]
+    }
+
+
+@pytest.mark.asyncio
+async def test_group_turn_prefers_chat_name_for_group_label(monkeypatch):
+    """When the adapter supplies a human-readable chat_name, use it as the group."""
+    monkeypatch.setenv("LETTA_BRAIN_URL", "http://localhost:8283")
+    monkeypatch.setenv("LETTA_BRAIN_AGENT_ID", "agent-abc")
+    monkeypatch.delenv("GATEWAY_PROXY_URL", raising=False)
+
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "hi", seen)
+    runner, _adapter = _make_runner()
+
+    src = SessionSource(
+        platform=Platform.TELEGRAM, user_id="7", chat_id="-100999",
+        user_name="Alice", chat_type="group", chat_name="#family",
+    )
+    await runner._run_agent_inner(
+        message="hello", context_prompt="", history=[], source=src, session_id="s",
+    )
+    assert seen["body"] == {
+        "messages": [{"role": "user", "content": "[from Alice in #family]\nhello"}]
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_letta_brain.py
+++ b/tests/gateway/test_letta_brain.py
@@ -62,6 +62,7 @@ def _install_fake_urlopen(monkeypatch, reply: str, seen: dict):
         seen["url"] = req.full_url
         seen["body"] = json.loads(req.data.decode("utf-8"))
         seen["timeout"] = timeout
+        seen["headers"] = dict(req.header_items())
         return _FakeUrlopenResponse(
             json.dumps(_letta_turn_response(reply)).encode("utf-8")
         )
@@ -270,3 +271,144 @@ async def test_letta_failure_returns_clear_error_not_crash(monkeypatch):
     assert result["final_response"].startswith("⚠️")
     assert "unreachable" in result["final_response"]
     assert result["api_calls"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Production hardening (real B1 — Swarm Map v1 slice 4)
+# ---------------------------------------------------------------------------
+
+
+def test_send_message_sends_bearer_auth_when_key_given(monkeypatch):
+    """Letta Cloud / secured servers need an Authorization header."""
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "ok", seen)
+    send_message("http://localhost:8283", "agent-1", "hi", api_key="sk-letta-xyz")
+    assert seen["headers"].get("Authorization") == "Bearer sk-letta-xyz"
+
+
+def test_send_message_no_auth_header_by_default(monkeypatch):
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "ok", seen)
+    send_message("http://localhost:8283", "agent-1", "hi")
+    assert "Authorization" not in seen["headers"]
+
+
+def test_tool_only_turn_returns_empty_reply_not_error(monkeypatch):
+    """A turn can legitimately end without an assistant_message (the agent only
+    ran tools). Production semantics: quiet empty reply, NOT an error the user
+    sees (resolves the prototype's TODO)."""
+
+    def _fake_urlopen(req, timeout=None):
+        return _FakeUrlopenResponse(
+            json.dumps(
+                {
+                    "messages": [
+                        {"message_type": "tool_call_message", "tool_call": {}},
+                        {"message_type": "tool_return_message", "tool_return": "..."},
+                    ]
+                }
+            ).encode("utf-8")
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    assert send_message("http://localhost:8283", "agent-1", "do the thing") == ""
+
+
+def test_parse_stream_line_assistant_delta():
+    from gateway.letta_brain import parse_stream_line
+
+    line = 'data: ' + json.dumps(
+        {"message_type": "assistant_message", "content": "Hel"}
+    )
+    assert parse_stream_line(line) == "Hel"
+
+
+def test_parse_stream_line_content_parts():
+    from gateway.letta_brain import parse_stream_line
+
+    line = 'data: ' + json.dumps(
+        {
+            "message_type": "assistant_message",
+            "content": [{"type": "text", "text": "lo"}],
+        }
+    )
+    assert parse_stream_line(line) == "lo"
+
+
+def test_parse_stream_line_ignores_non_assistant_and_noise():
+    from gateway.letta_brain import parse_stream_line
+
+    assert parse_stream_line("data: [DONE]") is None
+    assert (
+        parse_stream_line(
+            'data: {"message_type": "reasoning_message", "reasoning": "hmm"}'
+        )
+        is None
+    )
+    assert parse_stream_line("data: {not json") is None
+    assert parse_stream_line(": keepalive comment") is None
+    assert parse_stream_line("") is None
+
+
+def test_get_letta_brain_picks_up_api_key(monkeypatch):
+    monkeypatch.setenv("LETTA_BRAIN_URL", "http://localhost:8283")
+    monkeypatch.setenv("LETTA_BRAIN_AGENT_ID", "agent-abc")
+    monkeypatch.setenv("LETTA_BRAIN_API_KEY", "sk-letta-xyz")
+    runner, _ = _make_runner()
+    brain = runner._get_letta_brain()
+    assert brain["api_key"] == "sk-letta-xyz"
+
+
+def test_letta_agent_lock_identity():
+    """B3: one lock per bound Letta agent — same key, same lock."""
+    runner, _ = _make_runner()
+    a = runner._letta_agent_lock("http://h:8283|agent-1")
+    b = runner._letta_agent_lock("http://h:8283|agent-1")
+    c = runner._letta_agent_lock("http://h:8283|agent-2")
+    assert a is b
+    assert a is not c
+
+
+@pytest.mark.asyncio
+async def test_concurrent_group_turns_serialize_per_agent(monkeypatch):
+    """B3: Letta processes an agent's messages sequentially — concurrent group
+    messages must queue, never overlapping in flight."""
+    import asyncio
+    import threading
+
+    monkeypatch.setenv("LETTA_BRAIN_URL", "http://localhost:8283")
+    monkeypatch.setenv("LETTA_BRAIN_AGENT_ID", "agent-abc")
+    monkeypatch.delenv("GATEWAY_PROXY_URL", raising=False)
+    # Force the blocking client path so in-flight tracking is deterministic.
+    monkeypatch.setenv("LETTA_BRAIN_STREAMING", "off")
+
+    state = {"in_flight": 0, "max_in_flight": 0}
+    gate = threading.Lock()
+
+    def _slow_urlopen(req, timeout=None):
+        with gate:
+            state["in_flight"] += 1
+            state["max_in_flight"] = max(state["max_in_flight"], state["in_flight"])
+        import time as _t
+
+        _t.sleep(0.05)
+        with gate:
+            state["in_flight"] -= 1
+        return _FakeUrlopenResponse(
+            json.dumps(_letta_turn_response("ok")).encode("utf-8")
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", _slow_urlopen)
+    runner, _adapter = _make_runner()
+
+    src = _make_source()
+    results = await asyncio.gather(
+        runner._run_agent_inner(
+            message="one", context_prompt="", history=[], source=src, session_id="s1"
+        ),
+        runner._run_agent_inner(
+            message="two", context_prompt="", history=[], source=src, session_id="s2"
+        ),
+    )
+    assert [r["final_response"] for r in results] == ["ok", "ok"]
+    assert state["max_in_flight"] == 1, "turns for one Letta agent overlapped"

--- a/tests/gateway/test_letta_brain.py
+++ b/tests/gateway/test_letta_brain.py
@@ -1,0 +1,169 @@
+"""Tests for Letta-backed turn delegation (SLICE-0 PROTOTYPE, Swarm Map v1 B1).
+
+A gateway with LETTA_BRAIN_URL + LETTA_BRAIN_AGENT_ID configured must route
+an inbound turn to the Letta agent's REST endpoint instead of the native
+AIAgent loop, and return Letta's assistant_message content through the normal
+result-dict shape.
+"""
+
+import io
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.letta_brain import LettaBrainError, send_message
+from gateway.session import SessionSource
+
+
+def _letta_turn_response(reply: str) -> dict:
+    """Shape validated live against a self-hosted Letta server (2026-07-19)."""
+    return {
+        "messages": [
+            {
+                "id": "message-1",
+                "message_type": "reasoning_message",
+                "reasoning": "thinking about it",
+            },
+            {
+                "id": "message-2",
+                "message_type": "assistant_message",
+                "content": reply,
+            },
+        ],
+        "usage": {"completion_tokens": 10},
+        "stop_reason": "end_turn",
+    }
+
+
+class _FakeUrlopenResponse:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _install_fake_urlopen(monkeypatch, reply: str, seen: dict):
+    def _fake_urlopen(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["body"] = json.loads(req.data.decode("utf-8"))
+        seen["timeout"] = timeout
+        return _FakeUrlopenResponse(
+            json.dumps(_letta_turn_response(reply)).encode("utf-8")
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+def test_send_message_extracts_assistant_content(monkeypatch):
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "hello from letta", seen)
+
+    reply = send_message("http://localhost:8283", "agent-123", "hi there")
+
+    assert reply == "hello from letta"
+    assert seen["url"] == "http://localhost:8283/v1/agents/agent-123/messages"
+    assert seen["body"] == {"messages": [{"role": "user", "content": "hi there"}]}
+
+
+def test_send_message_unreachable_raises_clear_error(monkeypatch):
+    def _boom(req, timeout=None):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+
+    with pytest.raises(LettaBrainError) as excinfo:
+        send_message("http://localhost:8283", "agent-123", "hi")
+    assert "unreachable" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Gateway routing
+# ---------------------------------------------------------------------------
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    adapter = SimpleNamespace(send_typing=AsyncMock())
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    return runner, adapter
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="42",
+        chat_id="-100999",
+        user_name="tester",
+        chat_type="group",
+    )
+
+
+@pytest.mark.asyncio
+async def test_turn_routes_through_letta_delegation(monkeypatch):
+    """With a Letta brain bound, _run_agent_inner never touches the native
+    AIAgent loop — the turn goes to Letta and its reply comes back."""
+    monkeypatch.setenv("LETTA_BRAIN_URL", "http://localhost:8283")
+    monkeypatch.setenv("LETTA_BRAIN_AGENT_ID", "agent-abc")
+    monkeypatch.delenv("GATEWAY_PROXY_URL", raising=False)
+
+    seen: dict = {}
+    _install_fake_urlopen(monkeypatch, "the brain says hi", seen)
+
+    runner, adapter = _make_runner()
+
+    result = await runner._run_agent_inner(
+        message="hello brain",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="sess-1",
+    )
+
+    assert result["final_response"] == "the brain says hi"
+    assert result["api_calls"] == 1
+    assert seen["url"] == "http://localhost:8283/v1/agents/agent-abc/messages"
+    # Only the NEW message goes over the wire — Letta owns its own history.
+    assert seen["body"] == {"messages": [{"role": "user", "content": "hello brain"}]}
+    adapter.send_typing.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_letta_failure_returns_clear_error_not_crash(monkeypatch):
+    monkeypatch.setenv("LETTA_BRAIN_URL", "http://localhost:8283")
+    monkeypatch.setenv("LETTA_BRAIN_AGENT_ID", "agent-abc")
+
+    def _boom(req, timeout=None):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+
+    runner, _adapter = _make_runner()
+
+    result = await runner._run_agent_inner(
+        message="hello brain",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="sess-1",
+    )
+
+    assert result["final_response"].startswith("⚠️")
+    assert "unreachable" in result["final_response"]
+    assert result["api_calls"] == 0


### PR DESCRIPTION
Swarm Map v1 **slice 4 — real B1** (spec `memory/specs/2026-07-19-swarm-map-v1-definition.md` §2B/§3). Supersedes prototype #96 and B1.5 #101: both ride in as the first two commits (rebased onto current main), the third graduates them to production.

## What
A Hermes gateway with `LETTA_BRAIN_URL` + `LETTA_BRAIN_AGENT_ID` (+ optional `LETTA_BRAIN_API_KEY`) becomes the messaging **door** for a Letta **brain**: surfaces, pairing/group approval, audit, and budget all run as normal, then the turn is forwarded to the bound Letta agent over REST and the reply rides the normal delivery path.

## Production hardening over the prototype
- **B3 per-agent serialization** — per-(server|agent) asyncio lock; staleness re-checked after queue wait
- **Streaming** — Letta SSE → the same `GatewayStreamConsumer` proxy mode uses (`_setup_platform_stream_consumer` extracted verbatim, shared); `LETTA_BRAIN_STREAMING=off` forces blocking
- **Double-turn safety** — stream→blocking fallback only on provably pre-delivery failures (`LettaBrainError.retryable`); partials delivered, never retried
- **Auth** — Bearer key for Letta Cloud / secured servers
- **Tool-only turns** — quiet empty reply + audit log, not a user-facing error

## Tests
21/21 letta (9 new), 170 green across letta/proxy/stream-consumer/streaming-defaults; ruff clean. (9 aiohttp-less proxy failures pre-exist on main in envs without the optional extra.)

## Not in this PR (spec-tracked)
B2 (Swarm Map wires door↔brain), B4/C1 verification, interrupt handling, media forwarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)