### PR TITLE
fix(discord): inbound throttle + budget ceiling (R6), ban propagates to authz (R7)

### DIFF
--- a/gateway/inbound_throttle.py
+++ b/gateway/inbound_throttle.py
@@ -1,0 +1,353 @@
+"""Inbound turn throttle + daily ceilings (R6).
+
+Platform-agnostic rate limiting for inbound messages that would become LLM
+turns. Sits at the single choke point in ``BasePlatformAdapter.handle_message``
+so every platform adapter (Discord, Telegram, Signal, ...) is covered by one
+gate.
+
+Three layers, checked in order:
+
+1. **Per-user sliding windows** (per-minute + per-hour) — one flooding user
+   cannot monopolize the agent.
+2. **Per-scope sliding windows** (guild / workspace / chat) — a coordinated
+   raid across many users in one server still hits a ceiling.
+3. **Daily ceilings** (turn count + spend USD) — a persistent ledger caps the
+   worst-case daily cost of the agent regardless of who is talking. The
+   ledger survives restarts.
+
+FAIL CLOSED: if the persistent ledger cannot be read or written, the verdict
+is DENY — a broken limiter must not become an open gate. Spend accounting is
+also fail-closed: turns with unknown pricing consume a conservative fallback
+cost instead of being free.
+
+All limits are env-configurable and re-read at check time so container
+recreates (HSM env edits) take effect without a code change. Malformed env
+values fall back to the conservative defaults with one WARNING.
+
+In-memory state (sliding windows, notify cooldowns) is process-local; the
+daily ledger at ``{HERMES_HOME}/throttle/ledger.json`` is the only persistent
+state (atomic 0600 writes, same pattern as ``gateway/pairing.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Deque, Dict, Optional, Set
+
+from hermes_constants import get_hermes_home
+from utils import atomic_replace
+
+logger = logging.getLogger(__name__)
+
+# Conservative defaults. Sized so a single human operator in conversation
+# with the agent never trips them (a human rarely sends >4 messages/minute
+# sustained), while a flood — one hostile user or a raided guild — hits a
+# wall within seconds.
+_INT_DEFAULTS = {
+    "GATEWAY_THROTTLE_USER_PER_MINUTE": 4,
+    "GATEWAY_THROTTLE_USER_PER_HOUR": 30,
+    "GATEWAY_THROTTLE_SCOPE_PER_MINUTE": 12,
+    "GATEWAY_THROTTLE_SCOPE_PER_HOUR": 120,
+    "GATEWAY_THROTTLE_DAILY_TURN_CEILING": 300,
+}
+_FLOAT_DEFAULTS = {
+    "GATEWAY_THROTTLE_DAILY_SPEND_USD": 10.0,
+    "GATEWAY_THROTTLE_FALLBACK_TURN_COST_USD": 0.05,
+}
+
+# Seconds between repeated "throttled" notices to the same user key. The
+# denial notice must never amplify the flood it is suppressing.
+NOTIFY_COOLDOWN_SECONDS = 60.0
+
+# Seconds between repeated ledger-error log lines (the deny itself happens
+# on every call — only the logging is rate limited).
+_LEDGER_ERROR_LOG_INTERVAL = 60.0
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """Outcome of a throttle check."""
+
+    allowed: bool
+    reason: str = ""
+
+
+_ALLOW = Verdict(True, "")
+
+
+def _utc_day() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _secure_write(path: Path, data: str) -> None:
+    """Atomic 0600 write — same pattern as ``gateway.pairing._secure_write``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        atomic_replace(tmp_path, path)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass  # Windows doesn't support chmod the same way
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+class InboundThrottle:
+    """Process-wide inbound turn limiter. Use :func:`get_throttle`."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._user_windows: Dict[str, Deque[float]] = {}
+        self._scope_windows: Dict[str, Deque[float]] = {}
+        self._notify_last: Dict[str, float] = {}
+        self._last_ledger_error_log = 0.0
+        self._warned_env_vars: Set[str] = set()
+
+    # ── Config (read at check time, malformed → default + one WARNING) ──
+
+    def _env_int(self, name: str) -> int:
+        default = _INT_DEFAULTS[name]
+        raw = os.getenv(name)
+        if raw is None or not raw.strip():
+            return default
+        try:
+            value = int(raw.strip())
+            if value < 0:
+                raise ValueError("negative")
+            return value
+        except (TypeError, ValueError):
+            self._warn_env_once(name, raw, default)
+            return default
+
+    def _env_float(self, name: str) -> float:
+        default = _FLOAT_DEFAULTS[name]
+        raw = os.getenv(name)
+        if raw is None or not raw.strip():
+            return default
+        try:
+            value = float(raw.strip())
+            if value < 0:
+                raise ValueError("negative")
+            return value
+        except (TypeError, ValueError):
+            self._warn_env_once(name, raw, default)
+            return default
+
+    def _warn_env_once(self, name: str, raw: str, default) -> None:
+        if name in self._warned_env_vars:
+            return
+        self._warned_env_vars.add(name)
+        logger.warning(
+            "Malformed %s=%r — using conservative default %s", name, raw, default
+        )
+
+    @staticmethod
+    def _enabled() -> bool:
+        return os.getenv("GATEWAY_THROTTLE_ENABLED", "true").strip().lower() not in {
+            "false",
+            "0",
+            "no",
+        }
+
+    @staticmethod
+    def _exempt_users() -> Set[str]:
+        raw = os.getenv("GATEWAY_THROTTLE_EXEMPT_USERS", "")
+        return {part.strip() for part in raw.split(",") if part.strip()}
+
+    # ── Persistent daily ledger (fail closed) ──
+
+    @property
+    def _ledger_path(self) -> Path:
+        # Resolved per call, not cached: tests re-point HERMES_HOME per test.
+        return get_hermes_home() / "throttle" / "ledger.json"
+
+    def _read_ledger(self) -> dict:
+        """Read + day-rollover the ledger. Raises on any IO/parse error."""
+        path = self._ledger_path
+        if not path.exists():
+            # First run: no ledger yet is not an error — start a fresh day.
+            return {"day": _utc_day(), "turns": 0, "spend_usd": 0.0}
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("ledger is not a JSON object")
+        day = data.get("day")
+        turns = data.get("turns")
+        spend = data.get("spend_usd")
+        if not isinstance(day, str) or not isinstance(turns, int) or not isinstance(
+            spend, (int, float)
+        ):
+            raise ValueError("ledger schema mismatch")
+        today = _utc_day()
+        if day != today:
+            return {"day": today, "turns": 0, "spend_usd": 0.0}
+        return {"day": day, "turns": turns, "spend_usd": float(spend)}
+
+    def _write_ledger(self, ledger: dict) -> None:
+        _secure_write(self._ledger_path, json.dumps(ledger))
+
+    def _log_ledger_error(self, err: BaseException) -> None:
+        now = time.monotonic()
+        if now - self._last_ledger_error_log >= _LEDGER_ERROR_LOG_INTERVAL:
+            self._last_ledger_error_log = now
+            logger.error(
+                "Inbound throttle ledger unreadable/unwritable at %s (%s) — "
+                "FAILING CLOSED: all throttled turns are denied until the "
+                "ledger is repaired or removed.",
+                self._ledger_path,
+                err,
+            )
+
+    # ── Sliding windows ──
+
+    @staticmethod
+    def _window_counts(window: Deque[float], now: float) -> tuple:
+        """Prune entries older than 1h; return (count_last_minute, count_last_hour)."""
+        cutoff_hour = now - 3600.0
+        while window and window[0] <= cutoff_hour:
+            window.popleft()
+        cutoff_minute = now - 60.0
+        minute_count = sum(1 for ts in window if ts > cutoff_minute)
+        return minute_count, len(window)
+
+    # ── Public API ──
+
+    def check_and_consume(
+        self, platform: str, user_id: str, scope: Optional[str]
+    ) -> Verdict:
+        """Gate one inbound turn. Order: enabled → user window → scope window
+        → daily turn ceiling → daily spend ceiling. Fail closed on ledger
+        errors. On allow, consumes window slots and one daily turn."""
+        if not self._enabled():
+            return _ALLOW
+
+        user_key = f"{platform}:{user_id}"
+        scope_key = f"{platform}:{scope}" if scope else None
+        exempt = user_id and str(user_id) in self._exempt_users()
+
+        with self._lock:
+            now = time.monotonic()
+
+            if not exempt:
+                user_window = self._user_windows.setdefault(user_key, deque())
+                u_min, u_hour = self._window_counts(user_window, now)
+                if u_min >= self._env_int("GATEWAY_THROTTLE_USER_PER_MINUTE"):
+                    return Verdict(False, "user_rate_per_minute")
+                if u_hour >= self._env_int("GATEWAY_THROTTLE_USER_PER_HOUR"):
+                    return Verdict(False, "user_rate_per_hour")
+
+                if scope_key is not None:
+                    scope_window = self._scope_windows.setdefault(scope_key, deque())
+                    s_min, s_hour = self._window_counts(scope_window, now)
+                    if s_min >= self._env_int("GATEWAY_THROTTLE_SCOPE_PER_MINUTE"):
+                        return Verdict(False, "scope_rate_per_minute")
+                    if s_hour >= self._env_int("GATEWAY_THROTTLE_SCOPE_PER_HOUR"):
+                        return Verdict(False, "scope_rate_per_hour")
+
+            # Daily ceilings bind for EVERYONE, including exempt users — they
+            # protect the wallet, not the conversation.
+            try:
+                ledger = self._read_ledger()
+            except Exception as err:
+                self._log_ledger_error(err)
+                return Verdict(False, "ledger_error")
+
+            if ledger["turns"] >= self._env_int("GATEWAY_THROTTLE_DAILY_TURN_CEILING"):
+                return Verdict(False, "daily_turn_ceiling")
+            if ledger["spend_usd"] >= self._env_float("GATEWAY_THROTTLE_DAILY_SPEND_USD"):
+                return Verdict(False, "daily_spend_ceiling")
+
+            ledger["turns"] += 1
+            try:
+                self._write_ledger(ledger)
+            except Exception as err:
+                # If the consumed turn cannot be persisted the ceiling can be
+                # bypassed by crash-looping — deny instead (fail closed).
+                self._log_ledger_error(err)
+                return Verdict(False, "ledger_error")
+
+            if not exempt:
+                self._user_windows[user_key].append(now)
+                if scope_key is not None:
+                    self._scope_windows[scope_key].append(now)
+
+        return _ALLOW
+
+    def record_spend(
+        self, cost_usd: Optional[float], cost_status: Optional[str]
+    ) -> None:
+        """Add a completed turn's cost to the daily spend ledger.
+
+        Unknown/zero cost consumes GATEWAY_THROTTLE_FALLBACK_TURN_COST_USD so
+        turns with broken pricing still draw down the budget (fail-closed
+        spend accounting)."""
+        if not self._enabled():
+            return
+        if not cost_usd or cost_status in {None, "unknown"}:
+            cost = self._env_float("GATEWAY_THROTTLE_FALLBACK_TURN_COST_USD")
+        else:
+            try:
+                cost = float(cost_usd)
+            except (TypeError, ValueError):
+                cost = self._env_float("GATEWAY_THROTTLE_FALLBACK_TURN_COST_USD")
+
+        with self._lock:
+            try:
+                ledger = self._read_ledger()
+                ledger["spend_usd"] = float(ledger["spend_usd"]) + cost
+                self._write_ledger(ledger)
+            except Exception as err:
+                # Cannot record spend — check_and_consume will fail closed on
+                # the same error, so this does not open the gate.
+                self._log_ledger_error(err)
+
+    def should_notify(self, user_key: str) -> bool:
+        """True at most once per NOTIFY_COOLDOWN_SECONDS per user key —
+        denial notices must not amplify the flood they suppress."""
+        with self._lock:
+            now = time.monotonic()
+            last = self._notify_last.get(user_key)
+            if last is not None and now - last < NOTIFY_COOLDOWN_SECONDS:
+                return False
+            self._notify_last[user_key] = now
+            return True
+
+    def reset_state_for_tests(self) -> None:
+        """Clear in-memory windows/cooldowns (test helper — ledger untouched)."""
+        with self._lock:
+            self._user_windows.clear()
+            self._scope_windows.clear()
+            self._notify_last.clear()
+            self._warned_env_vars.clear()
+            self._last_ledger_error_log = 0.0
+
+
+_singleton: Optional[InboundThrottle] = None
+_singleton_lock = threading.Lock()
+
+
+def get_throttle() -> InboundThrottle:
+    """Process-wide throttle singleton."""
+    global _singleton
+    if _singleton is None:
+        with _singleton_lock:
+            if _singleton is None:
+                _singleton = InboundThrottle()
+    return _singleton

--- a/gateway/inbound_throttle.py
+++ b/gateway/inbound_throttle.py
@@ -120,6 +120,9 @@ class InboundThrottle:
         self._notify_last: Dict[str, float] = {}
         self._last_ledger_error_log = 0.0
         self._warned_env_vars: Set[str] = set()
+        # Last cumulative session total recorded per session key — see
+        # record_session_spend. Process-local, like the sliding windows.
+        self._session_spend_baseline: Dict[str, float] = {}
 
     # ── Config (read at check time, malformed → default + one WARNING) ──
 
@@ -318,6 +321,32 @@ class InboundThrottle:
                 # the same error, so this does not open the gate.
                 self._log_ledger_error(err)
 
+    def record_session_spend(
+        self, session_key: str, session_total_usd, cost_status: Optional[str]
+    ) -> None:
+        """Record one turn's spend given the agent's CUMULATIVE session total.
+
+        ``agent_result["estimated_cost_usd"]`` (agent/turn_finalizer.py) is a
+        running total for the whole session — agent_init zeroes it once and
+        conversation_loop does ``+=`` per API call. Charging it directly every
+        turn sums running totals (quadratic overcount) and trips the daily
+        spend ceiling on ordinary single-operator use. This converts the
+        total to a per-turn delta against the last total seen for
+        ``session_key``; a rebuilt/reset agent restarts its total from zero,
+        in which case the fresh total is charged whole. Non-numeric totals
+        fall through to :meth:`record_spend`'s fallback pricing."""
+        if isinstance(session_total_usd, bool) or not isinstance(
+            session_total_usd, (int, float)
+        ):
+            self.record_spend(None, cost_status)
+            return
+        total = float(session_total_usd)
+        with self._lock:
+            prev = self._session_spend_baseline.get(session_key, 0.0)
+            delta = total - prev if total >= prev else total
+            self._session_spend_baseline[session_key] = total
+        self.record_spend(delta, cost_status)
+
     def should_notify(self, user_key: str) -> bool:
         """True at most once per NOTIFY_COOLDOWN_SECONDS per user key —
         denial notices must not amplify the flood they suppress."""
