### PR TITLE
fix(discord): gateway channel-scoped access (opt-in) + fail closed on unparseable allowlists

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -405,6 +405,45 @@ class GatewayAuthorizationMixin:
                 ):
                     return True
 
+            # Discord: channel-scoped access — "anyone posting in #open-science may
+            # talk to the bot". The Discord adapter already implements this at
+            # intake (``_is_allowed_user`` consults DISCORD_ALLOWED_CHANNELS when no
+            # user/role allowlist matches), but this layer had no Discord entry at
+            # all, so the adapter admitted the message and the gateway then denied
+            # it — the bot went silent with no operator-visible error, and the
+            # obvious "fix" is DISCORD_ALLOWED_USERS=*, the worst available state.
+            #
+            # OPT-IN per agent, deliberately. Adding Discord to the shared
+            # chat_allowlist_env map above would widen every existing Discord agent
+            # the moment this ships: those agents use DISCORD_ALLOWED_CHANNELS to
+            # scope *where the bot speaks* while restricting *who may command it* to
+            # a short DISCORD_ALLOWED_USERS list. A chat-scoped grant authorizes
+            # every sender in the channel, so the map entry alone would silently
+            # promote "the bot may post here" into "anyone here may drive the bot".
+            #
+            # ``*`` is NOT honored, unlike the other platforms above. For channels
+            # it states where the bot may speak, not who may command it; treating it
+            # as an authorization grant turns one permissive scope value into a
+            # fully open bot. Channel-scoped access requires an explicit list.
+            #
+            # Known gap: Discord threads arrive as chat_type "thread", which is not
+            # in the guard set above, so a thread under an allowlisted channel is
+            # not covered. Left explicit rather than half-fixed — matching a
+            # thread needs its parent channel id, which this layer does not carry.
+            if source.platform == Platform.DISCORD and _auth_env(
+                "DISCORD_CHANNEL_SCOPED_ACCESS"
+            ).lower() in {"true", "1", "yes"}:
+                raw_channels = _auth_env("DISCORD_ALLOWED_CHANNELS")
+                allowed_channel_ids = {
+                    cid.strip()
+                    for cid in raw_channels.split(",")
+                    if cid.strip() and cid.strip() != "*"
+                }
+                if allowed_channel_ids and self._chat_id_in_allowlist(
+                    source, allowed_channel_ids
+                ):
+                    return True
+
         # Bots admitted by {PLATFORM}_ALLOW_BOTS bypass the human allowlist (#4466).
         # Checked before the no-user-id guard below: some platforms deliver
         # bot/automation traffic with no user_id at all -- e.g. Slack Workflow

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -821,6 +821,11 @@ class DiscordAdapter(BasePlatformAdapter):
         self._ready_event = asyncio.Event()
         self._allowed_user_ids: set = set()  # For button approval authorization
         self._allowed_role_ids: set = set()  # For DISCORD_ALLOWED_ROLES filtering
+        # Was the corresponding env var SET, regardless of whether it parsed to
+        # anything usable? Distinguishes "no allowlist configured" (may widen to
+        # channel-scoped/allow-all) from "configured but matches nobody" (deny).
+        self._user_allowlist_configured: bool = False
+        self._role_allowlist_configured: bool = False
         self.gateway_runner = None  # Set by gateway/run.py for cross-platform delivery
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
@@ -1008,21 +1013,51 @@ class DiscordAdapter(BasePlatformAdapter):
                 return False
 
             # Parse allowed user entries (may contain usernames or IDs)
+            #
+            # ``_*_allowlist_configured`` records that the operator SET the var,
+            # independently of whether it parsed to anything usable. A var that was
+            # set but yielded zero entries is a misconfiguration, and it must not
+            # read downstream as "no allowlist configured" — that state grants
+            # channel-scoped access to every sender and honors the allow-all flags,
+            # so a typo would silently WIDEN access. See _is_allowed_user.
             allowed_env = os.getenv("DISCORD_ALLOWED_USERS", "")
+            self._user_allowlist_configured = bool(allowed_env.strip())
             if allowed_env:
                 self._allowed_user_ids = {
                     _clean_discord_id(uid) for uid in allowed_env.split(",")
                     if uid.strip()
                 }
