### PR TITLE
feat(slack,discord): observe-unmentioned parity with Signal/Telegram

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4987,6 +4987,24 @@ class DiscordAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in {"false", "0", "no", "off"}
 
+    def _discord_observe_unmentioned(self) -> bool:
+        """Return whether unmentioned channel messages are ingested as context.
+
+        When true, a message failing the mention gate is recorded into the
+        session transcript (observe_only) for situational awareness rather than
+        dropped — but the agent still does not respond, and no auto-thread is
+        created. Orthogonal to require_mention. Defaults False (opt-in) so
+        existing deployments are unchanged, matching Telegram; operators (e.g.
+        HSM harness settings) opt in per surface via DISCORD_OBSERVE_UNMENTIONED
+        / config extra.observe_unmentioned.
+        """
+        configured = self.config.extra.get("observe_unmentioned")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("DISCORD_OBSERVE_UNMENTIONED", "false").lower() in {"true", "1", "yes", "on"}
+
     def _discord_allow_any_attachment(self) -> bool:
         """Return whether Discord attachments bypass the SUPPORTED_DOCUMENT_TYPES allowlist.
 
@@ -6484,6 +6502,11 @@ class DiscordAdapter(BasePlatformAdapter):
             if _self_role_id:
                 normalized_content = normalized_content.replace(f"<@&{_self_role_id}>", "").strip()
             message.content = normalized_content
+        # Observe-unmentioned: when enabled, a message that fails the mention
+        # gate is ingested into session context (observe_only) instead of
+        # dropped, while the agent still does not respond. Orthogonal to the
+        # mention gate; observe-only messages never spawn an auto-thread.
+        observe_only = False
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}
             if parent_channel_id:
@@ -6532,13 +6555,16 @@ class DiscordAdapter(BasePlatformAdapter):
 
             if require_mention and not is_free_channel and not in_bot_thread:
                 if not self._self_is_explicitly_mentioned(message) and not mention_prefix:
-                    return
+                    if self._discord_observe_unmentioned():
+                        observe_only = True  # ingest as context; still no response
+                    else:
+                        return
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.
         # no_thread_channels: channels where bot responds directly without thread.
         auto_threaded_channel = None
-        if not is_thread and not isinstance(message.channel, discord.DMChannel):
+        if not is_thread and not observe_only and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
             skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
@@ -6908,6 +6934,7 @@ class DiscordAdapter(BasePlatformAdapter):
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
             channel_context=_channel_context,
+            observe_only=observe_only,
         )
 
         # Track thread participation so the bot won't require @mention for

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3373,6 +3373,11 @@ class SlackAdapter(BasePlatformAdapter):
         )
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
+        # Observe-unmentioned: when enabled, an unmentioned channel message is
+        # ingested into session context (observe_only) instead of dropped, while
+        # the agent still does not respond. Orthogonal to the mention gate —
+        # REQUIRE/STRICT_MENTION control the response, this controls the input.
+        observe_only = False
 
         if not is_one_to_one_dm and bot_uid:
             # Check allowed channels — if set, only respond in these channels
@@ -3409,7 +3414,10 @@ class SlackAdapter(BasePlatformAdapter):
             elif not self._slack_require_mention():
                 pass  # Mention requirement disabled globally for Slack
             elif self._slack_strict_mention() and not is_mentioned:
-                return  # Strict mode: ignore until @-mentioned again
+                if self._slack_observe_unmentioned():
+                    observe_only = True  # ingest as context; still no response
+                else:
+                    return  # Strict mode: ignore until @-mentioned again
             elif not is_mentioned:
                 reply_to_bot_thread = (
                     is_thread_reply and event_thread_ts in self._bot_message_ts
@@ -3429,7 +3437,10 @@ class SlackAdapter(BasePlatformAdapter):
                     and not in_mentioned_thread
                     and not has_session
                 ):
-                    return
+                    if self._slack_observe_unmentioned():
+                        observe_only = True  # ingest as context; still no response
+                    else:
+                        return
 
         if is_mentioned:
             # Strip the bot mention from the text
@@ -3802,6 +3813,7 @@ class SlackAdapter(BasePlatformAdapter):
             channel_prompt=_channel_prompt,
             reply_to_text=reply_to_text,
             auto_skill=_auto_skill,
+            observe_only=observe_only,
             metadata={
                 "slack_team_id": team_id,
                 "slack_channel_id": channel_id,
@@ -4817,6 +4829,29 @@ class SlackAdapter(BasePlatformAdapter):
             "0",
             "no",
             "off",
+        }
+
+    def _slack_observe_unmentioned(self) -> bool:
+        """Return whether unmentioned channel messages are ingested as context.
+
+        When true, a message that fails the mention gate is recorded into the
+        session transcript (observe_only) instead of dropped, so the agent has
+        situational awareness — but it still does not respond (the mention gate
+        governs the response). Orthogonal to require_mention/strict_mention.
+        Defaults False (opt-in) so existing deployments are unchanged, matching
+        Telegram; operators (e.g. HSM harness settings) opt in per surface via
+        SLACK_OBSERVE_UNMENTIONED / config extra.observe_unmentioned.
+        """
+        configured = self.config.extra.get("observe_unmentioned")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("SLACK_OBSERVE_UNMENTIONED", "false").lower() in {
+            "true",
+            "1",
+            "yes",
+            "on",
         }
 
     def _slack_strict_mention(self) -> bool:

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -1575,3 +1575,75 @@ async def test_discord_role_mention_without_self_role_still_gated(adapter, monke
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# observe-unmentioned: input/context is orthogonal to the response gate. When
+# enabled, an unmentioned channel message is ingested as observe_only context
+# (no response, no auto-thread). Defaults OFF (opt-in) so existing deployments
+# are unchanged; HSM opts in per surface.
+# ---------------------------------------------------------------------------
+
+def test_discord_observe_unmentioned_defaults_false(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_OBSERVE_UNMENTIONED", raising=False)
+    assert adapter._discord_observe_unmentioned() is False
+
+
+def test_discord_observe_unmentioned_config_true(adapter):
+    adapter.config.extra["observe_unmentioned"] = "true"
+    assert adapter._discord_observe_unmentioned() is True
+
+
+def test_discord_observe_unmentioned_env_true(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_OBSERVE_UNMENTIONED", "true")
+    assert adapter._discord_observe_unmentioned() is True
+
+
+@pytest.mark.asyncio
+async def test_discord_unmentioned_observed_when_enabled(adapter, monkeypatch):
+    """observe on + unmentioned channel msg → ingested observe_only, no response."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_OBSERVE_UNMENTIONED", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    message = make_message(channel=FakeTextChannel(channel_id=777), content="passing chatter")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.observe_only is True
+
+
+@pytest.mark.asyncio
+async def test_discord_unmentioned_dropped_by_default(adapter, monkeypatch):
+    """observe default off → unmentioned channel msg is hard-dropped."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_OBSERVE_UNMENTIONED", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    message = make_message(channel=FakeTextChannel(channel_id=778), content="passing chatter")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_mentioned_is_not_observe_only(adapter, monkeypatch):
+    """A mentioned message is a normal (responded) turn, not observe_only."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_OBSERVE_UNMENTIONED", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=779),
+        content="<@999> hello",
+        mentions=[SimpleNamespace(id=999)],
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.observe_only is False

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -1196,3 +1196,67 @@ def test_mention_patterns_trigger_in_channel_without_literal_mention():
     assert _would_process(adapter, text="hey hermes what's the status") is True
     # Unrelated channel chatter is still ignored.
     assert _would_process(adapter, text="lunch anyone?") is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: observe-unmentioned (_slack_observe_unmentioned + real flow)
