### PR TITLE
fix(git-auth): inject short-lived App token as GH_TOKEN into tool subprocesses

### DIFF
--- a/tests/tools/test_gh_token_inject.py
+++ b/tests/tools/test_gh_token_inject.py
@@ -1,0 +1,148 @@
+"""Tests for short-lived GitHub App token injection as GH_TOKEN.
+
+Tier-1 stripping removes every ambient GitHub credential from tool
+subprocesses — deliberately: they are long-lived. But that leaves ``gh``
+with no auth at all. git is covered by the ``github_app_token`` credential
+helper, which mints a fresh installation token per operation; ``gh`` has no
+credential-helper concept and falls back to a ``hosts.yml`` written once at
+container boot, whose App token dies within the hour (observed live:
+hermes-nimbleco's ``gh`` dead from 2026-07-21 onward while git kept working).
+
+The fix mirrors the git path at the env boundary: mint (cache-first) the
+same short-lived installation token and inject it as ``GH_TOKEN`` into the
+sanitized subprocess env. Exposure is not widened — the helper already
+caches this token under the subprocess HOME, readable by any tool.
+
+See hermes_cli/github_app_token.py for the mint/cache layer.
+"""
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import tools.environments.local as local_mod
+from tools.environments.local import (
+    _make_run_env,
+    _sanitize_subprocess_env,
+)
+
+
+MINT_TARGET = "hermes_cli.github_app_token.get_installation_token"
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldown():
+    """Each test starts with a clean mint-failure cooldown."""
+    local_mod._GH_TOKEN_MINT_FAILURE_TS = 0.0
+    yield
+    local_mod._GH_TOKEN_MINT_FAILURE_TS = 0.0
+
+
+def _base_env(home="/data/agent/home"):
+    return {"HOME": home, "PATH": "/usr/bin"}
+
+
+class TestInjection:
+    def test_minted_token_injected_as_gh_token(self):
+        with patch(MINT_TARGET, return_value="ghs_minted") as mint:
+            env = _sanitize_subprocess_env(_base_env())
+        assert env.get("GH_TOKEN") == "ghs_minted"
+        mint.assert_called_once()
+
+    def test_home_parent_is_the_hermes_home_dir(self):
+        """The mint layer's contract: HOME is ``{HERMES_HOME}/home``, so the
+        dir holding ``.env`` is HOME's parent (github_app_token._default_home)."""
+        with patch(MINT_TARGET, return_value="ghs_minted") as mint:
+            env = _sanitize_subprocess_env(_base_env())
+        home = Path(env["HOME"])
+        assert mint.call_args.args[0] == home.parent
+
+    def test_run_env_path_also_injects(self):
+        """_make_run_env (foreground terminal) mirrors the sanitize path."""
+        with patch(MINT_TARGET, return_value="ghs_minted"):
+            env = _make_run_env(_base_env())
+        assert env.get("GH_TOKEN") == "ghs_minted"
+
+    def test_ambient_github_tokens_still_stripped(self):
+        """Injection must not resurrect the long-lived ambient credentials."""
+        base = _base_env() | {
+            "GITHUB_TOKEN": "ghp_longlived",
+            "GITHUB_APP_PRIVATE_KEY_B64": "pem",
+        }
+        with patch(MINT_TARGET, return_value="ghs_minted"):
+            env = _sanitize_subprocess_env(base)
+        assert env.get("GH_TOKEN") == "ghs_minted"
+        assert "GITHUB_TOKEN" not in env
+        assert "GITHUB_APP_PRIVATE_KEY_B64" not in env
+
+
+class TestFailSoft:
+    def test_no_app_creds_no_injection(self):
+        """None from the mint layer = this agent has no App creds. Not an
+        error: PAT-less / App-less installs see exactly the old behavior."""
+        with patch(MINT_TARGET, return_value=None):
+            env = _sanitize_subprocess_env(_base_env())
+        assert "GH_TOKEN" not in env
+
+    def test_mint_error_swallowed(self):
+        with patch(MINT_TARGET, side_effect=RuntimeError("api down")):
+            env = _sanitize_subprocess_env(_base_env())  # must not raise
+        assert "GH_TOKEN" not in env
+
+    def test_mint_error_starts_cooldown(self):
+        """A failed mint must not retry on every spawn while GitHub is down —
+        each retry costs a live HTTP timeout on the tool hot path."""
+        with patch(MINT_TARGET, side_effect=RuntimeError("api down")) as mint:
+            _sanitize_subprocess_env(_base_env())
+            _sanitize_subprocess_env(_base_env())
+        assert mint.call_count == 1
+
+    def test_cooldown_expires(self):
+        with patch(MINT_TARGET, side_effect=RuntimeError("api down")) as mint:
+            _sanitize_subprocess_env(_base_env())
+        local_mod._GH_TOKEN_MINT_FAILURE_TS = (
+            time.time() - local_mod._GH_TOKEN_MINT_COOLDOWN_SECONDS - 1
+        )
+        with patch(MINT_TARGET, return_value="ghs_recovered") as mint2:
+            env = _sanitize_subprocess_env(_base_env())
+        assert env.get("GH_TOKEN") == "ghs_recovered"
+        assert mint2.call_count == 1
+
+    def test_none_result_does_not_start_cooldown(self):
+        """No-creds is a cheap file read, not a failure — never cool down on
+        it, or an agent that gains App creds mid-session waits a minute."""
+        with patch(MINT_TARGET, return_value=None) as mint:
+            _sanitize_subprocess_env(_base_env())
+            _sanitize_subprocess_env(_base_env())
+        assert mint.call_count == 2
+
+    def test_missing_home_skips_quietly(self):
+        with patch(MINT_TARGET, return_value="ghs_minted") as mint:
+            env = _sanitize_subprocess_env({"PATH": "/usr/bin"})
+        # apply_subprocess_home_env may synthesize a HOME; only assert we
+        # didn't crash and the mint layer got a real dir if it was called.
+        if mint.called:
+            assert mint.call_args.args[0] != Path(".")
+        assert isinstance(env, dict)
+
+
+class TestPrecedence:
+    def test_forced_gh_token_wins_over_mint(self):
+        """An operator force-passing GH_TOKEN (force prefix) is explicit
+        intent — the mint must not clobber it."""
+        from tools.environments.local import _HERMES_PROVIDER_ENV_FORCE_PREFIX
+
+        extra = {_HERMES_PROVIDER_ENV_FORCE_PREFIX + "GH_TOKEN": "ghp_forced"}
+        with patch(MINT_TARGET, return_value="ghs_minted") as mint:
+            env = _sanitize_subprocess_env(_base_env(), extra_env=extra)
+        assert env.get("GH_TOKEN") == "ghp_forced"
+        mint.assert_not_called()
+
+    def test_opt_out_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_GH_TOKEN_INJECT", "off")
+        with patch(MINT_TARGET, return_value="ghs_minted") as mint:
+            env = _sanitize_subprocess_env(_base_env())
+        assert "GH_TOKEN" not in env
+        mint.assert_not_called()

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -344,6 +344,65 @@ def _inject_session_context_env(env: dict) -> None:
             env.pop(var_name, None)
 
 
