### PR TITLE
fix(web): warn when a configured search/extract backend is discarded

### DIFF
--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -67,3 +67,22 @@ def disable_lazy_stt_install():
     """
     with patch("tools.transcription_tools._try_lazy_install_stt", return_value=False):
         yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_web_backend_warn_dedup():
+    """Clear web_tools' session-global warn-dedup set between tests.
+
+    ``_backend_discard_warned`` persists for the process, so without this any
+    test asserting "a backend warning was emitted" becomes order-dependent —
+    passing alone and failing in full-suite order once an earlier test has
+    already consumed the once-per-process warning.
+    """
+    try:
+        from tools import web_tools
+    except Exception:  # pragma: no cover — tools import is optional here
+        yield
+        return
+    web_tools._backend_discard_warned.clear()
+    yield
+    web_tools._backend_discard_warned.clear()

--- a/tests/tools/test_web_backend_silent_fallback.py
+++ b/tests/tools/test_web_backend_silent_fallback.py
@@ -1,0 +1,159 @@
+"""A discarded ``web.*_backend`` config value must not be dropped silently.
+
+Real incident: a fleet had ``web.search_backend: brave`` set. The registered
+provider name is ``brave-free``, so ``_is_backend_available("brave")`` fell
+through every branch, returned False, and ``_get_capability_backend`` quietly
+auto-detected a *different* provider (firecrawl). Every web_search on every
+agent was served by a provider nobody configured, indefinitely, with nothing in
+the logs at any level. The config file and the actual behavior disagreed and
+nothing said so — the only symptom was "search returns empty".
+
+These tests pin that an explicitly-configured-but-discarded backend is reported
+once, and that the two distinct operator mistakes are distinguishable:
+
+- unknown name (a typo) -> says it is unrecognised, lists valid values
+- known name, missing credential -> says the credential is unset
+
+They also pin the dedup, because ``_get_capability_backend`` runs on every
+dispatch and on every ``hermes tools`` repaint.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from tools import web_tools
+
+
+@pytest.fixture(autouse=True)
+def _reset_warn_dedup():
+    web_tools._backend_fallback_warned.clear()
+    yield
+    web_tools._backend_fallback_warned.clear()
+
+
+@pytest.fixture
+def cfg(monkeypatch):
+    """Control the web config and the auto-detect result independently."""
+    def _apply(configured: str, resolved: str = "firecrawl"):
+        monkeypatch.setattr(
+            web_tools, "_load_web_config",
+            lambda: {"search_backend": configured, "extract_backend": configured},
+        )
+        monkeypatch.setattr(web_tools, "_get_backend", lambda: resolved)
+    return _apply
+
+
+class TestUnknownBackendName:
+    def test_typo_warns_and_names_valid_values(self, cfg, caplog):
+        cfg("brave", resolved="firecrawl")
+        caplog.set_level(logging.WARNING, logger="tools.web_tools")
+
+        got = web_tools._get_capability_backend("search")
+
+        assert got == "firecrawl", "the fallback still happens — behavior unchanged"
+        msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert msgs, "an unrecognised configured backend must be reported"
+        joined = " ".join(msgs)
+        assert "brave" in joined
+        assert "not a recognised backend" in joined
+        assert "brave-free" in joined, "the message should list valid values"
+
+    def test_message_says_configured_provider_is_not_used(self, cfg, caplog):
+        """The operator's actual misconception is 'my config is in effect'."""
+        cfg("brave", resolved="firecrawl")
+        caplog.set_level(logging.WARNING, logger="tools.web_tools")
+        web_tools._get_capability_backend("search")
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "NOT being used" in joined
+
+
+class TestKnownButUnavailable:
+    def test_missing_credential_is_a_different_message(self, cfg, caplog, monkeypatch):
+        """`tavily` is real but has no key — that is not a typo."""
+        cfg("tavily", resolved="firecrawl")
+        monkeypatch.setattr(web_tools, "_is_backend_available", lambda b: False)
+        caplog.set_level(logging.WARNING, logger="tools.web_tools")
+
+        web_tools._get_capability_backend("search")
+
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "known backend but is not available" in joined
+        assert "not a recognised backend" not in joined, (
+            "a real backend missing its key must not be reported as a typo"
+        )
+
+
+class TestNoSpuriousWarnings:
+    def test_available_backend_is_silent(self, cfg, caplog, monkeypatch):
+        cfg("firecrawl", resolved="firecrawl")
+        monkeypatch.setattr(web_tools, "_is_backend_available", lambda b: True)
+        caplog.set_level(logging.WARNING, logger="tools.web_tools")
+
+        assert web_tools._get_capability_backend("search") == "firecrawl"
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_unset_backend_is_silent(self, cfg, caplog):
+        """No configured value means nothing was discarded — say nothing."""
+        cfg("", resolved="firecrawl")
+        caplog.set_level(logging.WARNING, logger="tools.web_tools")
+
+        assert web_tools._get_capability_backend("search") == "firecrawl"
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_no_warning_when_fallback_equals_request(self, cfg, caplog, monkeypatch):
+        """If auto-detect lands on the same provider, nothing was lost."""
+        cfg("firecrawl", resolved="firecrawl")
+        monkeypatch.setattr(web_tools, "_is_backend_available", lambda b: False)
+        caplog.set_level(logging.WARNING, logger="tools.web_tools")
+
+        web_tools._get_capability_backend("search")
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+class TestDedup:
+    def test_warns_once_not_per_dispatch(self, cfg, caplog):
+        cfg("brave", resolved="firecrawl")
+        caplog.set_level(logging.WARNING, logger="tools.web_tools")
+
+        for _ in range(25):
+            web_tools._get_capability_backend("search")
+
+        warns = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warns) == 1, (
+            "this runs on every dispatch and every `hermes tools` repaint; "
+            f"an un-deduped warning becomes spam. Got {len(warns)}."
+        )
+
+    def test_search_and_extract_report_independently(self, cfg, caplog):
+        cfg("brave", resolved="firecrawl")
+        caplog.set_level(logging.WARNING, logger="tools.web_tools")
+
+        web_tools._get_capability_backend("search")
+        web_tools._get_capability_backend("extract")
+
+        warns = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warns) == 2, "each capability is a separate misconfiguration"
+        assert any("search_backend" in m for m in warns)
+        assert any("extract_backend" in m for m in warns)
+
+
+class TestKnownBackendsStaysInSync:
+    """_KNOWN_BACKENDS only exists to classify the error; drift makes it lie."""
+
+    def test_every_known_backend_is_probed_by_is_backend_available(self):
+        import inspect
+        src = inspect.getsource(web_tools._is_backend_available)
+        missing = [b for b in web_tools._KNOWN_BACKENDS if repr(b) not in src and f'"{b}"' not in src]
+        assert not missing, (
+            f"_KNOWN_BACKENDS lists {missing} but _is_backend_available does not "
+            "probe them — a real backend would be misreported as a typo."
+        )
+
+    def test_no_unknown_name_claims_to_be_known(self):
+        assert "brave" not in web_tools._KNOWN_BACKENDS, (
+            "'brave' is the typo from the original incident; the registered "
+            "provider is 'brave-free'. If an alias is ever added, it must be "
+            "registered in the provider registry, not just listed here."
+        )