+# Observe (input/context) is orthogonal to the mention gate (response): when
+# enabled, an unmentioned channel message is ingested as observe_only context
+# but the bot still does not respond. Defaults OFF (opt-in) so existing
+# deployments are unchanged; HSM opts in per surface.
+# ---------------------------------------------------------------------------
+
+def test_observe_unmentioned_defaults_to_false(monkeypatch):
+    monkeypatch.delenv("SLACK_OBSERVE_UNMENTIONED", raising=False)
+    adapter = _make_adapter()
+    assert adapter._slack_observe_unmentioned() is False
+
+
+def test_observe_unmentioned_config_true():
+    adapter = _make_adapter()
+    adapter.config.extra["observe_unmentioned"] = "true"
+    assert adapter._slack_observe_unmentioned() is True
+
+
+def test_observe_unmentioned_env_true(monkeypatch):
+    monkeypatch.setenv("SLACK_OBSERVE_UNMENTIONED", "true")
+    adapter = _make_adapter()
+    assert adapter._slack_observe_unmentioned() is True
+
+
+def test_observe_unmentioned_malformed_stays_false():
+    """Explicit-true parser: unrecognised values keep observe OFF (opt-in)."""
+    adapter = _make_adapter()
+    adapter.config.extra["observe_unmentioned"] = "maybe"
+    assert adapter._slack_observe_unmentioned() is False
+
+
+@pytest.mark.asyncio
+async def test_unmentioned_message_observed_when_enabled(monkeypatch):
+    """observe on + unmentioned channel msg → dispatched as observe_only."""
+    monkeypatch.setenv("SLACK_OBSERVE_UNMENTIONED", "true")
+    adapter = _make_real_adapter(allowed_channels="*")
+    await adapter._handle_slack_message(_channel_event(CHANNEL_ID, mentioned=False))
+    adapter.handle_message.assert_called_once()
+    msg_event = adapter.handle_message.call_args.args[0]
+    assert msg_event.observe_only is True
+
+
+@pytest.mark.asyncio
+async def test_unmentioned_message_dropped_by_default(monkeypatch):
+    """observe default off → unmentioned channel msg is hard-dropped."""
+    monkeypatch.delenv("SLACK_OBSERVE_UNMENTIONED", raising=False)
+    adapter = _make_real_adapter(allowed_channels="*")
+    await adapter._handle_slack_message(_channel_event(CHANNEL_ID, mentioned=False))
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mentioned_message_is_not_observe_only(monkeypatch):
+    """A mentioned message is a normal (responded) turn, not observe_only."""
+    monkeypatch.setenv("SLACK_OBSERVE_UNMENTIONED", "true")
+    adapter = _make_real_adapter(allowed_channels="*")
+    await adapter._handle_slack_message(_channel_event(CHANNEL_ID, mentioned=True))
+    adapter.handle_message.assert_called_once()
+    msg_event = adapter.handle_message.call_args.args[0]
+    assert msg_event.observe_only is False