+# Mint-failure cooldown for GH_TOKEN injection: a failed mint must not retry
+# on every spawn while GitHub is unreachable — each retry would add a live
+# HTTP timeout to the terminal hot path. One failure quiets the mint for the
+# cooldown window; a None result (agent simply has no App creds) is a cheap
+# .env read and never cools down.
+_GH_TOKEN_MINT_FAILURE_TS: float = 0.0
+_GH_TOKEN_MINT_COOLDOWN_SECONDS: float = 60.0
+
+
+def _inject_github_app_gh_token(env: dict) -> None:
+    """Inject a short-lived GitHub App installation token as ``GH_TOKEN``.
+
+    Tier-1 stripping removes every ambient GitHub credential from tool
+    subprocesses — deliberately: they are long-lived. But that leaves ``gh``
+    with no auth at all. git is covered by the ``github_app_token`` credential
+    helper, which mints per operation; ``gh`` has no credential-helper concept
+    and falls back to a ``hosts.yml`` written once at container boot, whose
+    App token dies within the hour. Mirror the git path at the env boundary:
+    mint (cache-first — at most one live mint per ~50 min) and hand the token
+    to the subprocess as ``GH_TOKEN``, which ``gh`` prefers over ``hosts.yml``.
+
+    Exposure is not widened: the helper already caches this same token under
+    the subprocess HOME (``github_app_token.cache_path``), readable by any
+    tool. A short-lived, App-scoped, revocable token replaces a fossilized
+    one — the long-lived PAT and the App private key stay stripped.
+
+    Ordering contract: call AFTER ``apply_subprocess_home_env`` (HOME is final
+    then; the mint layer derives the ``.env`` dir as ``HOME``'s parent, the
+    same contract as ``github_app_token._default_home``) and after the strip
+    passes (an explicit force-passed ``GH_TOKEN`` must win — presence in
+    ``env`` here means the operator asked for that exact token).
+
+    Fail-soft: no App creds → no injection (App-less installs see the old
+    behavior exactly); mint failure → cooldown, no retry storm. Opt out with
+    ``HERMES_GH_TOKEN_INJECT=off``.
+    """
+    global _GH_TOKEN_MINT_FAILURE_TS
+    if env.get("GH_TOKEN"):
+        return
+    if os.environ.get("HERMES_GH_TOKEN_INJECT", "").strip().lower() in (
+        "0", "off", "false", "no",
+    ):
+        return
+    if time.time() - _GH_TOKEN_MINT_FAILURE_TS < _GH_TOKEN_MINT_COOLDOWN_SECONDS:
+        return
+    home = env.get("HOME")
+    if not home:
+        return
+    try:
+        from hermes_cli.github_app_token import get_installation_token
+
+        token = get_installation_token(Path(home).parent)
+    except Exception:
+        _GH_TOKEN_MINT_FAILURE_TS = time.time()
+        return
+    if token:
+        env["GH_TOKEN"] = token
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -376,6 +435,10 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
 
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(sanitized)
+
+    # After HOME is final and the strips have run: hand `gh` a short-lived
+    # App installation token in place of the stripped long-lived credentials.
+    _inject_github_app_gh_token(sanitized)
 
     # Same cross-session leak guard as _make_run_env, for the background/PTY
     # spawn path (process_registry.spawn_local builds env via this function).