@@ -335,6 +364,7 @@ class InboundThrottle:
             self._user_windows.clear()
             self._scope_windows.clear()
             self._notify_last.clear()
+            self._session_spend_baseline.clear()
             self._warned_env_vars.clear()
             self._last_ledger_error_log = 0.0
 

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -161,6 +161,24 @@ def _sync_allowlist_remove(platform: str, user_id: str) -> None:
         pass
 
 
+def revoke_platform_authorization(platform: str, user_id: str) -> None:
+    """Revoke every pairing-layer grant for ``user_id`` on ``platform``.
+
+    Public entry point for moderation-driven revocation (R7). Unlike
+    :meth:`PairingStore.revoke` — whose allowlist mirror only fires when the
+    user was actually paired — this also prunes the platform allowlist env
+    var for never-paired users who were allowlisted directly.
+
+    Callers that also maintain an in-process copy of the allowlist MUST call
+    this BEFORE pruning ``os.environ``: ``_sync_allowlist_remove`` reads the
+    current ``os.getenv`` value to compute the persisted remainder.
+    """
+    PairingStore().revoke(platform, user_id)
+    # Unconditional: revoke()'s internal sync only runs when the user was
+    # paired; a never-paired allowlisted user still needs the .env prune.
+    _sync_allowlist_remove(platform, user_id)
+
+
 def _load_json_file(path: Path) -> dict:
     if path.exists():
         try:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -498,6 +498,7 @@ from enum import Enum
 from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
+from gateway import inbound_throttle
 from gateway.config import Platform, PlatformConfig
 from gateway.session import SessionSource, build_session_key
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home
@@ -506,6 +507,14 @@ from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes
 GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE = (
     "Secure secret entry is not supported over messaging. "
     "Load this skill in the local CLI to be prompted, or add the key to ~/.hermes/.env manually."
+)
+
+# R6: control commands that must survive a raid — they never spawn LLM work
+# and operators need them precisely when the throttle is biting (/stop an
+# in-flight turn, /approve or /deny a pending gate). Everything else —
+# including /retry and /steer, which DO spawn LLM turns — is throttled.
+_THROTTLE_EXEMPT_COMMANDS = frozenset(
+    {"stop", "new", "reset", "approve", "deny", "status", "help"}
 )
 
 
@@ -4678,10 +4687,42 @@ class BasePlatformAdapter(ABC):
 
         await self._drain_pending_after_session_command(session_key, command_guard)
 
+    async def _maybe_notify_throttled(self, event: "MessageEvent", verdict) -> None:
+        """Log every throttled turn; notify the user at most once per minute.
+
+        The log line makes denials observable (a silent drop is
+        indistinguishable from a broken bot); the per-user notice cooldown
+        ensures the denial path cannot amplify the flood it suppresses.
+        """
+        logger.warning(
+            "[%s] Inbound turn throttled (%s): user=%s chat=%s scope=%s",
+            self.name,
+            verdict.reason,
+            event.source.user_id,
+            event.source.chat_id,
+            event.source.scope_id or event.source.guild_id,
+        )
+        throttle = inbound_throttle.get_throttle()
+        user_key = f"{self.platform.value}:{event.source.user_id}"
+        if not throttle.should_notify(user_key):
+            return
+        if verdict.reason in {"daily_turn_ceiling", "daily_spend_ceiling", "ledger_error"}:
+            notice = "Daily usage limit reached — the agent is paused until tomorrow (UTC)."
+        else:
+            notice = "Rate limit reached — please wait a moment before sending more messages."
+        try:
+            await self._send_with_retry(
+                chat_id=event.source.chat_id,
+                content=notice,
+                reply_to=_reply_anchor_for_event(event),
+            )
+        except Exception as e:
+            logger.debug("[%s] Failed to send throttle notice: %s", self.name, e)
+
     async def handle_message(self, event: MessageEvent) -> None:
         """
         Process an incoming message.
-        
+
         This method returns quickly by spawning background tasks.
         This allows new messages to be processed even while an agent is running,
         enabling interruption support.
@@ -4700,6 +4741,31 @@ class BasePlatformAdapter(ABC):
             return
 
         coerce_plaintext_gateway_command(event)
+
+        # R6 inbound throttle: this is the single choke point where an inbound
+        # message becomes (or queues toward) an LLM turn on EVERY platform —
+        # direct text, batched-text flush, slash dispatch, and thread sessions
+        # all converge on handle_message. Control commands (/stop, /approve,
+        # ...) are exempt so operators can still steer during a flood;
+        # anything that spawns LLM work (/retry, /steer, plain text) is gated.
+        # Observe-only events returned above and never spawn turns.
+        _throttle_cmd = event.get_command()
+        if _throttle_cmd not in _THROTTLE_EXEMPT_COMMANDS:
+            _throttle_user = str(event.source.user_id) if event.source.user_id else ""
+            _throttle_scope = (
+                event.source.scope_id or event.source.guild_id or event.source.chat_id
+            )
+            _throttle_scope = str(_throttle_scope) if _throttle_scope else None
+            # Ledger IO happens off the event loop.
+            _verdict = await asyncio.to_thread(
+                inbound_throttle.get_throttle().check_and_consume,
+                self.platform.value,
+                _throttle_user,
+                _throttle_scope,
+            )
+            if not _verdict.allowed:
+                await self._maybe_notify_throttled(event, _verdict)
+                return
 
         # Rewrite ``event.source.thread_id`` via the installed recovery hook
         # (Telegram DM topic mode) so the session key, guard checks, and

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13011,13 +13011,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # ledger. The agent result (agent/turn_finalizer.py) is the ONLY
             # live source of estimated_cost_usd — the SessionStore cost
             # columns have no writer and must not be used for budgeting.
+            # NOTE: estimated_cost_usd is the agent's CUMULATIVE session
+            # total, so record_session_spend charges only this turn's delta.
             # Unknown/zero cost still consumes a fallback amount inside
             # record_spend (fail-closed spend accounting).
             try:
                 from gateway.inbound_throttle import get_throttle
 
                 await asyncio.to_thread(
-                    get_throttle().record_spend,
+                    get_throttle().record_session_spend,
+                    session_entry.session_key,
                     agent_result.get("estimated_cost_usd"),
                     agent_result.get("cost_status"),
                 )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13007,6 +13007,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
             )
 
+            # R6: feed the authoritative per-turn cost into the daily spend
+            # ledger. The agent result (agent/turn_finalizer.py) is the ONLY
+            # live source of estimated_cost_usd — the SessionStore cost
+            # columns have no writer and must not be used for budgeting.
+            # Unknown/zero cost still consumes a fallback amount inside
+            # record_spend (fail-closed spend accounting).
+            try:
+                from gateway.inbound_throttle import get_throttle
+
+                await asyncio.to_thread(
+                    get_throttle().record_spend,
+                    agent_result.get("estimated_cost_usd"),
+                    agent_result.get("cost_status"),
+                )
+            except Exception as _spend_err:
+                logger.warning("Throttle spend recording failed: %s", _spend_err)
+
             # Re-baseline the cached agent's message_count snapshot now that
             # ALL of this turn's transcript writes are done — the agent's
             # flushed user/assistant/tool rows AND the first-turn `session_meta`

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -127,6 +127,13 @@ from gateway.platforms.base import (
 )
 from tools.url_safety import is_safe_url
 
+# Sibling plugin module (same dual-context import pattern as voice_mixer:
+# bare when the plugin dir is on sys.path, package-relative under tests).
+try:
+    import moderation_sync as _moderation_sync
+except ImportError:  # package context (tests import plugins.platforms.discord.*)
+    from . import moderation_sync as _moderation_sync
+
 
 def _truncate_discord_component_text(text: str, limit: int) -> str:
     """Return text within Discord's UTF-16 component field budget."""