+            if self._user_allowlist_configured and not self._allowed_user_ids:
+                logger.error(
+                    "[%s] DISCORD_ALLOWED_USERS is set but no usable entry could be "
+                    "parsed from %r — failing CLOSED for user-allowlist access. Fix "
+                    "the value; an empty result is treated as 'matches nobody', not "
+                    "as 'no restriction'.",
+                    self.name, allowed_env,
+                )
 
             # Parse DISCORD_ALLOWED_ROLES — comma-separated role IDs.
             # Users with ANY of these roles can interact with the bot.
             roles_env = os.getenv("DISCORD_ALLOWED_ROLES", "")
+            self._role_allowlist_configured = bool(roles_env.strip())
             if roles_env:
                 self._allowed_role_ids = {
                     int(rid.strip()) for rid in roles_env.split(",")
                     if rid.strip().isdigit()
                 }
+            if self._role_allowlist_configured and not self._allowed_role_ids:
+                # The likely cause is a role NAME where a numeric id is required
+                # ("moderators" instead of 1531…). HSM can write this var since
+                # hsm#186, and its own fixtures use a bare name, so an operator
+                # typing what the UI implies produces a role gate that matches
+                # nobody. Fail closed and say so loudly.
+                logger.error(
+                    "[%s] DISCORD_ALLOWED_ROLES=%r contains no numeric role IDs — "
+                    "role-based access will match NOBODY (failing closed). Discord "
+                    "role IDs are numeric snowflakes, not role names: enable "
+                    "Developer Mode and copy the role's ID.",
+                    self.name, roles_env,
+                )
 
             # Set up intents.
             # Message Content is required for normal text replies.
@@ -3282,6 +3317,32 @@ class DiscordAdapter(BasePlatformAdapter):
         has_users = bool(allowed_users)
         has_roles = bool(allowed_roles)
 
+        # Whether an allowlist was CONFIGURED, as distinct from whether it parsed to
+        # anything. A var that was set but resolved to zero entries (e.g.
+        # DISCORD_ALLOWED_ROLES=moderators — a role name where a numeric snowflake
+        # is required) must count as configured: otherwise control reaches the
+        # "no allowlist at all" branch below, which grants channel-scoped access to
+        # every sender and honors DISCORD_ALLOW_ALL_USERS / GATEWAY_ALLOW_ALL_USERS.
+        # A misconfiguration would then WIDEN access instead of denying — the
+        # fail-open this guards. Configured-but-unresolvable means "matches
+        # nobody", so the checks below simply never match and we deny.
+        #
+        # The flag is purely ADDITIVE to the parsed truthiness: a populated set
+        # already proves an allowlist is in effect, so the flag only contributes
+        # the extra "set but unparseable" case. Deriving `configured` from the flag
+        # alone would go stale for any caller that assigns `_allowed_user_ids`
+        # directly after __init__ (several tests and the slash-auth fixture do
+        # exactly this) — the flag would still read False, the widening branch
+        # would be taken, and a legitimately allowlisted user would be denied.
+        # This form also keeps fixtures that skip __init__ entirely working
+        # (AGENTS.md pitfall #17).
+        users_configured = has_users or bool(
+            getattr(self, "_user_allowlist_configured", False)
+        )
+        roles_configured = has_roles or bool(
+            getattr(self, "_role_allowlist_configured", False)
+        )
+
         # Pairing is a first-class auth grant in the gateway auth union and in
         # Discord component buttons. Honor it here too so normal guild/DM text
         # messages do not get dropped at the adapter before the pairing-aware
@@ -3289,7 +3350,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if self._is_pairing_approved_user(user_id):
             return True
 