@@ -826,6 +889,10 @@ def _make_run_env(env: dict) -> dict:
 
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(run_env)
+
+    # After HOME is final and the strips have run: hand `gh` a short-lived
+    # App installation token in place of the stripped long-lived credentials.
+    _inject_github_app_gh_token(run_env)
 
     # Bridge ContextVar-based session vars into the subprocess env (with the
     # cross-session leak guard — strips _UNSET vars when a concurrent host is


### PR DESCRIPTION
## Problem

Tier-1 stripping removes every ambient GitHub credential from tool subprocesses — deliberately. git survives via the `github_app_token` credential helper (fresh mint per operation), but `gh` has no credential-helper concept: it falls back to a `hosts.yml` written **once** at container boot, whose App installation token dies within the hour.

**Observed live:** hermes-nimbleco's `gh` dead from 2026-07-21 onward (`Failed to log in ... hosts.yml`) while git kept working; the agent's self-rescue attempts were correctly blocked by the security scanner (exporting `GITHUB_TOKEN`) or fumbled the helper CLI.

## Fix

Mirror the git path at the env boundary: `_inject_github_app_gh_token()` mints (cache-first, ~50 min reuse — at most one live mint per window) and injects `GH_TOKEN` into both spawn paths (`_sanitize_subprocess_env`, `_make_run_env`), after `apply_subprocess_home_env` (HOME final; `.env` dir = HOME's parent, same contract as `_default_home`) and after the strips (a force-passed `GH_TOKEN` wins; mint skipped).

- **No widened exposure:** the helper already caches this same token under the subprocess HOME, readable by any tool. Long-lived PAT + App private key stay stripped.
- **Fail-soft:** no App creds → no injection, zero behavior change for App-less installs (cost: one `.env` read per spawn). Mint failure → 60s cooldown, no retry storm on the tool hot path. `None` (no creds) never cools down.
- **Opt-out:** `HERMES_GH_TOKEN_INJECT=off`.
- No boot-path changes, no daemons; the stale `hosts.yml` becomes moot because `gh` prefers the env var.

## Verification

- 12 new tests (`tests/tools/test_gh_token_inject.py`): injection on both paths, HOME-parent contract, ambient strip preserved, fail-soft matrix, cooldown semantics, force-prefix precedence, opt-out.
- Full `tests/tools`: failure set **byte-identical** to baseline (parent commit, clean worktree) — 57 env-specific pre-existing failures in file-tools/voice suites, zero attributable to this diff. Env-focused suites: 161/161.
- `ruff check` clean on changed files (repo-blocking rule PLW1514 included).
- **Live proof** in the hermes-nimbleco container: minted token via `GH_TOKEN` → `gh auth status` ✓, `gh pr list` / `gh api repos/...` ✓. (`gh api user` 403s by design — installation tokens have no user identity.)

## Upstream note

`hermes_cli/github_app_token.py` is absent from NousResearch upstream — the App-auth feature is fork-only. This fix is upstream-quality but dependency-blocked: it should accompany (not precede) upstreaming `github-app-auth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)