--- a/tests/tools/test_web_backend_silent_fallback.py
+++ b/tests/tools/test_web_backend_silent_fallback.py
@@ -1,21 +1,31 @@
 """A discarded ``web.*_backend`` config value must not be dropped silently.
 
 Real incident: a fleet had ``web.search_backend: brave`` set. The registered
-provider name is ``brave-free``, so ``_is_backend_available("brave")`` fell
-through every branch, returned False, and ``_get_capability_backend`` quietly
-auto-detected a *different* provider (firecrawl). Every web_search on every
-agent was served by a provider nobody configured, indefinitely, with nothing in
-the logs at any level. The config file and the actual behavior disagreed and
-nothing said so — the only symptom was "search returns empty".
+provider name is ``brave-free``, so the value was discarded and a *different*
+provider (firecrawl) served every search on every agent, indefinitely, with
+nothing logged at any level. The config file and the runtime disagreed and
+nothing said so — the only symptom was "search returns empty", which is
+indistinguishable from a provider outage.
 
-These tests pin that an explicitly-configured-but-discarded backend is reported
-once, and that the two distinct operator mistakes are distinguishable:
+Reporting happens at ONE place — the config layer, in
+``_warn_discarded_backend``, which knows which key it read. It covers
+``web.backend`` (the key ``hermes tools`` actually writes) as well as the
+per-capability keys.
 
-- unknown name (a typo) -> says it is unrecognised, lists valid values
-- known name, missing credential -> says the credential is unset
+The classification must not lie, and two earlier cuts of this change did:
 
-They also pin the dedup, because ``_get_capability_backend`` runs on every
-dispatch and on every ``hermes tools`` repaint.
+- a private duplicate of ``_LEGACY_WEB_BACKENDS`` reported *registered
+  third-party providers* as typos, with a "valid values" list excluding the
+  user's own provider;
+- a dispatch-layer warner named ``web.{capability}_backend`` even when the value
+  came from ``web.backend``, and asserted "the credential is set" — a fact
+  ``_resolve_backend`` never establishes, since it returns any legacy-or-
+  registered name without probing availability. It has been removed rather
+  than repaired: every bundled provider supports search, and the extract
+  dispatcher already emits a precise typed error for a real capability
+  mismatch, so it was near-dead as well as wrong.
+
+These tests pin the behaviour that prevents both.
 """
 from __future__ import annotations
 
@@ -26,134 +36,200 @@ import pytest
 from tools import web_tools
 
 
