### PR TITLE
fix(discord): treat managed self-role mentions as explicit bot mentions

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4868,18 +4868,48 @@ class DiscordAdapter(BasePlatformAdapter):
         content = getattr(message, "content", "") or ""
         return {match.group(1) for match in re.finditer(r"<@!?(\d+)>", content)}
 
+    def _self_managed_role_id(self, message: Any) -> Optional[str]:
+        """Return this bot's managed integration role id in the message's guild.
+
+        Discord's mention picker often resolves a bot's name to its managed
+        integration role (``<@&ROLE_ID>``) instead of the bot user. That role
+        is created by the integration, carries ``tags.bot_id`` equal to our
+        user id, and can only ever refer to this one bot — so mentioning it is
+        an unambiguous, explicit address of this bot. discord.py exposes it as
+        ``guild.self_role``. Returns None in DMs or when the role is absent.
+        """
+        guild = getattr(message, "guild", None)
+        if guild is None:
+            return None
+        self_role = getattr(guild, "self_role", None)
+        if self_role is None:
+            return None
+        return str(self_role.id)
+
     def _self_is_explicitly_mentioned(self, message: Any) -> bool:
         """Return True when this bot is explicitly @mentioned in the message.
 
-        Treats the bot as mentioned if it is either present in the resolved
-        ``message.mentions`` list OR referenced by its raw ``<@ID>`` / ``<@!ID>``
-        form in the message content.
+        Treats the bot as mentioned if it is present in the resolved
+        ``message.mentions`` list, referenced by its raw ``<@ID>`` / ``<@!ID>``
+        form in the message content, or addressed via its managed integration
+        role (``guild.self_role``) — either in ``message.role_mentions`` or as
+        a raw ``<@&ID>`` token. Mentions of other roles the bot merely holds
+        (e.g. a shared "bots" role) do NOT count: only the managed self-role
+        uniquely identifies this bot.
         """
         if not self._client or not self._client.user:
             return False
         if self._client.user in getattr(message, "mentions", []):
             return True
-        return str(self._client.user.id) in self._raw_mentioned_user_ids(message)
+        if str(self._client.user.id) in self._raw_mentioned_user_ids(message):
+            return True
+        role_id = self._self_managed_role_id(message)
+        if role_id is None:
+            return False
+        for role in getattr(message, "role_mentions", None) or []:
+            if str(getattr(role, "id", "")) == role_id:
+                return True
+        return f"<@&{role_id}>" in (getattr(message, "content", "") or "")
 
     def _self_is_raw_mentioned(self, message: Any) -> bool:
         """Return True only when this bot has an inline mention token.
@@ -4888,10 +4918,17 @@ class DiscordAdapter(BasePlatformAdapter):
         without a literal ``<@bot>`` token in ``message.content``. This helper
         intentionally ignores the resolved mentions list so the bot admission
         gate can distinguish an explicit cross-bot address from a reply chip.
+        A raw ``<@&self_role>`` token counts: it is an inline, deliberate
+        address of this bot (reply chips never produce role-mention tokens).
         """
         if not self._client or not self._client.user:
             return False
-        return str(self._client.user.id) in self._raw_mentioned_user_ids(message)
+        if str(self._client.user.id) in self._raw_mentioned_user_ids(message):
+            return True
+        role_id = self._self_managed_role_id(message)
+        return role_id is not None and f"<@&{role_id}>" in (
+            getattr(message, "content", "") or ""
+        )
 
     def _discord_bots_require_inline_mention(self) -> bool:
         """Whether another bot must type an inline @mention to trigger us.
@@ -6235,6 +6272,9 @@ class DiscordAdapter(BasePlatformAdapter):
             if self._client.user:
                 normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
                 normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
+            _self_role_id = self._self_managed_role_id(message)
+            if _self_role_id:
+                normalized_content = normalized_content.replace(f"<@&{_self_role_id}>", "").strip()
             message.content = normalized_content
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -1486,3 +1486,92 @@ async def test_discord_non_reply_free_channel_skips_backfill(adapter, monkeypatc
 
     adapter._fetch_channel_context.assert_not_awaited()
 
+
+
+@pytest.mark.asyncio
+async def test_discord_accepts_managed_role_mentions_when_required(adapter, monkeypatch):
+    """Mention-picker often yields the bot's managed role (<@&ID>), not the user.
+
+    A resolved role_mentions entry matching guild.self_role must count as an
+    explicit mention and be stripped from the delivered text (#67869 upstream).
+    """
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    self_role = SimpleNamespace(id=5555)
+    message = make_message(
+        channel=FakeTextChannel(channel_id=323),
+        content="<@&5555> hey girl you up?",
+        mentions=[],
+    )
+    message.guild = SimpleNamespace(id=99, self_role=self_role)
+    message.role_mentions = [self_role]
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "hey girl you up?"
+
+
+@pytest.mark.asyncio
+async def test_discord_accepts_raw_managed_role_mention_token(adapter, monkeypatch):
+    """Raw <@&self_role> token counts even when role_mentions is empty."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=324),
+        content="<@&5555> hello from raw role mention",
+        mentions=[],
+    )
+    message.guild = SimpleNamespace(id=99, self_role=SimpleNamespace(id=5555))
+    message.role_mentions = []
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "hello from raw role mention"
+
+
+@pytest.mark.asyncio
+async def test_discord_ignores_unrelated_role_mentions(adapter, monkeypatch):
+    """Roles the bot merely holds (shared @bots role) must NOT wake it."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=325),
+        content="<@&7777> everyone in bots-role, sound off",
+        mentions=[],
+    )
+    message.guild = SimpleNamespace(id=99, self_role=SimpleNamespace(id=5555))
+    message.role_mentions = [SimpleNamespace(id=7777)]
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_role_mention_without_self_role_still_gated(adapter, monkeypatch):
+    """No managed self-role in the guild -> role mentions change nothing."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=326),
+        content="<@&5555> anyone home?",
+        mentions=[],
+    )
+    message.guild = SimpleNamespace(id=99, self_role=None)
+    message.role_mentions = [SimpleNamespace(id=5555)]
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()


### PR DESCRIPTION
## Bug

Discord's mention picker frequently resolves `@botname` to the bot's **managed integration role** (`<@&ROLE_ID>`) instead of the bot user (`<@ID>`). Self-mention detection only recognized user mentions, so mention-gated bots silently dropped these messages (drop paths log at DEBUG — zero operator signal).

Production repro (Cyborg.Garden, 2026-07-27): `'<@&1531081708315869325> hey girl you up?'` with empty `mentions` array → silently ignored.

## Contract

**Only the managed self-role counts** — `guild.self_role`, the role with `tags.bot_id == our user id`, which can only ever refer to this one bot. This is still an *explicit* mention, not a mention-gating loosening. Shared roles the bot merely holds (`@bots`) are still ignored — covered by a test.

## Changes

- `_self_is_explicitly_mentioned`: accept self-role via `role_mentions` or raw `<@&ID>` token (mirrors existing raw `<@ID>`/`<@!ID>` fallback)
- `_self_is_raw_mentioned` (bot-admission gate): accept raw `<@&self_role>` token — an inline deliberate address; reply chips never produce role-mention tokens
- Mention stripping: `<@&self_role>` removed from delivered text like user mentions
- New helper `_self_managed_role_id` (None in DMs / when role absent)

## Tests

4 new cases in `tests/gateway/test_discord_free_response.py`; full Discord suite: **519 passed, 1 skipped**.

## Upstream

NousResearch/hermes-agent#67869 (bug), #67876 (equivalent open PR — we commented in support). Carry here until it lands upstream, then drop on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)