### PR TITLE
feat(routing): kimi-k3 on-demand premium + glm directives — three-tier fleet hierarchy

### DIFF
--- a/plugins/intelligent_routing/README.md
+++ b/plugins/intelligent_routing/README.md
@@ -133,6 +133,36 @@ in #43534's data (DeepSeek coding throughput directionally lower → keep code-g
 on Claude; DeepSeek only competitive AND cheap at CLI/tool orchestration). See
 `references/prior-art.md`.
 
+## Fleet tiers & user model directives
+
+The fleet runs a three-tier hierarchy. PRIMARY is whatever the agent's
+configured primary model is — premium/fail-open turns emit **no** route
+override, so they land on the primary automatically (no plugin change needed
+when the fleet primary flips).
+
+| Tier | Model | How a turn gets there |
+|---|---|---|
+| PRIMARY (chat default) | `z-ai/glm-5.2` / openrouter (configured primary) | classifier: judgment / uncertain / public-facing (fail-open — no override emitted) |
+| CHEAP (mechanical) | `deepseek/deepseek-v3.2` / openrouter | classifier: confident MECHANICAL (`routing.cheap_model` / `cheap_provider`) |
+| ON-DEMAND PREMIUM | `moonshotai/kimi-k3` / openrouter | user says `use kimi` (or `kimi3` / `k3`) in the message |
+
+A user can request a specific model mid-message — the directive short-circuits
+the classifier entirely (fires BEFORE the mechanical/judgment split, so a bare
+`use kimi` isn't misread as an imperative → mechanical → deepseek):
+
+| Directive | Routes to |
+|---|---|
+| `use kimi` / `use kimi3` / `use k3` | `moonshotai/kimi-k3` / openrouter |
+| `use glm` | `z-ai/glm-5.2` / openrouter |
+| `use deepseek` | `deepseek/deepseek-v3.2` / openrouter |
+| `use fable` | `claude-fable-5` / anthropic |
+| `use opus` | `claude-opus-4-8` / anthropic |
+| `use sonnet` | `claude-sonnet-4-6` / anthropic |
+| `use haiku` | `claude-haiku-4-5-20251001` / anthropic |
+| `use claude` | no override — stay on configured primary |
+
+Directives are turn-scoped (same `routing_override` path — reverted next turn).
+
 ## Scope — DONE vs DEFERRED
 
 **Done (Stage 1, our fork):**

--- a/plugins/intelligent_routing/registration.py
+++ b/plugins/intelligent_routing/registration.py
@@ -61,6 +61,10 @@ _USER_MODEL_MAP = {
     "sonnet": ("claude-sonnet-4-6", "anthropic"),
     "haiku": ("claude-haiku-4-5-20251001", "anthropic"),
     "deepseek": ("deepseek/deepseek-v3.2", "openrouter"),
+    "kimi": ("moonshotai/kimi-k3", "openrouter"),
+    "kimi3": ("moonshotai/kimi-k3", "openrouter"),
+    "k3": ("moonshotai/kimi-k3", "openrouter"),
+    "glm": ("z-ai/glm-5.2", "openrouter"),
     "claude": None,  # "use claude" = stay on configured primary
 }
 _DIRECTIVE_RE = re.compile(

--- a/tests/plugins/intelligent_routing/test_registration.py
+++ b/tests/plugins/intelligent_routing/test_registration.py
@@ -327,3 +327,82 @@ def test_no_directive_falls_through_to_classifier():
         )
     assert isinstance(result, dict)
     assert result.get("route") == {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}
+
+
+# ---- kimi / glm directives (three-tier fleet hierarchy) ----------------------
+#
+# Fleet cost restructure: PRIMARY = z-ai/glm-5.2 (chat default), CHEAP =
+# deepseek/deepseek-v3.2 (mechanical tier), ON-DEMAND PREMIUM =
+# moonshotai/kimi-k3 ("use kimi" runs that turn on Kimi K3). Same directive
+# mechanism as fable/opus/deepseek — intercepted before the classifier.
+
+
+def test_user_directive_kimi_routes_to_kimi_k3():
+    """'use kimi' overrides the classifier and routes to moonshotai/kimi-k3."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="use kimi for this — it needs the premium tier",
+            model="z-ai/glm-5.2", platform="signal",
+        )
+    assert isinstance(result, dict)
+    assert result["route"] == {"model": "moonshotai/kimi-k3", "provider": "openrouter"}
+    assert "user-requested" in result["context"]
+
+
+def test_user_directive_kimi_aliases_kimi3_and_k3():
+    """'use kimi3' and 'use k3' are aliases for moonshotai/kimi-k3."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        for phrase in ("please use kimi3 here", "use k3 — max reasoning"):
+            result = registration.on_pre_llm_call(
+                user_message=phrase, model="z-ai/glm-5.2", platform="cli",
+            )
+            assert isinstance(result, dict), phrase
+            assert result["route"] == {
+                "model": "moonshotai/kimi-k3", "provider": "openrouter",
+            }, phrase
+
+
+def test_user_directive_kimi_wins_over_mechanical_classifier():
+    """Bare 'use kimi' routes to kimi-k3, NOT deepseek.
+
+    'use' is in _IMPERATIVE_VERBS, so without the directive intercept a bare
+    'use kimi' would be classified mechanical → cheap → deepseek. The
+    directive must short-circuit the classifier (same trap as 'use fable').
+    """
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="use kimi",
+            model="z-ai/glm-5.2", platform="cli",
+        )
+    assert isinstance(result, dict)
+    route = result.get("route", {})
+    assert route.get("model") == "moonshotai/kimi-k3", (
+        f"'use kimi' must route to kimi-k3, not deepseek; got route={route}"
+    )
+
+
+def test_user_directive_glm_routes_to_glm():
+    """'use glm' routes to z-ai/glm-5.2 / openrouter (the fleet primary)."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="use glm for this one",
+            model="claude-sonnet-5", platform="cli",
+        )
+    assert isinstance(result, dict)
+    assert result["route"] == {"model": "z-ai/glm-5.2", "provider": "openrouter"}
+
+
+def test_user_directive_group_prefix_plus_kimi():
+    """Kimi directive still fires when a group [sender] prefix is present."""
+    with patch("plugins.intelligent_routing.registration.is_intelligent_routing_enabled",
+               return_value=True):
+        result = registration.on_pre_llm_call(
+            user_message="[mare] use kimi for this please",
+            model="z-ai/glm-5.2", platform="signal",
+        )
+    assert isinstance(result, dict)
+    assert result["route"] == {"model": "moonshotai/kimi-k3", "provider": "openrouter"}


### PR DESCRIPTION
## Three-tier fleet hierarchy

The fleet is moving to a three-tier model hierarchy as part of the cost restructure (GLM-5.2 becomes the fleet primary):

| Tier | Model | How a turn gets there |
|---|---|---|
| PRIMARY (chat default) | `z-ai/glm-5.2` / openrouter | classifier fail-open: judgment / uncertain / public-facing (no override emitted — lands on configured primary) |
| CHEAP (mechanical) | `deepseek/deepseek-v3.2` / openrouter | classifier: confident MECHANICAL |
| ON-DEMAND PREMIUM | `moonshotai/kimi-k3` / openrouter | user says `use kimi` (or `kimi3` / `k3`) in the message |

## What changed

- **New user directives** in `_USER_MODEL_MAP` (same mechanism as #91's fable/opus/deepseek — intercepted BEFORE the classifier, turn-scoped via the routing-override path):
  - `use kimi` / `use kimi3` / `use k3` → `moonshotai/kimi-k3` / openrouter
  - `use glm` → `z-ai/glm-5.2` / openrouter
- **README**: documents the three-tier hierarchy + full directive table.

## Premium-tier finding (no code change needed)

Premium is **derived from primary**, not hardcoded: premium/fail-open turns emit no `route` override, so they land on whatever the agent's configured primary is (`registration.py` — "Premium / fail-open turns emit no override and stay on the configured primary"). Flipping the fleet primary to GLM-5.2 automatically makes the classifier's fail-open target GLM-5.2. Only the cheap tier is an explicit target (`routing.cheap_model` / `cheap_provider`, default deepseek-v3.2/openrouter — unchanged).

Note (same trap as #91): `use` is in `_IMPERATIVE_VERBS`, so without the directive intercept a bare `use kimi` would classify mechanical → cheap → deepseek. Covered by `test_user_directive_kimi_wins_over_mechanical_classifier`.

## Test evidence

Red-first (`ac14a1c`): 5 new cases failed against main — kimi route, kimi3/k3 aliases, mechanical-classifier bypass, glm route, group `[sender]` prefix + kimi.

Green (`98374da`):

```
tests/plugins/intelligent_routing/ ................ 102 passed
+ tests/agent/test_routing_override_revert.py
+ tests/agent/test_routing_override.py
= 121 passed in 4.20s (Python 3.11)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