-        if not has_users and not has_roles:
+        if not users_configured and not roles_configured:
             if os.getenv("DISCORD_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
                 return True
             if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
@@ -3364,6 +3425,13 @@ class DiscordAdapter(BasePlatformAdapter):
         allowed_users = getattr(self, "_allowed_user_ids", set()) or set()
         allowed_roles = getattr(self, "_allowed_role_ids", set()) or set()
         if allowed_users or allowed_roles:
+            return
+        # Set-but-unparseable is a different failure with its own error at parse
+        # time ("contains no numeric role IDs"). Telling the operator to "set
+        # DISCORD_ALLOWED_ROLES" when they already did would send them in circles.
+        if getattr(self, "_user_allowlist_configured", False) or getattr(
+            self, "_role_allowlist_configured", False
+        ):
             return
         if os.getenv("DISCORD_ALLOWED_CHANNELS", "").strip():
             return

--- a/tests/gateway/test_discord_authz_failclosed.py
+++ b/tests/gateway/test_discord_authz_failclosed.py
@@ -1,0 +1,289 @@
+"""Discord authorization: gateway channel-scoped access (R2) + fail-closed allowlists (R1).
+
+Two independent defects, both found in a Discord control-surface audit:
+
+  R2 — ``_is_user_authorized`` had no Discord entry in its chat-scoped allowlist
+  map, while the Discord adapter DOES grant channel-scoped access at intake. So
+  the adapter admitted a guild message and the gateway then denied it: the bot
+  went silent with no operator-visible error, and the obvious operator "fix" is
+  ``DISCORD_ALLOWED_USERS=*`` — the worst available state.
+
+  The fix is deliberately OPT-IN via ``DISCORD_CHANNEL_SCOPED_ACCESS``. Simply
+  adding Discord to the shared map would widen every existing Discord agent:
+  those agents use ``DISCORD_ALLOWED_CHANNELS`` to scope *where the bot speaks*
+  while restricting *who may command it* to a short ``DISCORD_ALLOWED_USERS``
+  list, and a chat-scoped grant authorizes every sender in the channel.
+
+  R1 — an allowlist var that was SET but parsed to zero usable entries (e.g.
+  ``DISCORD_ALLOWED_ROLES=moderators``, a role name where a numeric snowflake is
+  required) read downstream as "no allowlist configured". That branch grants
+  channel-scoped access to everyone and honors the allow-all flags, so a typo
+  WIDENED access instead of denying.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.session import Platform, SessionSource
+
+
+@pytest.fixture(autouse=True)
+def _isolate_discord_env(monkeypatch):
+    """Start every test from a clean Discord env (mirrors test_discord_bot_auth_bypass)."""
+    for var in (
+        "DISCORD_ALLOW_BOTS",
+        "DISCORD_ALLOWED_USERS",
+        "DISCORD_ALLOWED_ROLES",
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_ALLOW_ALL_USERS",
+        "DISCORD_CHANNEL_SCOPED_ACCESS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_bare_runner():
+    """GatewayRunner skeleton — object.__new__ skips the heavy __init__ (pitfall #17)."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+    return runner
+
+
+def _discord_channel_msg(user_id="999", chat_id="555"):
+    """A human posting in a Discord guild text channel (chat_type 'channel')."""
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=chat_id,
+        chat_type="channel",
+        user_id=user_id,
+        user_name="SomeHuman",
+        is_bot=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# R2 — gateway channel-scoped access, opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_channel_scoped_access_is_off_by_default(monkeypatch):
+    """Without the opt-in flag, an allowlisted channel does NOT authorize a stranger.
+
+    This is the no-silent-widening guard: every existing Discord agent has
+    DISCORD_ALLOWED_CHANNELS set, so if this ever returns True the fix has
+    promoted 'the bot may post here' into 'anyone here may drive the bot'.
+    """
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "555")
+    runner = _make_bare_runner()
+    assert runner._is_user_authorized(_discord_channel_msg()) is False
+
+
+def test_channel_scoped_access_authorizes_when_opted_in(monkeypatch):
+    """With the flag and an explicit matching channel, the sender is authorized."""
+    monkeypatch.setenv("DISCORD_CHANNEL_SCOPED_ACCESS", "true")
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "111,555,222")
+    runner = _make_bare_runner()
+    assert runner._is_user_authorized(_discord_channel_msg(chat_id="555")) is True
+
+
+def test_channel_scoped_access_ignores_wildcard(monkeypatch):
+    """``*`` is a scope statement, not an authorization grant.
+
+    cyborg runs DISCORD_ALLOWED_CHANNELS=* today. Honoring the wildcard here
+    (as the Telegram/Signal branches do) would make it a fully open bot.
+    """
+    monkeypatch.setenv("DISCORD_CHANNEL_SCOPED_ACCESS", "true")
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "*")
+    runner = _make_bare_runner()
+    assert runner._is_user_authorized(_discord_channel_msg()) is False
+
+
+def test_channel_scoped_access_wildcard_mixed_with_real_ids(monkeypatch):
+    """A stray ``*`` among real ids is dropped, and the real ids still work."""
+    monkeypatch.setenv("DISCORD_CHANNEL_SCOPED_ACCESS", "true")
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "*,555")
+    runner = _make_bare_runner()
+    assert runner._is_user_authorized(_discord_channel_msg(chat_id="555")) is True
+    assert runner._is_user_authorized(_discord_channel_msg(chat_id="777")) is False
+
+
+def test_channel_scoped_access_denies_unlisted_channel(monkeypatch):
+    monkeypatch.setenv("DISCORD_CHANNEL_SCOPED_ACCESS", "true")
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "111,222")
+    runner = _make_bare_runner()
+    assert runner._is_user_authorized(_discord_channel_msg(chat_id="555")) is False
+
+
+def test_channel_scoped_access_does_not_apply_to_dms(monkeypatch):
+    """DMs have no channel scope to stand on — the flag must not authorize them."""
+    monkeypatch.setenv("DISCORD_CHANNEL_SCOPED_ACCESS", "true")
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "555")
+    runner = _make_bare_runner()
+    dm = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="555",
+        chat_type="dm",
+        user_id="999",
+        user_name="SomeHuman",
+        is_bot=False,
+    )
+    assert runner._is_user_authorized(dm) is False
+
+
+def test_other_platforms_still_honor_their_wildcard(monkeypatch):
+    """Regression guard: the Discord branch must not disturb Telegram semantics."""
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_CHATS", "*")
+    runner = _make_bare_runner()
+    tg = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="42",
+        chat_type="group",
+        user_id="999",
+        user_name="SomeHuman",
+        is_bot=False,
+    )
+    assert runner._is_user_authorized(tg) is True
+
+
+# ---------------------------------------------------------------------------
+# R1 — adapter fail-closed on a configured-but-unresolvable allowlist
+# ---------------------------------------------------------------------------
+
+
+def _make_bare_adapter(**attrs):
+    """DiscordAdapter skeleton for _is_allowed_user (object.__new__, pitfall #17)."""
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    adapter = object.__new__(DiscordAdapter)
+    # ``name`` is a read-only property deriving from ``_platform``
+    # (gateway/platforms/base.py:2764), so set the backing attribute.
+    adapter._platform = Platform.DISCORD
+    adapter._allowed_user_ids = set()
+    adapter._allowed_role_ids = set()
+    adapter._pairing_store = None
+    for k, v in attrs.items():
+        setattr(adapter, k, v)
+    return adapter
+
+
+def _no_pairing(adapter, monkeypatch):
+    monkeypatch.setattr(
+        type(adapter), "_is_pairing_approved_user", lambda self, uid: False, raising=False
+    )
+
+
+def test_role_allowlist_set_but_unparseable_fails_closed(monkeypatch):
+    """DISCORD_ALLOWED_ROLES=moderators must deny, not fall through to channel access.
+
+    Role names are not snowflakes, so the parse yields nothing. Before the fix
+    that looked identical to 'no allowlist configured', which grants
+    channel-scoped access to every sender.
+    """
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "555")
+    adapter = _make_bare_adapter(
+        _role_allowlist_configured=True,   # var was set...
+        _allowed_role_ids=set(),           # ...but parsed to nothing
+        _user_allowlist_configured=False,
+    )
+    _no_pairing(adapter, monkeypatch)
+    assert (
+        adapter._is_allowed_user("999", guild=object(), channel_ids={"555"})
+        is False
+    )
+
+
+def test_user_allowlist_set_but_unparseable_fails_closed(monkeypatch):
+    """DISCORD_ALLOWED_USERS=" , " parses to nothing and must deny."""
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "555")
+    adapter = _make_bare_adapter(
+        _user_allowlist_configured=True,
+        _allowed_user_ids=set(),
+        _role_allowlist_configured=False,
+    )
+    _no_pairing(adapter, monkeypatch)
+    assert (
+        adapter._is_allowed_user("999", guild=object(), channel_ids={"555"})
+        is False
+    )
+
+
+def test_unparseable_allowlist_does_not_honor_allow_all_flags(monkeypatch):
+    """A broken allowlist must not be rescued by GATEWAY_ALLOW_ALL_USERS either."""
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    adapter = _make_bare_adapter(
+        _role_allowlist_configured=True,
+        _allowed_role_ids=set(),
+        _user_allowlist_configured=False,
+    )
+    _no_pairing(adapter, monkeypatch)
+    assert adapter._is_allowed_user("999", guild=object()) is False
+
+
+def test_no_allowlist_at_all_still_grants_channel_scoped_access(monkeypatch):
+    """Unchanged behavior: genuinely-unset allowlists keep the channel bypass."""
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "555")
+    adapter = _make_bare_adapter(
+        _user_allowlist_configured=False,
+        _role_allowlist_configured=False,
+    )
+    _no_pairing(adapter, monkeypatch)
+    monkeypatch.setattr(
+        type(adapter),
+        "_discord_channel_ids_allowed",
+        lambda self, ids: True,
+        raising=False,
+    )
+    assert (
+        adapter._is_allowed_user("999", guild=object(), channel_ids={"555"}) is True
+    )
+
+
+def test_valid_user_allowlist_unaffected(monkeypatch):
+    """No regression: a real user allowlist still authorizes its members."""
+    adapter = _make_bare_adapter(
+        _user_allowlist_configured=True,
+        _allowed_user_ids={"999"},
+    )
+    _no_pairing(adapter, monkeypatch)
+    assert adapter._is_allowed_user("999", guild=object()) is True
+    assert adapter._is_allowed_user("111", guild=object()) is False
+
+
+def test_allowlist_assigned_after_init_is_still_configured(monkeypatch):
+    """A populated set must count as configured even when the flag says False.
+
+    Regression guard: __init__ sets the flags False, and several callers (plus
+    tests/gateway/test_discord_slash_auth.py's fixture) then assign
+    ``_allowed_user_ids`` directly. Deriving `configured` from the flag ALONE
+    left it stale-False, sent control into the "no allowlist" widening branch,
+    and denied a legitimately allowlisted user. The flag must be additive to the
+    parsed truthiness, never a replacement for it.
+    """
+    adapter = _make_bare_adapter(
+        _user_allowlist_configured=False,  # as __init__ leaves it
+        _role_allowlist_configured=False,
+    )
+    adapter._allowed_user_ids = {"999"}  # assigned afterwards, flag not updated
+    _no_pairing(adapter, monkeypatch)
+    assert adapter._is_allowed_user("999", guild=object()) is True
+    assert adapter._is_allowed_user("111", guild=object()) is False
+
+
+def test_missing_configured_attrs_fall_back_to_parsed_truthiness(monkeypatch):
+    """Fixtures that skip __init__ entirely keep their old behavior.
+
+    Without the getattr fallback, an adapter built via object.__new__ with a
+    populated _allowed_user_ids would read as 'not configured' and take the
+    widening branch — a fail-open introduced by the fix itself.
+    """
+    adapter = _make_bare_adapter(_allowed_user_ids={"999"})
+    # deliberately no _user_allowlist_configured / _role_allowlist_configured
+    assert not hasattr(adapter, "_user_allowlist_configured")
+    _no_pairing(adapter, monkeypatch)
+    assert adapter._is_allowed_user("999", guild=object()) is True
+    assert adapter._is_allowed_user("111", guild=object()) is False


