### PR TITLE
fix(ci): use ambient github.token for CI timing report (adopt upstream fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
 
       - name: Collect timings and generate report
         env:
-          GITHUB_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           python3 scripts/ci/timings_report.py \
             --baseline ci-timings-baseline.json \


### PR DESCRIPTION
## Problem

The **CI timing report** job (step "Collect timings and generate report") fails on essentially every push to main — e.g. runs [29990409635](https://github.com/NimbleCoOrg/hermes-agent-mt/actions/runs/29990409635) and [29990456363](https://github.com/NimbleCoOrg/hermes-agent-mt/actions/runs/29990456363). Non-required, but it leaves an UNSTABLE overall check state on PRs and a red X on main.

## Root cause

The step's env was:

```yaml
GITHUB_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT }}
```

`AUTOFIX_BOT_PAT` is an upstream (NousResearch) secret this fork does not have, so the env var resolved to empty and `scripts/ci/timings_report.py` failed immediately:

```
ValueError: missing environment variable GITHUB_TOKEN
```

The `AUTOFIX_BOT_PAT` reference arrived via the upstream sync merge (upstream PR #66373). A later fork-safety pass (upstream #66577, fork commit 1e01a4bbe) added the `secrets.AUTOFIX_BOT_PAT || github.token` fallback to the PR-gate step at line 58 but missed this one.

## Fix

Adopt upstream's current fix verbatim. NousResearch/hermes-agent has since migrated off `AUTOFIX_BOT_PAT` (upstream commit `7a69b82ad` "ci: migrate AUTOFIX_BOT_PAT to GitHub App token"), and their ci-timings step today reads:

```yaml
GITHUB_TOKEN: ${{ github.token }}
```

This is a one-line change. `github.token` exists in every repo — no secrets required — and the job's ambient token already carries `Actions: read` (visible in the failed run's permission block), which is all the timings collector needs. The script also fails soft (`TimingsUnavailable` → degraded summary, exit 0) on API hiccups, so the job stays green.

## Upstream consideration

Disabling the job with `if: github.repository == 'NousResearch/hermes-agent'` (the convention used by `docker.yml`, `deploy-site.yml`, `skills-index*.yml`) was considered, but with a working token the job provides real value in the fork (per-PR timing diff reports), and matching upstream's exact current line means future upstream syncs merge cleanly instead of reintroducing the failure.

## Verification

- Workflow YAML parses (`yaml.safe_load` OK)
- The failing exception is thrown solely on the empty env var; with the ambient token set, `collect_timings` has the Actions:read scope it needs

🤖 Generated with [Claude Code](https://claude.com/claude-code)