### PR TITLE
fix(git-auth): App credential helper must accept git's trailing operation arg

### DIFF
--- a/hermes_cli/github_app_token.py
+++ b/hermes_cli/github_app_token.py
@@ -237,9 +237,15 @@ def main(argv: Optional[list] = None) -> int:
     sub = parser.add_subparsers(dest="cmd", required=True)
     gc = sub.add_parser("get-credential", help="emit git credential-helper output")
     gc.add_argument("--home", type=Path, default=None)
+    # git invokes a credential helper as ``<helper> <operation>`` where operation
+    # is get/store/erase. Accept and ignore that trailing arg — without it argparse
+    # errors ("unrecognized arguments: get") and git can never read the credential.
+    gc.add_argument("op", nargs="?", default="get")
     args = parser.parse_args(argv)
 
     if args.cmd == "get-credential":
+        if args.op not in (None, "get"):
+            return 0  # store/erase are no-ops for a mint-on-demand helper
         home = args.home or _default_home()
         token = get_installation_token(home)
         if not token:

--- a/tests/hermes_cli/test_github_app_token.py
+++ b/tests/hermes_cli/test_github_app_token.py
@@ -243,3 +243,24 @@ def test_get_credential_stdout_format(app_env, monkeypatch, capsys):
     assert "username=x-access-token\n" in out
     assert "password=ghs_helper\n" in out
     assert out.endswith("\n\n")
+
+
+def test_get_credential_accepts_git_get_operation(app_env, monkeypatch, capsys):
+    # git invokes the helper as `<helper> get` — the trailing operation must not
+    # crash argparse (regression: "unrecognized arguments: get").
+    monkeypatch.setattr(gat, "get_installation_token", lambda home, force=False: "ghs_helper")
+    rc = gat.main(["get-credential", "--home", str(app_env), "get"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "password=ghs_helper\n" in out
+
+
+def test_get_credential_store_and_erase_are_noops(app_env, monkeypatch, capsys):
+    # store/erase carry no output and must never mint.
+    def boom(*a, **k):  # pragma: no cover - must not be called
+        raise AssertionError("mint attempted on store/erase")
+
+    monkeypatch.setattr(gat, "get_installation_token", boom)
+    for op in ("store", "erase"):
+        assert gat.main(["get-credential", "--home", str(app_env), op]) == 0
+        assert capsys.readouterr().out == ""


### PR DESCRIPTION
Lands the prod-proven canary commit (running on the fleet since 2026-07-22 via `app-canary-97`) onto main.

git invokes a credential helper as `<helper> get` (also `store`/`erase`). The `get-credential` subparser rejected the trailing `get` with `unrecognized arguments`, so git could never read the minted token — every App-auth git op failed with `could not read Username`. Accept the operation positional; emit only on `get`, no-op on `store`/`erase`.

Without this, main's helper is protocol-broken as a git credential helper; the fleet only works because the deployed canary carries it. This closes the canary↔main drift (after this, `app-canary-97`'s only delta is gone and the Mini checkout can move back to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)