### PR DESCRIPTION
Two independent Discord authorization defects from a control-surface audit. **Nothing here is deployed** — no runtime config was touched.

## R2 — the gateway denied what the adapter admitted

`_is_user_authorized` had **no Discord entry** in its chat-scoped allowlist map, while the Discord adapter *does* grant channel-scoped access at intake (`_is_allowed_user` consults `DISCORD_ALLOWED_CHANNELS`). So the adapter admitted a guild message, the gateway then denied it, and the bot went silent **with no operator-visible error**. The predictable operator response is `DISCORD_ALLOWED_USERS=*` — the worst available state.

### Why this is opt-in rather than a one-line map entry

Adding `Platform.DISCORD: "DISCORD_ALLOWED_CHANNELS"` to the shared map would have **silently widened every existing Discord agent**. Those agents use `DISCORD_ALLOWED_CHANNELS` to scope *where the bot speaks*, while restricting *who may command it* to a short `DISCORD_ALLOWED_USERS` list. A chat-scoped grant authorizes **every sender in the channel** — so five live agents would have gone from 1–3 authorized users to "anyone posting in the listed channels" the moment this shipped.

It is therefore gated on `DISCORD_CHANNEL_SCOPED_ACCESS`, per agent. Existing agents see **zero behavior change** until the flag is set deliberately.