-@pytest.fixture(autouse=True)
-def _reset_warn_dedup():
-    web_tools._backend_fallback_warned.clear()
-    yield
-    web_tools._backend_fallback_warned.clear()
+# NOTE: the dedup-set reset is an autouse fixture in tests/tools/conftest.py so
+# it protects every test in this directory, not just this file.
 
 
 @pytest.fixture
 def cfg(monkeypatch):
-    """Control the web config and the auto-detect result independently."""
-    def _apply(configured: str, resolved: str = "firecrawl"):
-        monkeypatch.setattr(
-            web_tools, "_load_web_config",
-            lambda: {"search_backend": configured, "extract_backend": configured},
-        )
-        monkeypatch.setattr(web_tools, "_get_backend", lambda: resolved)
+    def _apply(**web_config):
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: dict(web_config))
     return _apply
 
 
-class TestUnknownBackendName:
-    def test_typo_warns_and_names_valid_values(self, cfg, caplog):
-        cfg("brave", resolved="firecrawl")
+@pytest.fixture
+def no_registry(monkeypatch):
+    """No plugin-registered providers, so only built-ins are recognised."""
+    monkeypatch.setattr(web_tools, "_registered_web_provider", lambda b: None)
+    monkeypatch.setattr(web_tools, "_list_registered_web_providers", lambda: [])
+
+
+def _warnings(caplog):
+    return [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+# ---------------------------------------------------------------------------
+# The original incident: a typo in a per-capability key
+# ---------------------------------------------------------------------------
+
+class TestTypoInCapabilityKey:
+    def test_reports_typo_and_lists_valid_values(self, cfg, no_registry, caplog, monkeypatch):
+        cfg(search_backend="brave")
+        monkeypatch.setattr(web_tools, "_resolve_backend", lambda: "firecrawl")
         caplog.set_level(logging.WARNING, logger="tools.web_tools")
 
-        got = web_tools._get_capability_backend("search")
+        assert web_tools._get_capability_backend("search") == "firecrawl"
 
-        assert got == "firecrawl", "the fallback still happens — behavior unchanged"
-        msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
-        assert msgs, "an unrecognised configured backend must be reported"
-        joined = " ".join(msgs)
-        assert "brave" in joined
-        assert "not a recognised backend" in joined
-        assert "brave-free" in joined, "the message should list valid values"
-
-    def test_message_says_configured_provider_is_not_used(self, cfg, caplog):
-        """The operator's actual misconception is 'my config is in effect'."""
-        cfg("brave", resolved="firecrawl")
-        caplog.set_level(logging.WARNING, logger="tools.web_tools")
-        web_tools._get_capability_backend("search")
-        joined = " ".join(r.getMessage() for r in caplog.records)
-        assert "NOT being used" in joined
+        msgs = " ".join(_warnings(caplog))
+        assert "search_backend='brave'" in msgs
+        assert "not a known backend" in msgs
+        assert "NOT being used" in msgs
+        assert "brave-free" in msgs, "the valid-values list must name the real provider"
 
 
-class TestKnownButUnavailable:
-    def test_missing_credential_is_a_different_message(self, cfg, caplog, monkeypatch):
-        """`tavily` is real but has no key — that is not a typo."""
-        cfg("tavily", resolved="firecrawl")
-        monkeypatch.setattr(web_tools, "_is_backend_available", lambda b: False)
+# ---------------------------------------------------------------------------
+# Audit S1: web.backend is the key `hermes tools` writes — it must be covered
+# ---------------------------------------------------------------------------
+
+class TestSharedBackendKeyIsCovered:
+    def test_typo_in_web_backend_is_reported(self, cfg, no_registry, caplog):
+        """`hermes tools` writes ONLY web.backend, never the capability keys."""
+        cfg(backend="brave")
         caplog.set_level(logging.WARNING, logger="tools.web_tools")
 
-        web_tools._get_capability_backend("search")
+        resolved = web_tools._get_backend()
 
-        joined = " ".join(r.getMessage() for r in caplog.records)
-        assert "known backend but is not available" in joined
-        assert "not a recognised backend" not in joined, (
-            "a real backend missing its key must not be reported as a typo"
+        assert resolved != "brave"
+        msgs = " ".join(_warnings(caplog))
+        assert "backend='brave'" in msgs, (
+            "a typo in web.backend was previously 100% silent, and it is the "
+            "key the setup tool actually writes"
         )
 
 
-class TestNoSpuriousWarnings:
-    def test_available_backend_is_silent(self, cfg, caplog, monkeypatch):
-        cfg("firecrawl", resolved="firecrawl")
+# ---------------------------------------------------------------------------
+# Audit B2: a registered third-party provider is NOT a typo
+# ---------------------------------------------------------------------------
+
+class TestRegisteredProviderIsNeverCalledATypo:
+    def test_plugin_provider_missing_credential_is_not_a_typo(self, cfg, caplog, monkeypatch):
+        class MyCorp:
+            name = "mycorp"
+
+            def is_available(self):
+                return False
+
+        cfg(search_backend="mycorp")
+        monkeypatch.setattr(
+            web_tools, "_registered_web_provider",
+            lambda b: MyCorp() if b == "mycorp" else None,
+        )
+        monkeypatch.setattr(web_tools, "_list_registered_web_providers", lambda: [MyCorp()])
+        monkeypatch.setattr(web_tools, "_is_backend_available", lambda b: False)
+        monkeypatch.setattr(web_tools, "_resolve_backend", lambda: "brave-free")
+        caplog.set_level(logging.WARNING, logger="tools.web_tools")
+
+        web_tools._get_capability_backend("search")
+
+        msgs = " ".join(_warnings(caplog))
+        assert "recognised backend but is not available" in msgs, (
+            "'mycorp' IS registered — telling the operator it does not exist "
+            "would send them to change a correct config"
+        )
+        assert "not a known backend" not in msgs
+
+    def test_valid_values_includes_registered_providers(self, monkeypatch):
+        class MyCorp:
+            name = "mycorp"
+
+        monkeypatch.setattr(web_tools, "_list_registered_web_providers", lambda: [MyCorp()])
+        names = web_tools._valid_backend_names()
+        assert "mycorp" in names, (
+            "a valid-values list that omits the user's own provider would tell "
+            "them to switch to the wrong backend"
+        )
+        assert "brave-free" in names
+
+
+# ---------------------------------------------------------------------------
+# Audit B1: silence when the operator configured nothing
+# ---------------------------------------------------------------------------
+
+class TestNoConfigMeansNoBlame:
+    def test_empty_config_produces_no_warning(self, cfg, no_registry, caplog):
+        """A fresh install with no keys must not be told to hunt for a typo."""
+        cfg()
+        caplog.set_level(logging.WARNING, logger="tools.web_tools")
+
+        web_tools._get_capability_backend("search")
+        web_tools._get_backend()
+
+        assert not _warnings(caplog), (
+            "nothing was configured, so nothing was discarded — warning here "
+            "blames the operator for an auto-detected value and contradicts "
+            "the tool's own 'No web search provider configured' error"
+        )
+
+    def test_available_backend_is_silent(self, cfg, no_registry, caplog, monkeypatch):
+        cfg(search_backend="firecrawl")
         monkeypatch.setattr(web_tools, "_is_backend_available", lambda b: True)
         caplog.set_level(logging.WARNING, logger="tools.web_tools")
 
         assert web_tools._get_capability_backend("search") == "firecrawl"
-        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert not _warnings(caplog)
 
-    def test_unset_backend_is_silent(self, cfg, caplog):
-        """No configured value means nothing was discarded — say nothing."""
-        cfg("", resolved="firecrawl")
-        caplog.set_level(logging.WARNING, logger="tools.web_tools")
-
-        assert web_tools._get_capability_backend("search") == "firecrawl"
-        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
-
-    def test_no_warning_when_fallback_equals_request(self, cfg, caplog, monkeypatch):
-        """If auto-detect lands on the same provider, nothing was lost."""
-        cfg("firecrawl", resolved="firecrawl")
+    def test_no_warning_when_fallback_equals_request(self, cfg, no_registry, caplog, monkeypatch):
+        cfg(search_backend="firecrawl")
         monkeypatch.setattr(web_tools, "_is_backend_available", lambda b: False)
+        monkeypatch.setattr(web_tools, "_resolve_backend", lambda: "firecrawl")
         caplog.set_level(logging.WARNING, logger="tools.web_tools")
 
         web_tools._get_capability_backend("search")
-        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert not _warnings(caplog)
 
+
+# ---------------------------------------------------------------------------
+# Dedup — these run on every dispatch and every `hermes tools` repaint
+# ---------------------------------------------------------------------------
 
 class TestDedup:
-    def test_warns_once_not_per_dispatch(self, cfg, caplog):
-        cfg("brave", resolved="firecrawl")
+    def test_warns_once_not_per_dispatch(self, cfg, no_registry, caplog, monkeypatch):
+        cfg(search_backend="brave")
+        monkeypatch.setattr(web_tools, "_resolve_backend", lambda: "firecrawl")
         caplog.set_level(logging.WARNING, logger="tools.web_tools")
 
         for _ in range(25):
             web_tools._get_capability_backend("search")
 
-        warns = [r for r in caplog.records if r.levelno >= logging.WARNING]
-        assert len(warns) == 1, (
-            "this runs on every dispatch and every `hermes tools` repaint; "
-            f"an un-deduped warning becomes spam. Got {len(warns)}."
+        assert len(_warnings(caplog)) == 1, (
+            "un-deduped, this becomes the spam it exists to surface"
         )
 
-    def test_search_and_extract_report_independently(self, cfg, caplog):
-        cfg("brave", resolved="firecrawl")
+    def test_search_and_extract_report_independently(self, cfg, no_registry, caplog, monkeypatch):
+        cfg(search_backend="brave", extract_backend="brave")
+        monkeypatch.setattr(web_tools, "_resolve_backend", lambda: "firecrawl")
         caplog.set_level(logging.WARNING, logger="tools.web_tools")
 
         web_tools._get_capability_backend("search")
         web_tools._get_capability_backend("extract")
 
-        warns = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
-        assert len(warns) == 2, "each capability is a separate misconfiguration"
-        assert any("search_backend" in m for m in warns)
-        assert any("extract_backend" in m for m in warns)
+        msgs = _warnings(caplog)
+        assert len(msgs) == 2
+        assert any("search_backend" in m for m in msgs)
+        assert any("extract_backend" in m for m in msgs)
 
 
-class TestKnownBackendsStaysInSync:
-    """_KNOWN_BACKENDS only exists to classify the error; drift makes it lie."""
+# ---------------------------------------------------------------------------
+# No duplicated constant (audit S2)
+# ---------------------------------------------------------------------------
 
-    def test_every_known_backend_is_probed_by_is_backend_available(self):
-        import inspect
-        src = inspect.getsource(web_tools._is_backend_available)
-        missing = [b for b in web_tools._KNOWN_BACKENDS if repr(b) not in src and f'"{b}"' not in src]
-        assert not missing, (
-            f"_KNOWN_BACKENDS lists {missing} but _is_backend_available does not "
-            "probe them — a real backend would be misreported as a typo."
-        )
+class TestValidValuesRespectCapability:
+    """A suggestion list must not name backends that cannot do the job."""
 
-    def test_no_unknown_name_claims_to_be_known(self):
-        assert "brave" not in web_tools._KNOWN_BACKENDS, (
-            "'brave' is the typo from the original incident; the registered "
-            "provider is 'brave-free'. If an alias is ever added, it must be "
-            "registered in the provider registry, not just listed here."
-        )
+    def test_extract_list_excludes_search_only_backends(self, no_registry):
+        names = web_tools._valid_backend_names("extract")
+        for search_only in ("brave-free", "ddgs", "searxng", "xai"):
+            assert search_only not in names, (
+                f"{search_only} cannot extract — suggesting it swaps one "
+                "broken config for another, and contradicts the extract "
+                "dispatcher's own 'firecrawl, tavily, exa, or parallel'"
+            )
+        assert {"firecrawl", "tavily", "exa", "parallel"} <= set(names)
+
+    def test_search_list_includes_search_only_backends(self, no_registry):
+        assert "brave-free" in web_tools._valid_backend_names("search")
+
+    def test_no_dispatch_layer_warner(self):
+        """Deliberately removed: it misstated the config key and invented a
+        credential fact. Misconfiguration is reported at the config layer."""
+        assert not hasattr(web_tools, "_warn_dispatch_capability_mismatch")

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -328,17 +328,61 @@ def _get_extract_backend() -> str:
     return _get_capability_backend("extract")
 
 
+# Every backend name ``_is_backend_available`` knows how to probe. Used only to
+# tell "you typed a name that does not exist" apart from "the backend exists but
+# its credential is missing" — two different operator mistakes that otherwise
+# produce byte-identical (silent) behavior. Keep in sync with
+# ``_is_backend_available``; the test suite pins that.
+_KNOWN_BACKENDS: frozenset[str] = frozenset({
+    "exa", "parallel", "firecrawl", "tavily", "searxng",
+    "brave-free", "ddgs", "xai",
+})
+
+# (capability, configured_value) pairs already reported. _get_capability_backend
+# runs on EVERY web_search/web_extract dispatch and on every `hermes tools`
+# repaint, so an un-deduped warning here would itself become log spam.
+_backend_fallback_warned: set = set()
+
+
 def _get_capability_backend(capability: str) -> str:
     """Shared helper for per-capability backend selection.
 
     Reads ``web.{capability}_backend`` from config; if set and available,
     uses it. Otherwise falls through to the shared ``_get_backend()``.
+
+    When an explicitly configured backend is discarded, log it once. Silently
+    ignoring the operator's choice means a one-character typo
+    (``brave`` for ``brave-free``) reroutes every search to a completely
+    different provider, indefinitely, with nothing in the logs at any level —
+    the config file and the actual behavior disagree and nothing says so.
     """
     cfg = _load_web_config()
     specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
     if specific and _is_backend_available(specific):
         return specific
-    return _get_backend()
+
+    resolved = _get_backend()
+    if specific and specific != resolved:
+        key = (capability, specific)
+        if key not in _backend_fallback_warned:
+            _backend_fallback_warned.add(key)
+            if specific in _KNOWN_BACKENDS:
+                logger.warning(
+                    "web.%s_backend=%r is a known backend but is not available "
+                    "(its API key or URL is unset) — falling back to %r. Set "
+                    "the required credential, or change the config to match "
+                    "what you intend to use.",
+                    capability, specific, resolved or "auto-detect",
+                )
+            else:
+                logger.warning(
+                    "web.%s_backend=%r is not a recognised backend — falling "
+                    "back to %r. Valid values: %s. (This is a config typo: "
+                    "your configured provider is NOT being used.)",
+                    capability, specific, resolved or "auto-detect",
+                    ", ".join(sorted(_KNOWN_BACKENDS)),
+                )
+    return resolved
 
 
 def _is_backend_available(backend: str) -> bool:
@@ -723,6 +767,20 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             # configured backend isn't a registered search provider (typo,
             # uninstalled plugin, or capability mismatch).
             provider = get_active_search_provider()
+            # Say so, once. A resolved-but-unregistered backend silently
+            # rerouting every search is indistinguishable from working
+            # correctly, which turns a config typo into an unfalsifiable
+            # "search returns nothing" report.
+            if backend:
+                key = ("search-dispatch", backend)
+                if key not in _backend_fallback_warned:
+                    _backend_fallback_warned.add(key)
+                    logger.warning(
+                        "Configured search backend %r is not a registered "
+                        "search provider — using %r instead. Check for a typo "
+                        "or a disabled/uninstalled web plugin.",
+                        backend, getattr(provider, "name", None) or "none",
+                    )
 
         if provider is None:
             # A bundled web plugin the user explicitly disabled looks

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -253,7 +253,100 @@ def _list_registered_web_providers():
         return []
 
 
-def _get_backend() -> str:
+# (config_key, configured_value) pairs already reported by
+# _warn_discarded_backend. These paths run on EVERY web_search / web_extract
+# dispatch and on every `hermes tools` repaint, so an un-deduped warning would
+# itself become the log spam it exists to surface.
+_backend_discard_warned: set = set()
+
+
+def _valid_backend_names(capability: str = "") -> list:
+    """Backend names a user may legitimately configure, for messages.
+
+    Union of the built-in probes and whatever the plugin registry currently
+    holds — a third-party provider must appear here, or telling the operator
+    their name is invalid would be worse than saying nothing.
+
+    ``capability`` ("search" / "extract") filters to providers that actually
+    offer it. Without that filter an ``extract_backend`` typo was answered with
+    a list including ``brave-free``, ``ddgs``, ``searxng`` and ``xai`` — none of
+    which can extract — so following the advice swapped one broken config for
+    another, and it contradicted the precise list the extract dispatcher already
+    prints ("firecrawl, tavily, exa, or parallel").
+    """
+    names = set()
+    supports = f"supports_{capability}" if capability else ""
+    try:
+        for provider in _list_registered_web_providers():
+            name = getattr(provider, "name", None)
+            if not name:
+                continue
+            if supports:
+                probe = getattr(provider, supports, None)
+                try:
+                    if callable(probe) and not probe():
+                        continue
+                except Exception:  # noqa: BLE001 — a broken provider is skipped
+                    continue
+            names.add(str(name))
+    except Exception:  # noqa: BLE001 — a broken registry must not break logging
+        pass
+    # Legacy names have no registry entry to interrogate. Only xai/ddgs/searxng/
+    # brave-free are search-only among them; the rest do both.
+    _LEGACY_SEARCH_ONLY = {"brave-free", "ddgs", "searxng", "xai"}
+    for name in _LEGACY_WEB_BACKENDS:
+        if capability == "extract" and name in _LEGACY_SEARCH_ONLY:
+            continue
+        names.add(name)
+    return sorted(names)
+
+
+def _warn_discarded_backend(
+    config_key: str, configured: str, resolved: str, capability: str = ""
+) -> None:
+    """Report, once, that an explicitly configured backend was discarded.
+
+    Silently ignoring the operator's choice means a one-character typo
+    (``brave`` for ``brave-free``) reroutes every request to a different
+    provider indefinitely, with nothing at any log level — the config file and
+    the runtime disagree and nothing says so. The only symptom is "web search
+    returns empty", indistinguishable from a provider outage.
+
+    Distinguishes the two operator mistakes, which are otherwise identical:
+    a name that exists but lacks its credential, versus a name that does not
+    exist. Classification uses the same test as ``_get_backend`` —
+    ``_LEGACY_WEB_BACKENDS`` or the plugin registry — so a registered
+    third-party provider is never mislabelled a typo.
+    """
+    if not configured or configured == resolved:
+        return
+    key = (config_key, configured)
+    if key in _backend_discard_warned:
+        return
+    _backend_discard_warned.add(key)
+
+    recognised = (
+        configured in _LEGACY_WEB_BACKENDS
+        or _registered_web_provider(configured) is not None
+    )
+    if recognised:
+        logger.warning(
+            "web.%s=%r is a recognised backend but is not available (its API "
+            "key, URL or plugin is missing) — falling back to %r. Set the "
+            "required credential, or change the config to match what you "
+            "intend to use.",
+            config_key, configured, resolved,
+        )
+    else:
+        logger.warning(
+            "web.%s=%r is not a known backend — falling back to %r, so your "
+            "configured provider is NOT being used. Valid values: %s.",
+            config_key, configured, resolved,
+            ", ".join(_valid_backend_names(capability)),
+        )
+
+
+def _resolve_backend() -> str:
     """Determine which web backend to use (shared fallback).
 
     Reads ``web.backend`` from config.yaml (set by ``hermes tools``).
@@ -303,6 +396,41 @@ def _get_backend() -> str:
     return "firecrawl"  # default (backward compat)
 
 
+# NOTE: there is deliberately no dispatch-layer warning here.
+#
+# An earlier revision added one, and it was wrong in the only case it could
+# actually fire. It keyed on the value `_get_*_backend()` returned rather than
+# the key the operator set, so it named `web.{capability}_backend` even when the
+# value came from `web.backend` — the key `hermes tools` actually writes. It
+# also asserted "the credential is set", inferred from configured == resolved,
+# which `_resolve_backend` does not establish: that function returns any
+# legacy-or-registered NAME without probing availability at all. And it was
+# near-dead regardless — every bundled provider supports search, and the extract
+# dispatcher already returns a precise typed error for a real capability
+# mismatch a few lines below. A warning that misstates the key, invents a
+# credential fact, and duplicates a better error is worse than silence.
+#
+# Misconfiguration is reported at the config layer instead, by
+# _warn_discarded_backend, which knows which key it read.
+
+
+def _get_backend() -> str:
+    """``_resolve_backend`` plus a one-time report if ``web.backend`` was dropped.
+
+    ``web.backend`` is the key ``hermes tools`` actually writes (it never
+    writes the per-capability keys), so it is where most misconfigurations
+    live — and ``_resolve_backend`` discards an unrecognised value silently.
+    """
+    resolved = _resolve_backend()
+    try:
+        configured = (_load_web_config().get("backend") or "").lower().strip()
+        # No capability: web.backend is the shared key, used for both.
+        _warn_discarded_backend("backend", configured, resolved)
+    except Exception:  # pragma: no cover — logging must never break resolution
+        pass
+    return resolved
+
+
 def _get_search_backend() -> str:
     """Determine which backend to use for web_search specifically.
 
@@ -328,60 +456,23 @@ def _get_extract_backend() -> str:
     return _get_capability_backend("extract")
 
 
-# Every backend name ``_is_backend_available`` knows how to probe. Used only to
-# tell "you typed a name that does not exist" apart from "the backend exists but
-# its credential is missing" — two different operator mistakes that otherwise
-# produce byte-identical (silent) behavior. Keep in sync with
-# ``_is_backend_available``; the test suite pins that.
-_KNOWN_BACKENDS: frozenset[str] = frozenset({
-    "exa", "parallel", "firecrawl", "tavily", "searxng",
-    "brave-free", "ddgs", "xai",
-})
-
-# (capability, configured_value) pairs already reported. _get_capability_backend
-# runs on EVERY web_search/web_extract dispatch and on every `hermes tools`
-# repaint, so an un-deduped warning here would itself become log spam.
-_backend_fallback_warned: set = set()
-
-
 def _get_capability_backend(capability: str) -> str:
     """Shared helper for per-capability backend selection.
 
     Reads ``web.{capability}_backend`` from config; if set and available,
     uses it. Otherwise falls through to the shared ``_get_backend()``.
-
-    When an explicitly configured backend is discarded, log it once. Silently
-    ignoring the operator's choice means a one-character typo
-    (``brave`` for ``brave-free``) reroutes every search to a completely
-    different provider, indefinitely, with nothing in the logs at any level —
-    the config file and the actual behavior disagree and nothing says so.
     """
     cfg = _load_web_config()
     specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
     if specific and _is_backend_available(specific):
         return specific
-
     resolved = _get_backend()
-    if specific and specific != resolved:
-        key = (capability, specific)
-        if key not in _backend_fallback_warned:
-            _backend_fallback_warned.add(key)
-            if specific in _KNOWN_BACKENDS:
-                logger.warning(
-                    "web.%s_backend=%r is a known backend but is not available "
-                    "(its API key or URL is unset) — falling back to %r. Set "
-                    "the required credential, or change the config to match "
-                    "what you intend to use.",
-                    capability, specific, resolved or "auto-detect",
-                )
-            else:
-                logger.warning(
-                    "web.%s_backend=%r is not a recognised backend — falling "
-                    "back to %r. Valid values: %s. (This is a config typo: "
-                    "your configured provider is NOT being used.)",
-                    capability, specific, resolved or "auto-detect",
-                    ", ".join(sorted(_KNOWN_BACKENDS)),
-                )
+    try:
+        _warn_discarded_backend(
+            f"{capability}_backend", specific, resolved, capability=capability
+        )
+    except Exception:  # pragma: no cover — logging must never break resolution
+        pass
     return resolved
 
 
@@ -767,20 +858,6 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             # configured backend isn't a registered search provider (typo,
             # uninstalled plugin, or capability mismatch).
             provider = get_active_search_provider()
-            # Say so, once. A resolved-but-unregistered backend silently
-            # rerouting every search is indistinguishable from working
-            # correctly, which turns a config typo into an unfalsifiable
-            # "search returns nothing" report.
-            if backend:
-                key = ("search-dispatch", backend)
-                if key not in _backend_fallback_warned:
-                    _backend_fallback_warned.add(key)
-                    logger.warning(
-                        "Configured search backend %r is not a registered "
-                        "search provider — using %r instead. Check for a typo "
-                        "or a disabled/uninstalled web plugin.",
-                        backend, getattr(provider, "name", None) or "none",
-                    )
 
         if provider is None:
             # A bundled web plugin the user explicitly disabled looks


### PR DESCRIPTION
## The failure

A fleet had `web.search_backend: brave` set. The registered provider name is **`brave-free`**, so the value was discarded and a *different* provider (firecrawl) served every search on all seven agents, indefinitely, with **nothing logged at any level**. The config file and the runtime disagreed and nothing said so — the only symptom was "web search returns empty", indistinguishable from a provider outage. Diagnosing it required reading the dispatcher source.

## This PR was rewritten twice after audits

Both audits found the change **emitting false diagnostics** — disqualifying for a PR arguing that a wrong message turns a typo into an unfalsifiable bug report. Recording what was wrong, since the failures are more instructive than the fix:

**Round 1 — the classifier lied.**
- `_KNOWN_BACKENDS` was a **verbatim duplicate** of `_LEGACY_WEB_BACKENDS` 132 lines above it in the same file, used with the **opposite** meaning to that constant's own docstring. A registered third-party provider missing its key was therefore reported as a typo, with a "valid values" list *excluding the user's own provider*.
- The dispatch guard `if backend:` was **dead code** — `_get_backend()` never returns empty — so a fresh install with no config announced "Configured search backend 'brave-free' is not a registered provider", contradicting the tool's own error 15 lines later.
- `web.backend` — the **only** key `hermes tools` writes — wasn't covered at all.

**Round 2 — the replacement dispatch warner lied differently.** It hardcoded `web.%s_backend` while its value could come from `web.backend`, naming a key absent from the operator's config. It asserted "the credential is set", inferred from `configured == resolved` — a fact `_resolve_backend` never establishes, since it returns any legacy-or-registered *name* without probing availability.

## What it does now

**One report site: the config layer**, in `_warn_discarded_backend`, which knows which key it read. Classification uses `_LEGACY_WEB_BACKENDS or _registered_web_provider(...)` — the same test `_resolve_backend` uses — so a registered provider is never called a typo.

```
WARNING tools.web_tools: web.search_backend='brave' is not a known backend — falling
back to 'firecrawl', so your configured provider is NOT being used. Valid values:
brave-free, ddgs, exa, firecrawl, parallel, searxng, tavily, xai.
```

versus a real backend missing its credential:

```
WARNING tools.web_tools: web.search_backend='tavily' is a recognised backend but is
not available (its API key, URL or plugin is missing) — falling back to 'firecrawl'.
```

**The dispatch-layer warner is removed, not repaired.** Beyond being wrong, it was near-dead: every bundled provider supports search, and the extract dispatcher already returns a precise typed error for a genuine capability mismatch a few lines below. A warning that misstates the key, invents a credential fact, and duplicates a better error is worse than silence. A test asserts it stays gone.

**`_valid_backend_names` filters by capability.** An `extract_backend` typo was previously answered with a list including `brave-free`/`ddgs`/`searxng`/`xai` — none of which can extract — swapping one broken config for another and contradicting the extract dispatcher's own "firecrawl, tavily, exa, or parallel".

Deduped per `(key, value)`: these paths run on every dispatch and every `hermes tools` repaint, so an un-deduped warning becomes the spam it exists to surface. Silence is preserved wherever nothing was lost — no configured value, an available backend, or a fallback resolving to the same provider.

## Behavior

Logging only. Confirmed by AST comparison that `_resolve_backend`'s body is identical to the previous `_get_backend`; the new wrapper returns `resolved` unconditionally with the warn in `try/except`.

## Testing

12 tests, **mutation-verified** rather than trusted green — reverting each of six behaviours individually fails a test (silence the warner → 5 failures; misclassify registered providers, warn-when-unconfigured, drop `web.backend` coverage, capability-blind list, break dedup → 1 each). 265 web tests pass, ruff clean.

The dedup reset lives in `tests/tools/conftest.py` so it guards the whole directory: the set is process-global, and `pytest tests/tools/` shares one interpreter (cross-file isolation only holds under `scripts/run_tests_parallel.py`, which CI uses).

## Upstream

This code is upstream (`NousResearch/hermes-agent`) — the fallback block is `kshitijk4poor`'s "refactor(web): dispatch all three tools through web_search_registry", present verbatim on `upstream/main` at `tools/web_tools.py:685-691`. **Upstream issue #71929 already documents this bug**, with the identical `brave` vs `brave-free` example and the words "silently fails"; its proposed fix is a config-form dropdown, which does nothing for agents whose `config.yaml` is machine-written. So this is a different layer of fix to an already-reported problem, not a novel finding. No upstream PR is opened here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)