@@ -1043,6 +1050,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 # online when Members Intent isn't enabled in the Developer Portal.
                 any(entry != "*" and not entry.isdigit() for entry in self._allowed_user_ids)
                 or bool(self._allowed_role_ids)  # Need members intent for role lookup
+                # R7: GUILD_MEMBER_REMOVE (kick/leave propagation) requires the
+                # privileged Server Members intent. Only "remove" mode requests
+                # it — the default "ban" mode works with default intents and
+                # carries zero boot risk. Same portal caveat as above: enable
+                # Server Members in the Developer Portal BEFORE setting
+                # DISCORD_MODERATION_SYNC=remove or the bot may not come online.
+                or _moderation_sync.moderation_sync_mode() == "remove"
             )
             intents.voice_states = True
 
@@ -1237,6 +1251,47 @@ class DiscordAdapter(BasePlatformAdapter):
                         else f"moved {before.channel.name} -> {after.channel.name}",
                         guild_id,
                     )
+
+            # R7: moderation → authorization propagation. A guild ban (and,
+            # in "remove" mode, any member removal) revokes the user's Hermes
+            # authorization everywhere: pairing grant, DISCORD_ALLOWED_USERS
+            # (in-memory + persisted .env), GATEWAY_ALLOWED_USERS, plus the
+            # adapter-owned deny store that survives HSM console re-writes.
+            _mod_sync_mode = _moderation_sync.moderation_sync_mode()
+            if _mod_sync_mode != "off":
+
+                async def _moderation_sync_revoke(uid: str, gid: str, reason: str) -> None:
+                    if uid in _moderation_sync.exempt_user_ids():
+                        logger.info(
+                            "[%s] Moderation sync: uid=%s is exempt — not revoking (%s)",
+                            adapter_self.name, uid, reason,
+                        )
+                        return
+                    sync_guilds = _moderation_sync.sync_guild_ids()
+                    if sync_guilds and gid not in sync_guilds:
+                        return
+                    # Blocking file IO (deny store, .env persistence) off-loop.
+                    await asyncio.to_thread(
+                        _moderation_sync.revoke_user_authorization,
+                        adapter_self, uid, reason, gid,
+                    )
+
+                @self._client.event
+                async def on_member_ban(guild, user):
+                    # Non-privileged moderation intent — part of Intents.default().
+                    await _moderation_sync_revoke(str(user.id), str(guild.id), "ban")
+
+                if _mod_sync_mode == "remove":
+
+                    @self._client.event
+                    async def on_raw_member_remove(payload):
+                        # Fires for kick AND voluntary leave (indistinguishable
+                        # without audit-log permissions), and also after a ban
+                        # (double-fire with on_member_ban — revocation is
+                        # idempotent). Requires the privileged members intent.
+                        await _moderation_sync_revoke(
+                            str(payload.user.id), str(payload.guild_id), "remove"
+                        )
 
             # Register slash commands
             if self._slash_commands:
@@ -3274,6 +3329,14 @@ class DiscordAdapter(BasePlatformAdapter):
             channel_ids: Resolved text-channel ids for guild traffic when an
                 upstream gate has already scoped the message to a channel.
         """
+        # R7: the moderation deny store beats EVERY allow branch below —
+        # pairing, user/role allowlists, ALLOW_ALL flags, and the channel
+        # bypass. This is the backstop against the HSM console's stale
+        # whole-document save re-writing DISCORD_ALLOWED_USERS and silently
+        # re-granting a banned user.
+        if _moderation_sync.deny_store().is_denied(user_id):
+            return False
+
         # ``getattr`` fallbacks here guard against test fixtures that build
         # an adapter via ``object.__new__(DiscordAdapter)`` and skip __init__
         # (see AGENTS.md pitfall #17 — same pattern as gateway.run).
@@ -6834,6 +6897,16 @@ def _component_check_auth(
     """
     user = getattr(interaction, "user", None)
     if user is None or getattr(user, "id", None) is None:
+        return False
+
+    # R7: the moderation deny store beats every allow branch below —
+    # including the ALLOW_ALL flags and the GATEWAY_ALLOWED_USERS union.
+    # A banned user must not be able to click approval buttons.
+    try:
+        _denied_uid = str(user.id)
+    except AttributeError:
+        _denied_uid = ""
+    if _denied_uid and _moderation_sync.deny_store().is_denied(_denied_uid):
         return False
 
     if os.getenv("DISCORD_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:

--- a/plugins/platforms/discord/moderation_sync.py
+++ b/plugins/platforms/discord/moderation_sync.py
@@ -1,0 +1,281 @@
+"""Discord moderation → authorization propagation (R7).
+
+When a member is banned (or, in ``remove`` mode, kicked / leaves) from a
+guild, their Hermes authorization must die with the ban — otherwise a banned
+user keeps DM command access through the pairing store or a stale allowlist.
+
+Revocation removes every grant:
+
+  1. pairing store approval + persisted ``.env`` allowlist entry
+     (``gateway.pairing.revoke_platform_authorization``);
+  2. the adapter's in-memory ``_allowed_user_ids`` + ``os.environ``
+     mirror of ``DISCORD_ALLOWED_USERS``;
+  3. an exact ``GATEWAY_ALLOWED_USERS`` entry (cross-platform var — Discord
+     snowflakes are 17-19 digits so collision risk with other platforms'
+     IDs is nil);
+  4. a persistent, adapter-owned **deny store** at
+     ``{HERMES_HOME}/platforms/discord-denied.json``.
+
+The deny store is the backstop for a specific failure mode: the HSM console
+saves its whole env document back (stale whole-document PUT, audit SB-5/#2),
+which can re-write ``DISCORD_ALLOWED_USERS`` and silently re-grant a banned
+user. The deny store is checked before EVERY allow branch (pairing,
+allowlists, ALLOW_ALL, channel bypass, component clicks) and survives every
+console save. Deny beats allow, always.
+
+Config (read at call time):
+  DISCORD_MODERATION_SYNC=ban       off | ban (default) | remove.
+      "ban": bans propagate; works with default (non-privileged
+             moderation) intents; zero boot risk.
+      "remove": ban+kick+leave all revoke. GUILD_MEMBER_REMOVE cannot
+             distinguish a kick from a voluntary leave without audit-log
+             permissions, and it requires the privileged Server Members
+             intent (must be enabled in the Developer Portal or the bot
+             may fail to boot — see the adapter's intents warning).
+  DISCORD_MODERATION_SYNC_GUILDS=   comma guild ids; empty = all guilds.
+  DISCORD_MODERATION_SYNC_EXEMPT=   comma snowflakes never auto-revoked
+      (seed with break-glass operator ids so a test-guild departure cannot
+      strand the operators).
+
+This module NEVER posts to Discord/Telegram — revocation is silent on the
+platform and loud in the logs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Optional, Set
+
+from hermes_constants import get_hermes_home
+from utils import atomic_replace
+
+logger = logging.getLogger(__name__)
+
+_VALID_MODES = ("off", "ban", "remove")
+
+
+def moderation_sync_mode() -> str:
+    """Current sync mode: 'off' | 'ban' | 'remove' (malformed → 'ban')."""
+    raw = os.getenv("DISCORD_MODERATION_SYNC", "ban").strip().lower()
+    if raw not in _VALID_MODES:
+        logger.warning(
+            "DISCORD_MODERATION_SYNC=%r is not one of off|ban|remove — using 'ban'",
+            raw,
+        )
+        return "ban"
+    return raw
+
+
+def sync_guild_ids() -> Set[str]:
+    """Guilds whose moderation events propagate (empty = all guilds)."""
+    raw = os.getenv("DISCORD_MODERATION_SYNC_GUILDS", "")
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
+def exempt_user_ids() -> Set[str]:
+    """Snowflakes that are never auto-revoked (break-glass operators)."""
+    raw = os.getenv("DISCORD_MODERATION_SYNC_EXEMPT", "")
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
+def _secure_write(path: Path, data: str) -> None:
+    """Atomic 0600 write — same pattern as ``gateway.pairing._secure_write``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        atomic_replace(tmp_path, path)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass  # Windows doesn't support chmod the same way
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+class DenyStore:
+    """Persistent, adapter-owned deny list for Discord user ids.
+
+    ``{uid: {"reason": str, "at": ts, "guild_id": str}}`` at
+    ``{HERMES_HOME}/platforms/discord-denied.json`` (atomic 0600 writes).
+
+    The path is resolved per call (not cached) so per-test HERMES_HOME
+    isolation works and container recreates pick up env changes.
+    """
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self._explicit_path = path
+        self._lock = threading.RLock()
+
+    @property
+    def path(self) -> Path:
+        if self._explicit_path is not None:
+            return self._explicit_path
+        return get_hermes_home() / "platforms" / "discord-denied.json"
+
+    def _load(self) -> dict:
+        path = self.path
+        if not path.exists():
+            return {}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError("deny store is not a JSON object")
+            return data
+        except Exception as err:
+            # The file is only ever written atomically by this class, so
+            # corruption is a serious signal. We log loudly but treat the
+            # store as empty rather than denying every user on the platform:
+            # the deny store is a *backstop* on top of the allowlist prune —
+            # a banned user is normally already out of every allowlist.
+            logger.error(
+                "Discord deny store unreadable at %s (%s) — treating as empty. "
+                "Banned users pruned from allowlists stay revoked, but the "
+                "console-save backstop is DOWN until this file is repaired.",
+                path,
+                err,
+            )
+            return {}
+
+    def add(self, uid: str, reason: str, guild_id: str) -> None:
+        with self._lock:
+            data = self._load()
+            data[str(uid)] = {
+                "reason": reason,
+                "at": time.time(),
+                "guild_id": str(guild_id),
+            }
+            _secure_write(self.path, json.dumps(data, indent=2, ensure_ascii=False))
+
+    def is_denied(self, uid) -> bool:
+        if uid is None:
+            return False
+        with self._lock:
+            return str(uid) in self._load()
+
+    def remove(self, uid: str) -> bool:
+        """Operator un-ban (CLI). Returns True if the uid was present."""
+        with self._lock:
+            data = self._load()
+            if str(uid) not in data:
+                return False
+            del data[str(uid)]
+            _secure_write(self.path, json.dumps(data, indent=2, ensure_ascii=False))
+            return True
+
+
+_store: Optional[DenyStore] = None
+_store_lock = threading.Lock()
+
+
+def deny_store() -> DenyStore:
+    """Process-wide deny store (path resolved lazily on every operation)."""
+    global _store
+    if _store is None:
+        with _store_lock:
+            if _store is None:
+                _store = DenyStore()
+    return _store
+
+
+def revoke_user_authorization(adapter, uid: str, reason: str, guild_id: str) -> None:
+    """Remove every Hermes authorization grant for ``uid``. Idempotent.
+
+    Order matters: the pairing-layer prune (step 1) reads ``os.getenv`` to
+    compute the persisted ``.env`` remainder, so it must run BEFORE the
+    in-process ``os.environ`` rewrite (step 2). Steps are individually
+    guarded so a failure in one layer cannot skip the deny-store backstop.
+
+    Runs blocking file IO — call via ``asyncio.to_thread`` from the event
+    loop. NEVER posts to Discord/Telegram.
+    """
+    uid = str(uid)
+    guild_id = str(guild_id)
+
+    # 1. Pairing grant + persisted .env allowlist entry (reads os.getenv,
+    #    so it runs while os.environ still holds the pre-prune list).
+    try:
+        from gateway.pairing import revoke_platform_authorization
+
+        revoke_platform_authorization("discord", uid)
+    except Exception:
+        logger.error(
+            "R7: pairing/env revocation failed for uid=%s — continuing to "
+            "deny-store backstop",
+            uid,
+            exc_info=True,
+        )
+
+    # 2. Adapter in-memory allowlist + os.environ mirror (same rewrite the
+    #    adapter's username resolution performs).
+    try:
+        allowed = getattr(adapter, "_allowed_user_ids", None)
+        if allowed and uid in allowed:
+            allowed.discard(uid)
+            os.environ["DISCORD_ALLOWED_USERS"] = ",".join(sorted(allowed))
+    except Exception:
+        logger.error(
+            "R7: in-memory allowlist prune failed for uid=%s", uid, exc_info=True
+        )
+
+    # 3. Exact match in the cross-platform GATEWAY_ALLOWED_USERS var.
+    try:
+        raw = os.getenv("GATEWAY_ALLOWED_USERS", "")
+        ids = [part.strip() for part in raw.split(",") if part.strip()]
+        if uid in ids:
+            remaining = [part for part in ids if part != uid]
+            logger.warning(
+                "R7: pruning uid=%s from cross-platform GATEWAY_ALLOWED_USERS "
+                "(Discord snowflakes are 17-19 digits; exact-match prune)",
+                uid,
+            )
+            os.environ["GATEWAY_ALLOWED_USERS"] = ",".join(remaining)
+            from hermes_cli.config import remove_env_value, save_env_value
+
+            if remaining:
+                save_env_value("GATEWAY_ALLOWED_USERS", ",".join(remaining))
+            else:
+                remove_env_value("GATEWAY_ALLOWED_USERS")
+    except Exception:
+        logger.error(
+            "R7: GATEWAY_ALLOWED_USERS prune failed for uid=%s", uid, exc_info=True
+        )
+
+    # 4. Deny-store backstop — survives HSM console whole-document saves
+    #    that re-write the allowlist env vars.
+    deny_store().add(uid, reason, guild_id)
+
+    # 5. Gate-shape alarm: if the pruned user allowlist is now empty and no
+    #    role allowlist is configured, the adapter's auth gate falls through
+    #    to the channel-bypass / ALLOW_ALL branch semantics. The deny store
+    #    still blocks THIS uid, but operators must know the shape changed.
+    remaining_users = getattr(adapter, "_allowed_user_ids", set()) or set()
+    remaining_roles = getattr(adapter, "_allowed_role_ids", set()) or set()
+    if not remaining_users and not remaining_roles:
+        logger.critical(
+            "R7: DISCORD_ALLOWED_USERS is now EMPTY and no roles are "
+            "configured — the Discord auth gate has fallen through to "
+            "channel-bypass/ALLOW_ALL branch semantics. The deny store still "
+            "blocks uid=%s, but review the adapter's authorization config.",
+            uid,
+        )
+
+    logger.info(
+        "R7: revoked Discord authorization for uid=%s (reason=%s, guild=%s)",
+        uid,
+        reason,
+        guild_id,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -390,6 +390,12 @@ def _hermetic_environment(tmp_path, monkeypatch):
     # should never perform that implicit network/bootstrap path; Tirith-specific
     # tests opt back in by patching the security config directly.
     monkeypatch.setenv("TIRITH_ENABLED", "false")
+    # R6 inbound throttle: default-on in production, default-off in the
+    # hermetic suite — hundreds of existing tests drive handle_message far
+    # faster than any human and would trip the per-user window. Throttle
+    # tests opt back in with monkeypatch.setenv("GATEWAY_THROTTLE_ENABLED",
+    # "true") and a fresh InboundThrottle/reset singleton.
+    monkeypatch.setenv("GATEWAY_THROTTLE_ENABLED", "false")
 
     # 5. Reset plugin singleton so tests don't leak plugins from
     #    ~/.hermes/plugins/ (which, per step 3, is now empty — but the

--- a/tests/gateway/test_discord_moderation_sync.py
+++ b/tests/gateway/test_discord_moderation_sync.py
@@ -1,0 +1,433 @@
+"""Security regression tests: R7 moderation → authorization propagation.
+
+A user banned (or, in "remove" mode, kicked/leaving) from a guild must lose
+Hermes authorization EVERYWHERE — pairing grant, DISCORD_ALLOWED_USERS
+(in-memory + env), GATEWAY_ALLOWED_USERS — and land in a persistent,
+adapter-owned deny store. The deny store exists because the HSM console's
+stale whole-document save can re-write DISCORD_ALLOWED_USERS and silently
+re-grant a banned user (audit SB-5/#2): deny must beat every allow branch —
+pairing, allowlists, ALLOW_ALL flags, and the component-click auth union —
+and must survive any console re-write.
+
+These tests pin: revocation pruning across all layers, deny-beats-everything
+semantics on both auth surfaces, handler registration per
+DISCORD_MODERATION_SYNC mode (off | ban | remove), the privileged-intent
+request being confined to "remove" mode, exemption and guild filters, and
+idempotency under the ban/remove double-fire.
+"""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+# Importing the production modules triggers the shared discord mock from
+# tests/gateway/conftest.py.
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+from plugins.platforms.discord import moderation_sync  # noqa: E402
+from plugins.platforms.discord.adapter import (  # noqa: E402
+    DiscordAdapter,
+    _component_check_auth,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for name in (
+        "DISCORD_ALLOWED_USERS",
+        "DISCORD_ALLOWED_ROLES",
+        "DISCORD_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "DISCORD_MODERATION_SYNC",
+        "DISCORD_MODERATION_SYNC_GUILDS",
+        "DISCORD_MODERATION_SYNC_EXEMPT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def pairing_store_mock():
+    """Mock PairingStore at its source module (the adapter and pairing code
+    import it at function level) so tests never touch real pairing files."""
+    store = MagicMock()
+    store.is_approved.return_value = False
+    store.revoke.return_value = True
+    with patch("gateway.pairing.PairingStore", return_value=store):
+        yield store
+
+
+@pytest.fixture
+def env_persistence_mock():
+    """Mock the .env persistence layer (save/remove) to observe writes."""
+    with patch("hermes_cli.config.save_env_value") as save_mock, patch(
+        "hermes_cli.config.remove_env_value"
+    ) as remove_mock:
+        yield SimpleNamespace(save=save_mock, remove=remove_mock)
+
+
+def _bare_adapter(allowed_users=(), allowed_roles=()):
+    """Adapter without __init__ (AGENTS.md pitfall #17 pattern)."""
+    adapter = object.__new__(DiscordAdapter)
+    adapter._allowed_user_ids = set(allowed_users)
+    adapter._allowed_role_ids = set(allowed_roles)
+    return adapter
+
+
+BANNED = "769524422783664158"  # 18-digit snowflake
+OTHER = "111111111111111111"
+
+
+# ---------------------------------------------------------------------------
+# revoke_user_authorization: every layer is pruned
+# ---------------------------------------------------------------------------
+
+
+class TestRevocation:
+    def test_ban_prunes_all_authorization_layers(
+        self, monkeypatch, pairing_store_mock, env_persistence_mock
+    ):
+        adapter = _bare_adapter(allowed_users={BANNED, OTHER})
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", f"{BANNED},{OTHER}")
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", f"{BANNED},999888777666555444")
+
+        moderation_sync.revoke_user_authorization(adapter, BANNED, "ban", "g1")
+
+        # In-memory allowlist + os.environ mirror pruned.
+        assert BANNED not in adapter._allowed_user_ids
+        assert OTHER in adapter._allowed_user_ids
+        assert BANNED not in os.environ["DISCORD_ALLOWED_USERS"]
+        # Pairing grant revoked.
+        pairing_store_mock.revoke.assert_called_once_with("discord", BANNED)
+        # Persisted .env allowlists pruned (DISCORD via pairing sync,
+        # GATEWAY via the exact-match prune).
+        saved = {call.args[0]: call.args[1] for call in env_persistence_mock.save.call_args_list}
+        assert saved.get("DISCORD_ALLOWED_USERS") == OTHER
+        assert saved.get("GATEWAY_ALLOWED_USERS") == "999888777666555444"
+        assert BANNED not in os.environ["GATEWAY_ALLOWED_USERS"]
+        # Deny-store backstop recorded.
+        assert moderation_sync.deny_store().is_denied(BANNED)
+
+    def test_never_paired_allowlisted_user_still_gets_env_prune(
+        self, monkeypatch, pairing_store_mock, env_persistence_mock
+    ):
+        """PairingStore.revoke returns False for a never-paired user — its
+        internal allowlist sync never fires. The public helper must prune the
+        .env allowlist anyway."""
+        pairing_store_mock.revoke.return_value = False
+        adapter = _bare_adapter(allowed_users={BANNED})
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", BANNED)
+
+        moderation_sync.revoke_user_authorization(adapter, BANNED, "ban", "g1")
+
+        # Empty remainder → remove_env_value path.
+        removed = [call.args[0] for call in env_persistence_mock.remove.call_args_list]
+        assert "DISCORD_ALLOWED_USERS" in removed
+
+    def test_revocation_is_idempotent(
+        self, monkeypatch, pairing_store_mock, env_persistence_mock
+    ):
+        """Ban fires both on_member_ban and (in remove mode)
+        on_raw_member_remove — double revocation must be harmless."""
+        adapter = _bare_adapter(allowed_users={BANNED, OTHER})
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", f"{BANNED},{OTHER}")
+
+        moderation_sync.revoke_user_authorization(adapter, BANNED, "ban", "g1")
+        moderation_sync.revoke_user_authorization(adapter, BANNED, "remove", "g1")
+
+        assert moderation_sync.deny_store().is_denied(BANNED)
+        assert OTHER in adapter._allowed_user_ids
+
+    def test_pruning_last_user_logs_critical_and_stays_denied(
+        self, monkeypatch, pairing_store_mock, env_persistence_mock, caplog
+    ):
+        """Emptying the allowlist changes the auth-gate shape (channel
+        bypass / ALLOW_ALL branch) — operators must be alerted, and the
+        banned uid must stay blocked by the deny store regardless."""
+        adapter = _bare_adapter(allowed_users={BANNED})
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", BANNED)
+
+        with caplog.at_level("CRITICAL"):
+            moderation_sync.revoke_user_authorization(adapter, BANNED, "ban", "g1")
+
+        assert any(r.levelname == "CRITICAL" for r in caplog.records)
+        # Even with the gate shape changed to allow-all, THIS uid stays out.
+        monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+        assert adapter._is_allowed_user(BANNED) is False
+
+
+# ---------------------------------------------------------------------------
+# Deny beats every allow branch
+# ---------------------------------------------------------------------------
+
+
+class TestDenyBeatsAllow:
+    def test_hsm_readd_scenario_still_denied(self, pairing_store_mock):
+        """The HSM console's stale whole-document save re-writes
+        DISCORD_ALLOWED_USERS with the banned uid back in. The deny store
+        must still block them."""
+        moderation_sync.deny_store().add(BANNED, "ban", "g1")
+        adapter = _bare_adapter(allowed_users={BANNED})  # console re-granted
+
+        assert adapter._is_allowed_user(BANNED) is False
+        assert adapter._is_allowed_user(OTHER) is False  # not in list either
+
+    def test_deny_beats_pairing(self, pairing_store_mock):
+        pairing_store_mock.is_approved.return_value = True
+        adapter = _bare_adapter()
+        # Sanity: pairing alone authorizes.
+        assert adapter._is_allowed_user(BANNED) is True
+
+        moderation_sync.deny_store().add(BANNED, "ban", "g1")
+        assert adapter._is_allowed_user(BANNED) is False
+
+    def test_deny_beats_allow_all(self, monkeypatch, pairing_store_mock):
+        monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+        adapter = _bare_adapter()
+        assert adapter._is_allowed_user(BANNED) is True  # sanity
+
+        moderation_sync.deny_store().add(BANNED, "ban", "g1")
+        assert adapter._is_allowed_user(BANNED) is False
+        assert adapter._is_allowed_user(OTHER) is True  # others unaffected
+
+    @staticmethod
+    def _interaction(uid):
+        return SimpleNamespace(user=SimpleNamespace(id=int(uid), roles=[]))
+
+    def test_component_deny_beats_allow_all(self, monkeypatch, pairing_store_mock):
+        monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+        moderation_sync.deny_store().add(BANNED, "ban", "g1")
+
+        assert _component_check_auth(self._interaction(BANNED), set(), set()) is False
+        assert _component_check_auth(self._interaction(OTHER), set(), set()) is True
+
+    def test_component_deny_beats_gateway_allowed_users_union(
+        self, monkeypatch, pairing_store_mock
+    ):
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", BANNED)
+        assert _component_check_auth(self._interaction(BANNED), set(), set()) is True  # sanity
+
+        moderation_sync.deny_store().add(BANNED, "ban", "g1")
+        assert _component_check_auth(self._interaction(BANNED), set(), set()) is False
+
+    def test_component_deny_beats_explicit_user_allowlist(
+        self, pairing_store_mock
+    ):
+        moderation_sync.deny_store().add(BANNED, "ban", "g1")
+        assert (
+            _component_check_auth(self._interaction(BANNED), {BANNED}, set()) is False
+        )
+
+    def test_deny_store_remove_restores_access(self, monkeypatch, pairing_store_mock):
+        """Operator un-ban path: DenyStore.remove lifts the block."""
+        monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+        adapter = _bare_adapter()
+        moderation_sync.deny_store().add(BANNED, "ban", "g1")
+        assert adapter._is_allowed_user(BANNED) is False
+
+        assert moderation_sync.deny_store().remove(BANNED) is True
+        assert adapter._is_allowed_user(BANNED) is True
+
+
+# ---------------------------------------------------------------------------
+# Handler registration + intents per mode (full connect with a fake bot)
+# ---------------------------------------------------------------------------
+
+
+class _FakeTree:
+    def __init__(self):
+        self.sync = AsyncMock(return_value=[])
+        self.fetch_commands = AsyncMock(return_value=[])
+
+    def command(self, *args, **kwargs):
+        return lambda fn: fn
+
+    def get_commands(self, *args, **kwargs):
+        return []
+
+
+class _FakeBot:
+    def __init__(self, *, intents, allowed_mentions=None, **_):
+        self.intents = intents
+        self.allowed_mentions = allowed_mentions
+        self.application_id = 999
+        self.user = SimpleNamespace(id=999, name="Hermes")
+        self._events = {}
+        self.tree = _FakeTree()
+
+    def event(self, fn):
+        self._events[fn.__name__] = fn
+        return fn
+
+    async def start(self, token):
+        if "on_ready" in self._events:
+            await self._events["on_ready"]()
+
+    async def close(self):
+        return None
+
+    def is_closed(self):
+        return False
+
+
+async def _connect_adapter(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(
+        message_content=False,
+        dm_messages=False,
+        guild_messages=False,
+        members=False,
+        voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    created = {}
+
+    def fake_bot_factory(*, command_prefix, intents, proxy=None, allowed_mentions=None, **_):
+        created["bot"] = _FakeBot(intents=intents, allowed_mentions=allowed_mentions)
+        return created["bot"]
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", fake_bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    ok = await adapter.connect()
+    assert ok is True
+    return adapter, created["bot"]
+
+
+class TestHandlerRegistration:
+    @pytest.mark.asyncio
+    async def test_mode_off_registers_no_moderation_handlers(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_MODERATION_SYNC", "off")
+        adapter, bot = await _connect_adapter(monkeypatch)
+        try:
+            assert "on_member_ban" not in bot._events
+            assert "on_raw_member_remove" not in bot._events
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_default_mode_ban_registers_ban_only(self, monkeypatch):
+        """Default (env unset) is 'ban': bans propagate with default intents;
+        GUILD_MEMBER_REMOVE is NOT subscribed (kick/leave don't revoke)."""
+        adapter, bot = await _connect_adapter(monkeypatch)
+        try:
+            assert "on_member_ban" in bot._events
+            assert "on_raw_member_remove" not in bot._events
+            assert bot.intents.members is False, (
+                "'ban' mode must not request the privileged members intent "
+                "(portal-dependent boot risk)"
+            )
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_mode_remove_registers_both_and_requests_members_intent(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("DISCORD_MODERATION_SYNC", "remove")
+        adapter, bot = await _connect_adapter(monkeypatch)
+        try:
+            assert "on_member_ban" in bot._events
+            assert "on_raw_member_remove" in bot._events
+            assert bot.intents.members is True, (
+                "'remove' mode needs the Server Members intent for "
+                "GUILD_MEMBER_REMOVE"
+            )
+        finally:
+            await adapter.disconnect()
+
+
+class TestHandlerBehavior:
+    @pytest.mark.asyncio
+    async def test_ban_event_revokes(self, monkeypatch):
+        adapter, bot = await _connect_adapter(monkeypatch)
+        calls = []
+        monkeypatch.setattr(
+            discord_platform._moderation_sync,
+            "revoke_user_authorization",
+            lambda a, uid, reason, gid: calls.append((uid, reason, gid)),
+        )
+        try:
+            await bot._events["on_member_ban"](
+                SimpleNamespace(id=int("123456789012345678")),
+                SimpleNamespace(id=int(BANNED)),
+            )
+            assert calls == [(BANNED, "ban", "123456789012345678")]
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_exempt_uid_never_revoked(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_MODERATION_SYNC_EXEMPT", BANNED)
+        adapter, bot = await _connect_adapter(monkeypatch)
+        calls = []
+        monkeypatch.setattr(
+            discord_platform._moderation_sync,
+            "revoke_user_authorization",
+            lambda a, uid, reason, gid: calls.append(uid),
+        )
+        try:
+            await bot._events["on_member_ban"](
+                SimpleNamespace(id=1), SimpleNamespace(id=int(BANNED))
+            )
+            assert calls == []
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_sync_guilds_filter_honored(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_MODERATION_SYNC_GUILDS", "123")
+        adapter, bot = await _connect_adapter(monkeypatch)
+        calls = []
+        monkeypatch.setattr(
+            discord_platform._moderation_sync,
+            "revoke_user_authorization",
+            lambda a, uid, reason, gid: calls.append(gid),
+        )
+        try:
+            # Ban in a non-synced guild: ignored.
+            await bot._events["on_member_ban"](
+                SimpleNamespace(id=999), SimpleNamespace(id=int(BANNED))
+            )
+            assert calls == []
+            # Ban in the synced guild: propagates.
+            await bot._events["on_member_ban"](
+                SimpleNamespace(id=123), SimpleNamespace(id=int(BANNED))
+            )
+            assert calls == ["123"]
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_ban_and_remove_double_fire_is_idempotent(
+        self, monkeypatch, pairing_store_mock, env_persistence_mock
+    ):
+        """A ban in 'remove' mode fires BOTH events; the second revocation
+        must be a harmless no-op on top of the first."""
+        monkeypatch.setenv("DISCORD_MODERATION_SYNC", "remove")
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", f"{BANNED},{OTHER}")
+        adapter, bot = await _connect_adapter(monkeypatch)
+        adapter._allowed_user_ids = {BANNED, OTHER}
+        try:
+            await bot._events["on_member_ban"](
+                SimpleNamespace(id=123), SimpleNamespace(id=int(BANNED))
+            )
+            await bot._events["on_raw_member_remove"](
+                SimpleNamespace(user=SimpleNamespace(id=int(BANNED)), guild_id=123)
+            )
+            assert moderation_sync.deny_store().is_denied(BANNED)
+            assert adapter._is_allowed_user(BANNED) is False
+            assert OTHER in adapter._allowed_user_ids
+        finally:
+            await adapter.disconnect()

--- a/tests/gateway/test_inbound_throttle.py
+++ b/tests/gateway/test_inbound_throttle.py
@@ -257,6 +257,46 @@ class TestSpend:
         t.record_spend(1.23, "unknown")
         assert _read_ledger()["spend_usd"] == pytest.approx(0.25)
 
+    def test_session_spend_charges_delta_not_cumulative(self, monkeypatch):
+        """estimated_cost_usd is the agent's CUMULATIVE session total.
+
+        Regression: charging the running total every turn sums 0.10 + 0.30 +
+        0.60 = 1.00 instead of the real 0.60, overcounting quadratically and
+        tripping the daily ceiling on ordinary single-operator sessions."""
+        t = InboundThrottle()
+        t.record_session_spend("discord:c1", 0.10, "estimated")
+        t.record_session_spend("discord:c1", 0.30, "estimated")
+        t.record_session_spend("discord:c1", 0.60, "estimated")
+        assert _read_ledger()["spend_usd"] == pytest.approx(0.60)
+
+    def test_session_spend_baselines_are_per_session(self, monkeypatch):
+        t = InboundThrottle()
+        t.record_session_spend("discord:c1", 0.10, "estimated")
+        t.record_session_spend("discord:c2", 0.10, "estimated")
+        assert _read_ledger()["spend_usd"] == pytest.approx(0.20)
+
+    def test_session_spend_reset_agent_charges_fresh_total(self, monkeypatch):
+        """A rebuilt/reset agent restarts its cumulative total from zero —
+        the smaller fresh total must be charged whole, not skipped."""
+        t = InboundThrottle()
+        t.record_session_spend("discord:c1", 0.50, "estimated")
+        t.record_session_spend("discord:c1", 0.20, "estimated")  # agent reset
+        assert _read_ledger()["spend_usd"] == pytest.approx(0.70)
+
+    def test_session_spend_non_numeric_falls_back(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_FALLBACK_TURN_COST_USD", "0.25")
+        t = InboundThrottle()
+        t.record_session_spend("discord:c1", None, None)
+        assert _read_ledger()["spend_usd"] == pytest.approx(0.25)
+
+    def test_session_spend_unchanged_total_charges_fallback(self, monkeypatch):
+        """A turn whose priced delta is zero is still not free."""
+        monkeypatch.setenv("GATEWAY_THROTTLE_FALLBACK_TURN_COST_USD", "0.25")
+        t = InboundThrottle()
+        t.record_session_spend("discord:c1", 0.10, "estimated")
+        t.record_session_spend("discord:c1", 0.10, "estimated")
+        assert _read_ledger()["spend_usd"] == pytest.approx(0.35)
+
     def test_spend_persists_across_restart(self, monkeypatch):
         monkeypatch.setenv("GATEWAY_THROTTLE_DAILY_SPEND_USD", "0.10")
         t1 = InboundThrottle()

--- a/tests/gateway/test_inbound_throttle.py
+++ b/tests/gateway/test_inbound_throttle.py
@@ -1,0 +1,303 @@
+"""Security tests: R6 inbound turn throttle + daily ceilings (pure module).
+
+An unauthenticated flood of inbound messages (a Discord raid, a compromised
+allowlisted account, a runaway bot loop) must not be able to spawn unbounded
+LLM turns or unbounded spend. These tests pin the fail-closed contract of
+``gateway.inbound_throttle``:
+
+  - per-user and per-scope sliding windows bind independently;
+  - the daily turn/spend ceilings persist across process restarts;
+  - a corrupt or unreadable ledger DENIES (a broken limiter must never
+    become an open gate);
+  - unknown per-turn pricing still consumes budget via the fallback cost;
+  - malformed env overrides fall back to the conservative defaults instead
+    of disabling enforcement.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+from gateway.inbound_throttle import InboundThrottle, Verdict
+from hermes_constants import get_hermes_home
+
+
+@pytest.fixture(autouse=True)
+def _enable_throttle(monkeypatch):
+    """The hermetic suite disables the throttle globally; opt back in here."""
+    monkeypatch.setenv("GATEWAY_THROTTLE_ENABLED", "true")
+    for var in (
+        "GATEWAY_THROTTLE_USER_PER_MINUTE",
+        "GATEWAY_THROTTLE_USER_PER_HOUR",
+        "GATEWAY_THROTTLE_SCOPE_PER_MINUTE",
+        "GATEWAY_THROTTLE_SCOPE_PER_HOUR",
+        "GATEWAY_THROTTLE_DAILY_TURN_CEILING",
+        "GATEWAY_THROTTLE_DAILY_SPEND_USD",
+        "GATEWAY_THROTTLE_FALLBACK_TURN_COST_USD",
+        "GATEWAY_THROTTLE_EXEMPT_USERS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _ledger_path():
+    return get_hermes_home() / "throttle" / "ledger.json"
+
+
+def _read_ledger():
+    return json.loads(_ledger_path().read_text(encoding="utf-8"))
+
+
+def _write_ledger(data):
+    path = _ledger_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Sliding windows
+# ---------------------------------------------------------------------------
+
+
+class TestSlidingWindows:
+    def test_user_window_allows_n_then_denies(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "3")
+        t = InboundThrottle()
+        for _ in range(3):
+            assert t.check_and_consume("discord", "u1", "g1").allowed
+        v = t.check_and_consume("discord", "u1", "g1")
+        assert not v.allowed
+        assert v.reason == "user_rate_per_minute"
+
+    def test_user_hour_window(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "100")
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_HOUR", "2")
+        t = InboundThrottle()
+        assert t.check_and_consume("discord", "u1", "g1").allowed
+        assert t.check_and_consume("discord", "u1", "g1").allowed
+        v = t.check_and_consume("discord", "u1", "g1")
+        assert not v.allowed
+        assert v.reason == "user_rate_per_hour"
+
+    def test_scope_window_independent_of_user(self, monkeypatch):
+        """Different users in the same guild share the SCOPE window: a raid
+        by many fresh accounts still hits a per-guild ceiling."""
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "100")
+        monkeypatch.setenv("GATEWAY_THROTTLE_SCOPE_PER_MINUTE", "3")
+        t = InboundThrottle()
+        for i in range(3):
+            assert t.check_and_consume("discord", f"user-{i}", "guild-1").allowed
+        v = t.check_and_consume("discord", "user-99", "guild-1")
+        assert not v.allowed
+        assert v.reason == "scope_rate_per_minute"
+        # A different guild is unaffected.
+        assert t.check_and_consume("discord", "user-99", "guild-2").allowed
+
+    def test_different_users_have_independent_user_windows(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "1")
+        monkeypatch.setenv("GATEWAY_THROTTLE_SCOPE_PER_MINUTE", "100")
+        t = InboundThrottle()
+        assert t.check_and_consume("discord", "u1", "g1").allowed
+        assert not t.check_and_consume("discord", "u1", "g1").allowed
+        assert t.check_and_consume("discord", "u2", "g1").allowed
+
+    def test_no_scope_skips_scope_window(self, monkeypatch):
+        """DMs (no scope) are still bound by the user window."""
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "1")
+        t = InboundThrottle()
+        assert t.check_and_consume("discord", "u1", None).allowed
+        assert not t.check_and_consume("discord", "u1", None).allowed
+
+
+# ---------------------------------------------------------------------------
+# Exemptions
+# ---------------------------------------------------------------------------
+
+
+class TestExemptUsers:
+    def test_exempt_user_bypasses_windows_but_not_daily_ceiling(self, monkeypatch):
+        """Break-glass operators skip the anti-flood windows, but the daily
+        ceilings protect the wallet and bind for EVERYONE."""
+        monkeypatch.setenv("GATEWAY_THROTTLE_EXEMPT_USERS", "111,222")
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "1")
+        monkeypatch.setenv("GATEWAY_THROTTLE_SCOPE_PER_MINUTE", "1")
+        monkeypatch.setenv("GATEWAY_THROTTLE_DAILY_TURN_CEILING", "5")
+        t = InboundThrottle()
+        for _ in range(5):
+            assert t.check_and_consume("discord", "111", "g1").allowed
+        v = t.check_and_consume("discord", "111", "g1")
+        assert not v.allowed
+        assert v.reason == "daily_turn_ceiling"
+
+    def test_exempt_user_does_not_consume_scope_window(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_EXEMPT_USERS", "111")
+        monkeypatch.setenv("GATEWAY_THROTTLE_SCOPE_PER_MINUTE", "1")
+        t = InboundThrottle()
+        assert t.check_and_consume("discord", "111", "g1").allowed
+        assert t.check_and_consume("discord", "111", "g1").allowed
+        # Non-exempt user still has a full scope budget.
+        assert t.check_and_consume("discord", "u2", "g1").allowed
+
+
+# ---------------------------------------------------------------------------
+# Daily ceilings (persistent ledger)
+# ---------------------------------------------------------------------------
+
+
+class TestDailyCeilings:
+    def test_daily_turn_ceiling_binds(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_DAILY_TURN_CEILING", "2")
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "100")
+        t = InboundThrottle()
+        assert t.check_and_consume("discord", "u1", None).allowed
+        assert t.check_and_consume("discord", "u2", None).allowed
+        v = t.check_and_consume("discord", "u3", None)
+        assert not v.allowed
+        assert v.reason == "daily_turn_ceiling"
+
+    def test_daily_ceiling_survives_restart(self, monkeypatch):
+        """A fresh InboundThrottle (simulated restart) reads the same ledger —
+        crash-looping the gateway must not reset the daily budget."""
+        monkeypatch.setenv("GATEWAY_THROTTLE_DAILY_TURN_CEILING", "2")
+        t1 = InboundThrottle()
+        assert t1.check_and_consume("discord", "u1", None).allowed
+        assert t1.check_and_consume("discord", "u1", None).allowed
+
+        t2 = InboundThrottle()  # restart
+        v = t2.check_and_consume("discord", "u1", None)
+        assert not v.allowed
+        assert v.reason == "daily_turn_ceiling"
+
+    def test_utc_day_rollover_resets(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_DAILY_TURN_CEILING", "2")
+        _write_ledger({"day": "2000-01-01", "turns": 999, "spend_usd": 999.0})
+        t = InboundThrottle()
+        assert t.check_and_consume("discord", "u1", None).allowed
+        assert _read_ledger()["turns"] == 1
+
+    def test_ledger_turns_persisted_on_allow(self):
+        t = InboundThrottle()
+        assert t.check_and_consume("discord", "u1", None).allowed
+        assert _read_ledger()["turns"] == 1
+        assert oct(os.stat(_ledger_path()).st_mode & 0o777) == oct(0o600) or (
+            sys.platform == "win32"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fail closed
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosed:
+    def test_corrupt_ledger_denies(self):
+        _ledger_path().parent.mkdir(parents=True, exist_ok=True)
+        _ledger_path().write_text("{not json", encoding="utf-8")
+        t = InboundThrottle()
+        v = t.check_and_consume("discord", "u1", "g1")
+        assert not v.allowed
+        assert v.reason == "ledger_error"
+
+    def test_wrong_schema_ledger_denies(self):
+        _write_ledger({"day": "2026-01-01", "turns": "many", "spend_usd": 0.0})
+        # Even a same-day-shaped but schema-invalid ledger denies.
+        t = InboundThrottle()
+        v = t.check_and_consume("discord", "u1", "g1")
+        assert not v.allowed
+        assert v.reason == "ledger_error"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="chmod semantics differ")
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses file modes")
+    def test_unreadable_ledger_denies(self):
+        _write_ledger({"day": "2026-01-01", "turns": 0, "spend_usd": 0.0})
+        os.chmod(_ledger_path(), 0o000)
+        try:
+            t = InboundThrottle()
+            v = t.check_and_consume("discord", "u1", "g1")
+            assert not v.allowed
+            assert v.reason == "ledger_error"
+        finally:
+            os.chmod(_ledger_path(), 0o600)
+
+
+# ---------------------------------------------------------------------------
+# Spend accounting
+# ---------------------------------------------------------------------------
+
+
+class TestSpend:
+    def test_record_spend_accumulates_and_cap_denies(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_DAILY_SPEND_USD", "0.10")
+        t = InboundThrottle()
+        t.record_spend(0.06, "estimated")
+        assert t.check_and_consume("discord", "u1", None).allowed
+        t.record_spend(0.06, "estimated")
+        v = t.check_and_consume("discord", "u1", None)
+        assert not v.allowed
+        assert v.reason == "daily_spend_ceiling"
+
+    def test_none_cost_applies_fallback(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_FALLBACK_TURN_COST_USD", "0.25")
+        t = InboundThrottle()
+        t.record_spend(None, None)
+        assert _read_ledger()["spend_usd"] == pytest.approx(0.25)
+
+    def test_zero_cost_applies_fallback(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_FALLBACK_TURN_COST_USD", "0.25")
+        t = InboundThrottle()
+        t.record_spend(0.0, "estimated")
+        assert _read_ledger()["spend_usd"] == pytest.approx(0.25)
+
+    def test_unknown_status_applies_fallback_even_with_cost(self, monkeypatch):
+        """A cost paired with status 'unknown' is not trusted — the fallback
+        keeps unpriced turns from being free."""
+        monkeypatch.setenv("GATEWAY_THROTTLE_FALLBACK_TURN_COST_USD", "0.25")
+        t = InboundThrottle()
+        t.record_spend(1.23, "unknown")
+        assert _read_ledger()["spend_usd"] == pytest.approx(0.25)
+
+    def test_spend_persists_across_restart(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_DAILY_SPEND_USD", "0.10")
+        t1 = InboundThrottle()
+        t1.record_spend(0.20, "estimated")
+        t2 = InboundThrottle()  # restart
+        v = t2.check_and_consume("discord", "u1", None)
+        assert not v.allowed
+        assert v.reason == "daily_spend_ceiling"
+
+
+# ---------------------------------------------------------------------------
+# Config robustness
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_malformed_env_falls_back_to_default_and_enforces(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "banana")
+        t = InboundThrottle()
+        for _ in range(4):  # default is 4/minute
+            assert t.check_and_consume("discord", "u1", None).allowed
+        v = t.check_and_consume("discord", "u1", None)
+        assert not v.allowed
+        assert v.reason == "user_rate_per_minute"
+
+    def test_negative_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_DAILY_SPEND_USD", "-5")
+        t = InboundThrottle()
+        t.record_spend(5.0, "estimated")
+        # Default cap 10.0 still enforced (5 < 10 → allowed).
+        assert t.check_and_consume("discord", "u1", None).allowed
+
+    def test_disabled_allows_everything(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_ENABLED", "false")
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "0")
+        t = InboundThrottle()
+        for _ in range(20):
+            assert t.check_and_consume("discord", "u1", "g1").allowed
+
+    def test_notify_cooldown(self):
+        t = InboundThrottle()
+        assert t.should_notify("discord:u1")
+        assert not t.should_notify("discord:u1")
+        assert t.should_notify("discord:u2")  # independent per key

--- a/tests/gateway/test_throttle_dispatch.py
+++ b/tests/gateway/test_throttle_dispatch.py
@@ -1,0 +1,180 @@
+"""Security tests: R6 throttle enforcement at the handle_message choke point.
+
+Every platform's inbound-LLM paths converge on
+``BasePlatformAdapter.handle_message`` — direct text, batched-text flush,
+slash dispatch, and thread sessions. These tests pin the dispatch contract:
+
+  - a throttled event never reaches ``_start_session_processing`` (no LLM
+    turn is spawned and nothing is queued);
+  - control commands (/stop, /approve, /new, ...) bypass the throttle so
+    operators can steer during the very flood the throttle is suppressing;
+  - /retry IS throttled (it spawns LLM work);
+  - observe-only events bypass (they never spawn turns);
+  - the denial notice is sent at most once per user per cooldown window —
+    the notice must not amplify the flood.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway import inbound_throttle
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+
+
+class _StubAdapter(BasePlatformAdapter):
+    """Concrete adapter with abstract methods stubbed out."""
+
+    async def connect(self, *, is_reconnect: bool = False):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, text, **kwargs):
+        pass
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="test-token")
+    adapter = _StubAdapter(config, Platform.DISCORD)
+    adapter._busy_text_mode = ""
+    adapter.sent_responses = []
+    adapter.started_sessions = []
+
+    async def _mock_handler(event):
+        cmd = event.get_command()
+        return f"handled:{cmd}" if cmd else f"handled:text:{event.text}"
+
+    adapter._message_handler = _mock_handler
+
+    async def _mock_send_retry(chat_id, content, **kwargs):
+        adapter.sent_responses.append(content)
+
+    adapter._send_with_retry = _mock_send_retry
+
+    def _mock_start(event, session_key):
+        adapter.started_sessions.append(session_key)
+
+    adapter._start_session_processing = _mock_start
+    return adapter
+
+
+def _make_event(text="hello", user_id="u1", chat_id="c1", scope_id="g1"):
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=chat_id,
+        chat_type="group",
+        user_id=user_id,
+        scope_id=scope_id,
+    )
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=source)
+
+
+@pytest.fixture(autouse=True)
+def _throttle_env(monkeypatch):
+    """Enable the throttle (the hermetic suite disables it globally) and give
+    each test a pristine singleton so windows don't leak between tests."""
+    monkeypatch.setenv("GATEWAY_THROTTLE_ENABLED", "true")
+    monkeypatch.setattr(inbound_throttle, "_singleton", inbound_throttle.InboundThrottle())
+
+
+class TestThrottleDispatch:
+    @pytest.mark.asyncio
+    async def test_throttled_event_never_starts_session(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "1")
+        adapter = _make_adapter()
+
+        await adapter.handle_message(_make_event("first"))
+        await adapter.handle_message(_make_event("second — throttled"))
+
+        assert len(adapter.started_sessions) == 1, (
+            "throttled message still reached _start_session_processing"
+        )
+        assert not adapter._pending_messages, (
+            "throttled message was queued instead of dropped"
+        )
+
+    @pytest.mark.asyncio
+    async def test_control_commands_bypass_throttle_when_exhausted(self, monkeypatch):
+        """Operators must be able to /stop and /approve DURING a raid."""
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "0")
+        adapter = _make_adapter()
+        sk = build_session_key(_make_event().source)
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_event("/stop"))
+        assert any("handled:stop" in r for r in adapter.sent_responses), (
+            "/stop was throttled — operators cannot stop the agent mid-flood"
+        )
+
+        adapter._active_sessions[sk] = asyncio.Event()
+        await adapter.handle_message(_make_event("/approve"))
+        assert any("handled:approve" in r for r in adapter.sent_responses)
+
+    @pytest.mark.asyncio
+    async def test_retry_is_throttled(self, monkeypatch):
+        """/retry spawns a fresh LLM turn — it must NOT be exempt."""
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "0")
+        adapter = _make_adapter()
+
+        await adapter.handle_message(_make_event("/retry"))
+
+        assert adapter.started_sessions == []
+        assert not adapter._pending_messages
+
+    @pytest.mark.asyncio
+    async def test_observe_only_bypasses_throttle(self, monkeypatch):
+        """Observe-only events never spawn turns — throttling them would
+        drop transcript context for no cost saving."""
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "0")
+        adapter = _make_adapter()
+        handled = []
+
+        async def _observe_handler(event):
+            handled.append(event.text)
+
+        adapter._message_handler = _observe_handler
+        event = _make_event("observed")
+        event.observe_only = True
+
+        await adapter.handle_message(event)
+
+        assert handled == ["observed"]
+
+    @pytest.mark.asyncio
+    async def test_denial_notice_once_per_cooldown_then_silent(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "0")
+        adapter = _make_adapter()
+
+        for i in range(5):
+            await adapter.handle_message(_make_event(f"flood {i}"))
+
+        assert len(adapter.sent_responses) == 1, (
+            f"expected exactly one throttle notice, got {adapter.sent_responses}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_notice_cooldown_is_per_user(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "0")
+        adapter = _make_adapter()
+
+        await adapter.handle_message(_make_event("a", user_id="u1"))
+        await adapter.handle_message(_make_event("b", user_id="u2"))
+
+        assert len(adapter.sent_responses) == 2
+
+    @pytest.mark.asyncio
+    async def test_disabled_throttle_dispatches_normally(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_THROTTLE_ENABLED", "false")
+        monkeypatch.setenv("GATEWAY_THROTTLE_USER_PER_MINUTE", "0")
+        adapter = _make_adapter()
+
+        await adapter.handle_message(_make_event("hello"))
+
+        assert len(adapter.started_sessions) == 1


### PR DESCRIPTION
Two commits: R6 (inbound throttle + daily ceilings) and R7 (moderation → authorization propagation). Launch hardening for the Discord fleet; R6 is platform-agnostic and covers every adapter.

## Does this change live behaviour today?

**No — nothing changes until this is merged and the fleet is redeployed.** This PR does not deploy anything. Once deployed:

- **R6 activates immediately on every platform adapter** (Discord, Telegram, Signal, ...), default-on. At current single-operator volumes it should never fire (numbers below); `GATEWAY_THROTTLE_ENABLED=false` or `GATEWAY_THROTTLE_EXEMPT_USERS` are the escape hatches.
- **R7 activates in `ban` mode by default**: a guild ban revokes Hermes authorization. No new intents are requested in the default mode, so there is zero boot risk. `remove` mode (kick/leave also revoke) is opt-in and requires enabling the Server Members intent in the Developer Portal **first**.

## R6 — inbound throttle + daily ceiling (fail closed)

New `gateway/inbound_throttle.py`, enforced at the single choke point where an inbound message becomes an LLM turn (`BasePlatformAdapter.handle_message`) — all four Discord inbound paths (direct text, batched-text flush, `_run_simple_slash`, thread sessions) and every other platform adapter converge there.

Check order: enabled → per-user windows → per-scope (guild) windows → daily turn ceiling → daily spend ceiling. **Any ledger read/parse/IO error denies the turn** (fail closed; ERROR logged at most once per minute). Every denial is logged; the user-facing notice is capped at one per user per 60s so the denial path cannot amplify a flood.

Spend is fed from the per-turn agent result (`turn_finalizer`'s `estimated_cost_usd`) at the `update_session` site in `gateway/run.py`. The `SessionStore` cost columns are **not** used — they have no writer (the broken budget path flagged in the audit). Turns with unknown/zero pricing consume a `$0.05` fallback so broken pricing still draws down the budget. No HSM budget-endpoint coupling: the ledger is local, at `{HERMES_HOME}/throttle/ledger.json` (atomic 0600 writes, survives restarts, UTC day rollover).

### Defaults and reasoning

| Limit | Default | Reasoning |
|---|---|---|
| `GATEWAY_THROTTLE_USER_PER_MINUTE` | 4 | A human in conversation with an agent whose turns take 10–60s sends ~1–2 messages/min sustained; 4/min sustained is bot/raid behaviour. Rapid multi-message corrections are merged by the existing text debounce before they become turns. |
| `GATEWAY_THROTTLE_USER_PER_HOUR` | 30 | A heavy human session runs well under 30 turns/hour against a slow agent; 30+/hour sustained from one account is automation. |
| `GATEWAY_THROTTLE_SCOPE_PER_MINUTE` | 12 | Per guild: a raid by many fresh accounts defeats per-user limits; 12 turns/min across a whole server is far above organic single-agent usage and caps raid burn at ~12 turns/min worst case. |
| `GATEWAY_THROTTLE_SCOPE_PER_HOUR` | 120 | Same logic, hour horizon. |
| `GATEWAY_THROTTLE_DAILY_TURN_CEILING` | 300 | Per agent per UTC day, all platforms. Normal daily use is tens of turns; 300 gives ~10x headroom while capping a slow-drip attack. |
| `GATEWAY_THROTTLE_DAILY_SPEND_USD` | 10.0 | Worst-case daily bill per agent even if every other control fails. Six agents → $60/day absolute worst case. |
| `GATEWAY_THROTTLE_FALLBACK_TURN_COST_USD` | 0.05 | Charged when a turn's cost is unknown — unpriced turns are never free. 200 unknown-cost turns exhaust the $10 budget. |

`GATEWAY_THROTTLE_EXEMPT_USERS` (comma snowflakes) skips the user/scope windows only — **daily ceilings bind for everyone**, including operators: they protect the wallet, not the conversation. Control commands (`/stop`, `/new`, `/reset`, `/approve`, `/deny`, `/status`, `/help`) bypass the throttle so operators can steer during the very flood being suppressed; `/retry` and `/steer` spawn LLM work and are throttled. All limits are env-overridable and re-read at check time (container recreates pick up HSM env edits); malformed values fall back to the conservative defaults with one WARNING.

Single-operator impact: at Juniper-talking-to-a-bot volumes none of these fire. If an operator ever trips the per-minute window during a rapid-fire session, the cost is a dropped message plus one notice — and the exempt list removes even that.

## R7 — moderation events propagate to authorization

The adapter previously registered only `on_ready` / `on_message` / `on_voice_state_update` — **it did not receive ban or member-remove events at all** (audit gap #11). A banned user kept DM command access via the pairing store or a stale allowlist.

Now: `on_member_ban` (and `on_raw_member_remove` in `remove` mode) revokes everything, in this order:

1. pairing grant + persisted `.env` allowlist entry — new public `gateway.pairing.revoke_platform_authorization`, which prunes the allowlist even for never-paired users, and runs **before** the in-process env rewrite because `_sync_allowlist_remove` reads `os.getenv`;
2. the adapter's in-memory `_allowed_user_ids` + `os.environ` mirror;
3. an exact `GATEWAY_ALLOWED_USERS` entry (cross-platform var; WARNING logged; snowflakes are 17–19 digits so cross-platform collision risk is nil);
4. a persistent, adapter-owned **deny store** (`{HERMES_HOME}/platforms/discord-denied.json`, atomic 0600), checked at the top of `_is_allowed_user` and `_component_check_auth` — **before pairing, allowlists, `ALLOW_ALL` flags, the `GATEWAY_ALLOWED_USERS` union, and the channel bypass**. Deny beats every allow. This is the backstop against the HSM console's stale whole-document save re-writing `DISCORD_ALLOWED_USERS` and silently re-granting a banned user (audit SB-5/#2).

Revocation is idempotent (a ban double-fires both events in `remove` mode), runs off the event loop, never posts to Discord/Telegram, and logs CRITICAL if the prune empties the user allowlist with no roles configured (the auth gate falls through to channel-bypass/ALLOW_ALL branch semantics — the deny store still blocks the banned uid, but operators must know the gate shape changed).

Config: `DISCORD_MODERATION_SYNC=off|ban|remove` (default `ban`), `DISCORD_MODERATION_SYNC_GUILDS` (empty = all guilds), `DISCORD_MODERATION_SYNC_EXEMPT` (seed with the break-glass operator ids so a test-guild departure can't strand the operators). Only `remove` mode extends the members-intent condition; `ban` mode needs nothing beyond `Intents.default()`. Launch checklist for the six agents if kick/leave propagation is wanted: enable Server Members intent in the portal **first**, then set `remove`.

Kick vs. voluntary leave: `GUILD_MEMBER_REMOVE` cannot distinguish them without audit-log permissions — in `remove` mode both revoke. Documented in the module; operator un-ban is `DenyStore.remove(uid)` (CLI hook-up is follow-up work).

## Tests

Baseline established on `b8aee7f79` **before** any changes: `pytest tests/gateway/ -k discord -q` → **616 passed, 3 skipped, 0 failed**.

After both commits: same subset → **634 passed, 3 skipped, 0 failed** (616 baseline + 18 new). New files: `test_inbound_throttle.py` (23), `test_throttle_dispatch.py` (7), `test_discord_moderation_sync.py` (18) — all green. Full `tests/gateway/` compared branch vs. pristine-baseline worktree (single-process runs, which are NOT the repo's canonical per-file-subprocess runner): branch 20 failed / 9712 passed, baseline 21 failed / 9663 passed — overlapping, order-dependent failure sets (telegram/wecom/channel_directory/etc. cross-file leakage that the per-file runner exists to prevent). Every branch-only failure passes when its file is run in canonical per-file isolation. The one reproducible failure, `test_background_command.py::test_media_files_routed_by_type`, fails identically on pristine `b8aee7f79` — pre-existing, not introduced here. **Zero new failures.**

Note: the hermetic suite disables the throttle globally in `tests/conftest.py` (hundreds of existing tests drive `handle_message` faster than any human); throttle tests opt back in explicitly. Production default remains **on**.

Not done here: no deploy, no merge, no Discord app/portal changes, no live-host writes. All tests run against the shared discord mock and per-test `HERMES_HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