`*` is also **not honored here**, unlike the Telegram/Signal branches above it. For channels, `*` states where the bot may speak, not who may command it; treating it as an authorization grant turns one permissive scope value into a fully open bot. An explicit channel list is required.

**Known gap, left explicit rather than half-fixed:** Discord threads arrive as `chat_type "thread"`, which is not in the guard set, so a thread under an allowlisted channel isn't covered. Matching one needs its parent channel id, which this layer doesn't carry.

## R1 — a misconfigured allowlist widened access instead of denying

An allowlist var that was **set but parsed to zero usable entries** read downstream as *"no allowlist configured"*. That branch grants channel-scoped access to every sender and honors `DISCORD_ALLOW_ALL_USERS` / `GATEWAY_ALLOW_ALL_USERS` — so a typo **opened the bot** rather than closing it.

The realistic trigger:

```
DISCORD_ALLOWED_ROLES=moderators     # a role NAME; snowflake required
```

`{int(rid) for rid in ... if rid.isdigit()}` yields an empty set, `has_roles` is False, and the role gate vanishes. HSM has been able to write this var since hsm#186 and **its own test fixtures use a bare role name**, so an operator typing what the console implies got a role gate matching nobody.

Now tracked via `_user_allowlist_configured` / `_role_allowlist_configured`, with an error naming the actual cause (numeric snowflake, not role name).