### PR DESCRIPTION
Resolves #141. Slack and Discord gain observe-unmentioned, matching Signal/Mattermost/Telegram.

**What:** when enabled, a channel message that fails the mention gate is ingested into session context (`observe_only`) for situational awareness while the agent still does **not** respond. Orthogonal to `REQUIRE_MENTION`/`STRICT_MENTION` (those gate the response; this gates the input).

**How:** reuses the shared `MessageEvent.observe_only` field already consumed centrally at `gateway/run.py` — Slack/Discord previously `return`-and-dropped unmentioned messages; now they set `observe_only=True` and fall through. No new plumbing, no gateway change.

- `SLACK_OBSERVE_UNMENTIONED` / `DISCORD_OBSERVE_UNMENTIONED` (+ config `extra.observe_unmentioned`).
- **Default FALSE (opt-in)** — deliberately: preserves existing behavior for every current deployment, matching Telegram. (Signal/Mattermost default true; we chose opt-in for the framework and let operators/HSM turn it on per surface — see swarm-map#214.)
- Discord: observe-only messages never spawn an auto-thread (guarded). Slack: reactions already gate on mention, so observed messages get no reaction.
- Auth drops (non-allowed / ignored channels) remain hard drops — only the mention gate becomes an observe fall-through.

**Tests:** helper parsing + real message-flow for both adapters (observe_only True when enabled; hard-dropped by default; mentioned messages stay observe_only=False). Full Slack+Discord gating suites: 174 passed.

Note: shipping to the fleet needs an image rebuild+redeploy (the running image predates this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)