### One design note worth reviewing

The flag is **additive** to the parsed truthiness, never a replacement:

```python
users_configured = has_users or bool(getattr(self, "_user_allowlist_configured", False))
```

`__init__` leaves the flag `False`, and several callers — including `tests/gateway/test_discord_slash_auth.py`'s fixture — assign `_allowed_user_ids` **directly afterwards**. Deriving `configured` from the flag alone left it stale-`False`, sent control into the widening branch, and **denied legitimately allowlisted users**. That was caught by the existing slash-auth suite during review and is now covered by its own regression test here.

`_warn_if_fail_closed_default` no longer fires for the set-but-unparseable case, which has its own error — telling an operator to "set `DISCORD_ALLOWED_ROLES`" when they already did sends them in circles.

## Testing

14 new tests in `tests/gateway/test_discord_authz_failclosed.py`, covering both defects plus the no-widening and no-regression guards.

| | passed | failed |
|---|---|---|
| pristine `origin/main` baseline | 9751 | 16 |
| this branch | **9765** | 16 |

Same 16 pre-existing failures in both (telegram markdown escaping, feishu websocket, channel directory, shutdown forensics — all unrelated); `+14` is exactly the new tests. Verified by running the full `tests/gateway` suite against a detached `origin/main` worktree.

## Deploying this

`DISCORD_CHANNEL_SCOPED_ACCESS` is off everywhere, so merging changes no live behavior. Before enabling it on any agent, note that **cyborg currently runs `DISCORD_ALLOWED_CHANNELS=*`** — the wildcard is rejected as an auth grant, so it would get no channel-scoped access until it has an explicit commons list.