### PR TITLE
fix(git-auth): refresh gh credentials on the token's lifetime, not the file's existence

### DIFF
--- a/hermes_cli/git_credentials_boot.py
+++ b/hermes_cli/git_credentials_boot.py
@@ -24,22 +24,58 @@ Mirrors ``container_boot.py``: a pure, per-home function plus a profile-aware
 ``provision_all`` and a ``main()`` entry point wired into the image as a
 cont-init.d hook. No HSM dependence on a runtime-internal path — the runtime
 owns the path now.
+
+**Manage-if-ours, not apply-if-absent.** Provisioning originally refused to
+touch any file that already existed, so that a human's own ``.gitconfig`` was
+never clobbered. The rule is right; the test was wrong. "Does a file exist
+here?" cannot distinguish someone else's config from our own stale output, so
+every file this module wrote became permanent on the first boot that wrote it:
+an installation token good for ~1h froze into ``hosts.yml`` for weeks, and a
+git identity resolved before ``HERMES_AGENT_NAME`` was consulted kept authoring
+commits as "data" long after the resolution was fixed. Files are now stamped
+with :data:`MANAGED_MARKER`, ownership is the gate, and a file we own is
+reconciled to current content on every boot. Credentials that carry an expiry
+additionally record it (``# token-expires-at:``) so refresh is driven by the
+token's lifetime rather than by the container's.
 """
 from __future__ import annotations
 
 import os
 import re
 import sys
+import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-from hermes_cli.github_app_token import get_installation_token, read_app_credentials
+from hermes_cli.github_app_token import (
+    get_installation_token_detail,
+    read_app_credentials,
+)
 
 GIT_HOST = "github.com"
 
 # Checked in order; a dedicated GITHUB_PAT wins over the copilot GITHUB_TOKEN.
 TOKEN_VARS = ("GITHUB_PAT", "GITHUB_TOKEN", "GH_TOKEN")
+
+# Stamped as the first line of every file this module owns. It is what lets
+# provisioning be *manage-if-ours* rather than *apply-if-absent*: a file we
+# wrote is kept current on every boot; a file we did not write is never
+# touched. Both `.gitconfig` (INI) and `hosts.yml` (YAML) treat `#` as a
+# comment, so the marker is inert to git and gh.
+MANAGED_MARKER = "# managed-by: hermes git_credentials_boot"
+
+# Prefix of the expiry stamp written into an App-mode ``hosts.yml``. `gh` has
+# no credential-helper hook, so its token is a value at rest with a ~1h life.
+# Recording the death time next to it is what makes "this credential is dead"
+# an inspectable fact instead of a silent 401.
+GH_EXPIRY_STAMP_PREFIX = "# token-expires-at: "
+
+# Rewrite an App-mode ``hosts.yml`` once it is within this many seconds of its
+# recorded expiry. Matches ``github_app_token.REMINT_MARGIN_SECONDS`` so the
+# file and the mint cache roll over together.
+GH_HOSTS_REFRESH_MARGIN_SECONDS = 600
 
 
 # ---------------------------------------------------------------------------
@@ -56,6 +92,7 @@ def build_git_config_content(*, name: str, email: str) -> str:
     """Minimal ``~/.gitconfig``: store helper + identity + ssh→https rewrites."""
     return "\n".join(
         [
+            MANAGED_MARKER,
             "[credential]",
             "\thelper = store",
             "[user]",
@@ -85,6 +122,7 @@ def build_git_config_content_app(
     """
     return "\n".join(
         [
+            MANAGED_MARKER,
             "[credential]",
             "\thelper =",
             f'\thelper = "!{python_exe} -m {module} get-credential"',
@@ -99,7 +137,7 @@ def build_git_config_content_app(
     )
 
 
-def build_gh_hosts_content(token: str) -> str:
+def build_gh_hosts_content(token: str, *, expires_at: Optional[str] = None) -> str:
     """The ``~/.config/gh/hosts.yml`` the GitHub CLI reads for HTTPS auth.
 
     Same rationale as the git credential file: ``gh`` runs in the tool
@@ -107,15 +145,117 @@ def build_gh_hosts_content(token: str) -> str:
     only way ``gh`` can authenticate. Without this, ``git`` worked from agent
     tools but ``gh`` reported "not logged in" — leaving half the GitHub surface
     unusable to the agent.
+
+    ``expires_at`` (App mode) is stamped as a YAML comment so the file carries
+    its own death date. A PAT has no expiry the runtime can know, so it is
+    stamped only when supplied.
     """
-    return "\n".join(
-        [
-            f"{GIT_HOST}:",
-            f"    oauth_token: {token}",
-            "    git_protocol: https",
-            "    user: x-access-token",
-            "",
-        ]
+    lines = [MANAGED_MARKER]
+    if expires_at:
+        lines.append(f"{GH_EXPIRY_STAMP_PREFIX}{expires_at}")
+    lines += [
+        f"{GIT_HOST}:",
+        f"    oauth_token: {token}",
+        "    git_protocol: https",
+        "    user: x-access-token",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Ownership + staleness — the two predicates that replace "does the file exist"
+# ---------------------------------------------------------------------------
+
+# Shape fingerprints for files written by builds that predate MANAGED_MARKER.
+# Without these, every already-deployed agent would look "foreign" forever and
+# never heal — the fossil would simply be frozen by the fix instead of thawed.
+_LEGACY_GITCONFIG_SIGNS = (
+    f"insteadOf = git@{GIT_HOST}:",
+    f"insteadOf = ssh://git@{GIT_HOST}/",
+)
+_LEGACY_GH_HOSTS_SIGN = "user: x-access-token"
+
+
+def is_managed_gitconfig(text: str) -> bool:
+    """True when ``text`` is a ``.gitconfig`` this module owns.
+
+    Ownership, not absence, is what licenses a rewrite. A human's own
+    ``.gitconfig`` (or an imported agent's) is left strictly alone; one we
+    generated is ours to keep current — which is how a fossilized
+    ``name = data`` identity gets corrected on the next boot instead of
+    surviving forever behind an existence check.
+    """
+    if MANAGED_MARKER in text:
+        return True
+    return all(sign in text for sign in _LEGACY_GITCONFIG_SIGNS) and (
+        "helper = store" in text or "hermes_cli.github_app_token" in text
+    )
+
+
+def is_managed_gh_hosts(text: str) -> bool:
+    """True when ``text`` is a ``hosts.yml`` this module owns."""
+    return MANAGED_MARKER in text or _LEGACY_GH_HOSTS_SIGN in text
+
+
+def is_managed_git_credentials(text: str) -> bool:
+    """True when ``text`` is a ``.git-credentials`` this module owns.
+
+    No marker here: git's ``store`` helper parses the file as one credential
+    URL per line, so a comment is not safely inert. The generated line is its
+    own fingerprint — only this module writes the ``x-access-token`` username,
+    a human's own file carries their login.
+    """
+    return any(
+        line.strip().startswith("https://x-access-token:")
+        and line.strip().endswith(f"@{GIT_HOST}")
+        for line in text.splitlines()
+    )
+
+
+def read_gh_hosts_expiry(text: str) -> Optional[str]:
+    """The ISO expiry stamped into a managed ``hosts.yml``, if any."""
+    m = re.search(
+        rf"^{re.escape(GH_EXPIRY_STAMP_PREFIX)}(\S+)\s*$", text, re.MULTILINE
+    )
+    return m.group(1) if m else None
+
+
+def gh_hosts_needs_refresh(
+    text: Optional[str], *, now: Optional[float] = None
+) -> bool:
+    """Should this ``hosts.yml`` be re-minted and rewritten?
+
+    The lifetime question, asked of the file itself:
+
+    * absent → yes (nothing to serve)
+    * not ours → no (never touch a file we do not own)
+    * ours but unstamped → yes. Every file written before this change is in
+      this bucket, and each one holds a token that died within an hour of
+      being written. "Unknown lifetime" must mean refresh, not skip.
+    * ours and stamped → yes once inside ``GH_HOSTS_REFRESH_MARGIN_SECONDS``
+      of the recorded expiry.
+    """
+    if text is None:
+        return True
+    if not is_managed_gh_hosts(text):
+        return False
+    stamped = read_gh_hosts_expiry(text)
+    if not stamped:
+        return True
+    try:
+        expiry = _parse_iso_z(stamped)
+    except ValueError:
+        return True  # unparseable stamp = unknown lifetime = refresh
+    reference = time.time() if now is None else now
+    return expiry - reference <= GH_HOSTS_REFRESH_MARGIN_SECONDS
+
+
+def _parse_iso_z(value: str) -> float:
+    return (
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+        .replace(tzinfo=timezone.utc)
+        .timestamp()
     )
 
 
@@ -154,6 +294,10 @@ class ProvisionResult:
     provisioned: bool
     reason: Optional[str] = None
     source: Optional[str] = None
+    # The git author identity actually written. Reported at boot because
+    # "commits are authored as data@users.noreply.github.com" was invisible
+    # from inside the container for weeks — nothing ever said which name won.
+    identity: Optional[str] = None
 
 
 def provision_git_credentials(
@@ -169,8 +313,11 @@ def provision_git_credentials(
     root and the tool subprocess HOME at ``{home_dir}/home``. Idempotent;
     a no-op (``provisioned=False``) when no token is configured.
 
-    Apply-if-absent: never clobbers an existing ``.git-credentials`` /
-    ``.gitconfig`` (e.g. an imported agent's own setup) unless ``force``.
+    Manage-if-ours: a file this module wrote is reconciled to current content
+    on every boot (rotated token, corrected identity); a file it did not write
+    is never touched unless ``force``. The previous apply-if-absent rule could
+    not tell those two cases apart, so it protected the fleet's own fossils as
+    carefully as it protected a human's config.
     """
     subprocess_home = home_dir / "home"
     cred_path = subprocess_home / ".git-credentials"
@@ -199,33 +346,60 @@ def provision_git_credentials(
         return ProvisionResult(home_dir, False, reason="no GitHub token configured")
     token, source = found
 
-    # git and gh are provisioned INDEPENDENTLY (apply-if-absent each). An agent
-    # provisioned by an older build has git set up but no gh hosts.yml — gating
-    # both on "git present" left gh permanently unconfigured. Writing them
-    # separately heals that on the next boot without clobbering a user's setup.
+    # git and gh are provisioned INDEPENDENTLY. An agent provisioned by an older
+    # build may have git set up but no gh hosts.yml — gating both on "git
+    # present" left gh permanently unconfigured. Each is reconciled on its own.
+    #
+    # A rotated PAT is the same fossil class as an expired App token: the .env
+    # gets the new value, and under apply-if-absent the credential files kept
+    # serving the old one until someone deleted them by hand. Reconciling
+    # against desired content fixes rotation for free.
+    subprocess_home.mkdir(parents=True, exist_ok=True)
     wrote: list[str] = []
-    if force or not (cred_path.exists() or cfg_path.exists()):
-        subprocess_home.mkdir(parents=True, exist_ok=True)
-        _write_file(cred_path, build_git_credentials_content(token), mode=0o600)
-        _write_file(
+
+    git_writes = [
+        _write_managed(
+            cred_path,
+            build_git_credentials_content(token),
+            mode=0o600,
+            owned=is_managed_git_credentials,
+            force=force,
+        ),
+        _write_managed(
             cfg_path,
             build_git_config_content(name=resolved_name, email=resolved_email),
             mode=0o644,
-        )
+            owned=is_managed_gitconfig,
+            force=force,
+        ),
+    ]
+    if any(git_writes):
         wrote.append("git")
-    if force or not gh_hosts_path.exists():
-        gh_hosts_path.parent.mkdir(parents=True, exist_ok=True)
-        _write_file(gh_hosts_path, build_gh_hosts_content(token), mode=0o600)
+
+    if _write_managed(
+        gh_hosts_path,
+        build_gh_hosts_content(token),
+        mode=0o600,
+        owned=is_managed_gh_hosts,
+        force=force,
+    ):
         wrote.append("gh")
 
     if not wrote:
         return ProvisionResult(
             home_dir,
             False,
-            reason="git+gh already present (pass force to overwrite)",
+            reason="git+gh already current",
             source=source,
+            identity=resolved_name,
         )
-    return ProvisionResult(home_dir, True, reason="wrote " + "+".join(wrote), source=source)
+    return ProvisionResult(
+        home_dir,
+        True,
+        reason="wrote " + "+".join(wrote),
+        source=source,
+        identity=resolved_name,
+    )
 
 
 def _provision_app_mode(
@@ -238,55 +412,195 @@ def _provision_app_mode(
     email: str,
     force: bool,
 ) -> ProvisionResult:
-    """Provision GitHub App auth: helper-based ``.gitconfig`` + boot-fresh ``gh``.
+    """Provision GitHub App auth: helper-based ``.gitconfig`` + a lifetime-refreshed ``gh``.
 
     No ``.git-credentials`` is written — in App mode there is no long-lived
-    token to store; git mints one per ``credential fill``. ``gh`` reads a static
-    ``hosts.yml`` and has no credential-helper hook, so it gets one token minted
-    at boot (documented tradeoff: ``gh`` is boot-fresh, ``git`` is always-fresh).
+    token to store; git mints one per ``credential fill``. ``gh`` has no
+    credential-helper hook, so its ``hosts.yml`` holds a real ~1h token at rest.
+    That file is therefore refreshed against its **recorded expiry**, not
+    against its existence: gating on ``not gh_hosts_path.exists()`` meant the
+    first boot's token was the only one an agent ever got, and every container
+    that had booted once was pinned to a credential that died an hour later.
     """
+    subprocess_home.mkdir(parents=True, exist_ok=True)
     wrote: list[str] = []
 
-    if force or not cfg_path.exists():
-        subprocess_home.mkdir(parents=True, exist_ok=True)
-        _write_file(
-            cfg_path,
-            build_git_config_content_app(
-                name=name, email=email, python_exe=sys.executable
-            ),
-            mode=0o644,
-        )
+    if _write_managed(
+        cfg_path,
+        build_git_config_content_app(
+            name=name, email=email, python_exe=sys.executable
+        ),
+        mode=0o644,
+        owned=is_managed_gitconfig,
+        force=force,
+    ):
         wrote.append("git(app)")
 
-    if force or not gh_hosts_path.exists():
+    existing = _read_text(gh_hosts_path)
+    if force or gh_hosts_needs_refresh(existing):
         # Best-effort: a mint failure (network, bad key) must not break boot —
-        # git still works via the helper, which retries on every invocation.
+        # git still works via the helper, which retries on every invocation,
+        # and gh is covered at the env boundary by the GH_TOKEN injection in
+        # tools/environments/local.py.
         try:
-            token = get_installation_token(home_dir, force=True)
-        except Exception as exc:  # pragma: no cover - defensive
-            token = None
+            detail = get_installation_token_detail(home_dir)
+        except Exception as exc:
+            detail = None
             print(f"git-credentials: gh token mint failed ({exc})")
-        if token:
-            gh_hosts_path.parent.mkdir(parents=True, exist_ok=True)
-            _write_file(gh_hosts_path, build_gh_hosts_content(token), mode=0o600)
-            wrote.append("gh")
+        if detail and _write_managed(
+            gh_hosts_path,
+            build_gh_hosts_content(detail.token, expires_at=detail.expires_at),
+            mode=0o600,
+            owned=is_managed_gh_hosts,
+            force=force,
+        ):
+            wrote.append(f"gh(expires {detail.expires_at})")
+        elif detail is None and existing is not None:
+            # Say it out loud rather than leaving a dead credential in place
+            # with a silent boot log — the exact failure mode this fixes.
+            print(
+                f"git-credentials: WARNING stale gh hosts.yml left in place at "
+                f"{gh_hosts_path} (mint unavailable); gh falls back to the "
+                f"GH_TOKEN injected per subprocess"
+            )
 
     if not wrote:
         return ProvisionResult(
             home_dir,
             False,
-            reason="git+gh already present (pass force to overwrite)",
+            reason="git+gh already current",
             source="GITHUB_APP",
+            identity=name,
         )
     return ProvisionResult(
-        home_dir, True, reason="wrote " + "+".join(wrote), source="GITHUB_APP"
+        home_dir,
+        True,
+        reason="wrote " + "+".join(wrote),
+        source="GITHUB_APP",
+        identity=name,
     )
+
+
+def _read_text(path: Path) -> Optional[str]:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _write_managed(
+    path: Path,
+    content: str,
+    *,
+    mode: int,
+    owned,
+    force: bool = False,
+) -> bool:
+    """Reconcile ``path`` to ``content``. Returns True when it wrote.
+
+    The single ownership rule for every credential file this module produces:
+
+    * absent → write
+    * present, ``owned(text)`` false → leave alone (a human's or an imported
+      agent's config; ``force`` overrides)
+    * present, ours, content already equal → no write (keeps boot idempotent
+      and mtimes honest)
+    * present, ours, content differs → rewrite
+
+    This is the whole of the "apply-if-absent" repair. Existence answered
+    "has anyone written here?"; ownership answers "is what is written here
+    still what we mean?", which is the question a rotating credential and a
+    corrected identity both need asked.
+    """
+    existing = _read_text(path)
+    if existing is not None and not force and not owned(existing):
+        return False
+    if existing == content:
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _write_file(path, content, mode=mode)
+    return True
 
 
 def _write_file(path: Path, content: str, *, mode: int) -> None:
     """Write ``content`` then force ``mode`` (umask-independent)."""
     path.write_text(content, encoding="utf-8")
     os.chmod(path, mode)
+
+
+def refresh_gh_hosts(subprocess_home: Path, token: str, expires_at: str) -> bool:
+    """Bring a managed ``hosts.yml`` up to ``token`` if it has gone stale.
+
+    Boot is not a schedule for a credential that lives ~1h and a container that
+    lives weeks. This is the other half of the refresh: the tool-subprocess env
+    boundary already mints (cache-first) a fresh installation token on every
+    spawn, so it can hand the same token to ``hosts.yml`` for free — the file
+    is then reconciled on the token's own lifetime, at the exact moment its
+    staleness would have mattered.
+
+    Cheap by construction: a stamped, still-valid file short-circuits on a
+    ~200-byte read, so the actual write happens at most once per token
+    (~50 min), never per spawn. Returns True when it wrote.
+    """
+    path = subprocess_home / ".config" / "gh" / "hosts.yml"
+    existing = _read_text(path)
+    if existing is not None and not is_managed_gh_hosts(existing):
+        return False  # someone else's gh login — not ours to rotate
+    if not gh_hosts_needs_refresh(existing):
+        return False
+    return _write_managed(
+        path,
+        build_gh_hosts_content(token, expires_at=expires_at),
+        mode=0o600,
+        owned=is_managed_gh_hosts,
+    )
+
+
+# Basenames a HERMES_HOME mount point can have that are never an agent's name.
+# Falling through to one of these is how commits ended up authored as
+# "data <data@users.noreply.github.com>" — /opt/data's basename standing in for
+# an identity nobody ever chose.
+_NON_IDENTITY_BASENAMES = frozenset(
+    {"data", "home", "opt", "root", "srv", "var", "mnt", "app", "workspace", ""}
+)
+
+
+def resolve_root_identity(hermes_home: Path) -> tuple[Optional[str], Optional[str]]:
+    """Resolve the default profile's git author name. Returns ``(name, warning)``.
+
+    Precedence, most-to-least specific:
+
+    1. ``HERMES_AGENT_NAME`` in the process env (set by the container runtime);
+    2. ``HERMES_AGENT_NAME`` in the agent's own ``.env`` on the mounted volume —
+       the durable source that survives being invoked outside ``with-contenv``,
+       and the same file the credentials themselves come from;
+    3. the mount basename, which in production is ``/opt/data`` → "data" and is
+       not an identity at all. Returning it is reported as a warning rather than
+       accepted silently, because that fallback is the bug, not the behaviour.
+    """
+    from_env = (os.environ.get("HERMES_AGENT_NAME") or "").strip()
+    if from_env:
+        return from_env, None
+    content = _read_text(hermes_home / ".env")
+    if content:
+        from_file = _read_env_var_value(content, "HERMES_AGENT_NAME")
+        if from_file:
+            return from_file, None
+    basename = hermes_home.name
+    if basename.lower() in _NON_IDENTITY_BASENAMES:
+        return None, (
+            f"HERMES_AGENT_NAME unset and {hermes_home} has no agent name; "
+            f"git identity would fall back to the mount basename "
+            f"{basename!r} — commits will be authored as {basename!r}"
+        )
+    return None, None
+
+
+def _read_env_var_value(content: str, key: str) -> Optional[str]:
+    m = re.search(rf"^{re.escape(key)}=(.*)$", content, re.MULTILINE)
+    if not m:
+        return None
+    return re.sub(r'^["\']|["\']$', "", m.group(1).strip()) or None
 
 
 def provision_all(hermes_home: Path) -> list[ProvisionResult]:
@@ -296,11 +610,14 @@ def provision_all(hermes_home: Path) -> list[ProvisionResult]:
     default profile, and named profiles live under ``{HERMES_HOME}/profiles/<name>/``.
 
     The root's basename is uninformative in production (``/opt/data`` → "data"),
-    so the git identity for the default profile comes from ``HERMES_AGENT_NAME``
-    when set — commits are authored as the agent, not "data". A named profile is
-    its own agent and is identified by its profile directory name.
+    so the git identity for the default profile comes from
+    :func:`resolve_root_identity` — commits are authored as the agent, not
+    "data". A named profile is its own agent and is identified by its profile
+    directory name.
     """
-    root_name = os.environ.get("HERMES_AGENT_NAME") or None
+    root_name, warning = resolve_root_identity(hermes_home)
+    if warning:
+        print(f"git-credentials: WARNING {warning}")
     results = [provision_git_credentials(hermes_home, name=root_name)]
     profiles_dir = hermes_home / "profiles"
     if profiles_dir.is_dir():
@@ -314,11 +631,12 @@ def main() -> int:
     hermes_home = Path(os.environ.get("HERMES_HOME", "/opt/data"))
     for r in provision_all(hermes_home):
         status = (
-            f"provisioned (source={r.source})"
+            f"provisioned (source={r.source}, {r.reason})"
             if r.provisioned
             else f"skipped ({r.reason})"
         )
-        print(f"git-credentials: home={r.home} {status}")
+        identity = f" identity={r.identity}" if r.identity else ""
+        print(f"git-credentials: home={r.home}{identity} {status}")
     return 0
 
 

--- a/hermes_cli/github_app_token.py
+++ b/hermes_cli/github_app_token.py
@@ -181,12 +181,19 @@ def _expires_epoch(iso: str) -> float:
     ).timestamp()
 
 
-def _load_cache(path: Path) -> Optional[Tuple[str, float]]:
+def _load_cache_raw(path: Path) -> Optional[Tuple[str, str]]:
+    """``(token, expires_at_iso)`` from the cache, or ``None`` if absent/corrupt."""
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-        return data["token"], _expires_epoch(data["expires_at"])
+        _expires_epoch(data["expires_at"])  # validate parseability
+        return data["token"], data["expires_at"]
     except Exception:
         return None  # absent or corrupt → caller re-mints
+
+
+def _load_cache(path: Path) -> Optional[Tuple[str, float]]:
+    raw = _load_cache_raw(path)
+    return (raw[0], _expires_epoch(raw[1])) if raw else None
 
 
 def _store_cache(path: Path, token: str, expires_at_iso: str) -> None:
@@ -197,11 +204,35 @@ def _store_cache(path: Path, token: str, expires_at_iso: str) -> None:
     os.replace(tmp, path)  # atomic — a concurrent reader never sees a partial file
 
 
-def get_installation_token(home_dir: Path, *, force: bool = False) -> Optional[str]:
-    """Return a valid installation token for ``home_dir``, minting if needed.
+@dataclass(frozen=True)
+class InstallationToken:
+    """A minted installation token together with the instant it dies.
+
+    The expiry travels WITH the token because every consumer that persists it
+    (``gh``'s ``hosts.yml``) needs to know when its copy goes dead. A token
+    handed around as a bare string is a credential whose lifetime is invisible,
+    which is exactly how ``hosts.yml`` fossilized for 16 days.
+    """
+
+    token: str
+    expires_at: str  # ISO-8601 Z, verbatim from GitHub
+
+    @property
+    def expires_epoch(self) -> float:
+        return _expires_epoch(self.expires_at)
+
+
+def get_installation_token_detail(
+    home_dir: Path, *, force: bool = False
+) -> Optional[InstallationToken]:
+    """Return a valid :class:`InstallationToken` for ``home_dir``, minting if needed.
 
     Cache-first: a cached token with more than ``REMINT_MARGIN_SECONDS`` of life
     left is returned as-is. Returns ``None`` only if the home has no App creds.
+
+    This is the lifetime-aware primitive; :func:`get_installation_token` is the
+    string-only convenience wrapper for callers that only need to authenticate
+    right now and never persist the value.
     """
     creds = read_app_credentials(home_dir / ".env")
     if creds is None:
@@ -209,13 +240,19 @@ def get_installation_token(home_dir: Path, *, force: bool = False) -> Optional[s
 
     path = cache_path(home_dir)
     if not force:
-        cached = _load_cache(path)
-        if cached and cached[1] - time.time() > REMINT_MARGIN_SECONDS:
-            return cached[0]
+        cached = _load_cache_raw(path)
+        if cached and _expires_epoch(cached[1]) - time.time() > REMINT_MARGIN_SECONDS:
+            return InstallationToken(cached[0], cached[1])
 
     token, expires_at = mint_installation_token(creds)
     _store_cache(path, token, expires_at)
-    return token
+    return InstallationToken(token, expires_at)
+
+
+def get_installation_token(home_dir: Path, *, force: bool = False) -> Optional[str]:
+    """Return a valid installation token string for ``home_dir``, minting if needed."""
+    detail = get_installation_token_detail(home_dir, force=force)
+    return detail.token if detail else None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_git_credentials_boot.py
+++ b/tests/hermes_cli/test_git_credentials_boot.py
@@ -143,27 +143,30 @@ def test_empty_token_value_is_inert(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Apply-if-absent (the data-loss guard from HSM PR #53)
+# Manage-if-ours (the data-loss guard from HSM PR #53, re-based on ownership)
+#
+# The guard's intent — never clobber a config we did not write — is unchanged.
+# What changed is the test for it: "the file exists" also protected our OWN
+# stale output, which is how a 1h token survived 16 days in hosts.yml and a
+# git identity kept authoring as "data". Ownership separates the two cases.
 # ---------------------------------------------------------------------------
 
 
-def test_apply_if_absent_does_not_clobber_existing_credentials(tmp_path):
+def test_does_not_clobber_foreign_credentials_file(tmp_path):
     _write_env(tmp_path, "GITHUB_PAT=ghp_new\n")
     home = tmp_path / "home"
     home.mkdir()
-    (home / ".git-credentials").write_text("PRE-EXISTING\n")
+    (home / ".git-credentials").write_text("https://human:theirpat@github.com\n")
 
     result = provision_git_credentials(tmp_path)
 
-    # git creds are left intact; gh is provisioned independently (apply-if-absent),
-    # so the call did do work → provisioned=True, but it did NOT clobber git.
-    assert result.provisioned is True
-    assert "gh" in (result.reason or "")
-    assert "git" not in (result.reason or "")
-    assert (home / ".git-credentials").read_text() == "PRE-EXISTING\n"  # untouched
+    assert result.provisioned is True  # gitconfig + gh still provisioned
+    assert (
+        home / ".git-credentials"
+    ).read_text() == "https://human:theirpat@github.com\n"  # untouched
 
 
-def test_apply_if_absent_does_not_clobber_existing_gitconfig(tmp_path):
+def test_does_not_clobber_foreign_gitconfig(tmp_path):
     _write_env(tmp_path, "GITHUB_PAT=ghp_new\n")
     home = tmp_path / "home"
     home.mkdir()
@@ -171,27 +174,121 @@ def test_apply_if_absent_does_not_clobber_existing_gitconfig(tmp_path):
 
     result = provision_git_credentials(tmp_path)
 
-    # gitconfig left intact; gh provisioned independently → not a no-op, not a clobber.
     assert result.provisioned is True
-    assert "gh" in (result.reason or "")
     assert (home / ".gitconfig").read_text() == "[user]\n\tname = human\n"  # untouched
 
 
-def test_no_op_when_git_and_gh_both_present(tmp_path):
-    # the true no-op branch (provisioned=False) now needs BOTH git and gh present —
-    # the only test covering it after the git/gh split. Locks that branch.
+def test_no_op_when_everything_already_current(tmp_path):
+    """The true no-op branch: a second boot with nothing changed writes nothing.
+
+    Locks idempotence — manage-if-ours must not rewrite identical content, or
+    every boot would churn mtimes and make "when did this last rotate?"
+    unanswerable.
+    """
     _write_env(tmp_path, "GITHUB_PAT=ghp_new\n")
-    home = tmp_path / "home"
-    (home / ".config" / "gh").mkdir(parents=True)
-    (home / ".git-credentials").write_text("PRE-EXISTING\n")
-    (home / ".config" / "gh" / "hosts.yml").write_text("PRE-GH\n")
+    provision_git_credentials(tmp_path)
+    before = {
+        p: p.read_text()
+        for p in (_cred_path(tmp_path), _cfg_path(tmp_path), _gh_hosts_path(tmp_path))
+    }
 
     result = provision_git_credentials(tmp_path)
 
     assert result.provisioned is False
-    assert "already present" in (result.reason or "")
-    assert (home / ".git-credentials").read_text() == "PRE-EXISTING\n"
-    assert (home / ".config" / "gh" / "hosts.yml").read_text() == "PRE-GH\n"
+    assert "already current" in (result.reason or "")
+    assert all(p.read_text() == text for p, text in before.items())
+
+
+def test_does_not_clobber_foreign_gh_hosts(tmp_path):
+    _write_env(tmp_path, "GITHUB_PAT=ghp_new\n")
+    home = tmp_path / "home"
+    (home / ".config" / "gh").mkdir(parents=True)
+    (home / ".config" / "gh" / "hosts.yml").write_text(
+        "github.com:\n    oauth_token: human_token\n    user: a-human\n"
+    )
+
+    provision_git_credentials(tmp_path)
+
+    assert "human_token" in _gh_hosts_path(tmp_path).read_text()
+
+
+def test_rotated_pat_is_picked_up_on_next_boot(tmp_path):
+    """The PAT half of the same fossil: apply-if-absent kept serving the OLD
+    token after .env was rotated, until someone deleted the files by hand."""
+    _write_env(tmp_path, "GITHUB_PAT=ghp_old\n")
+    provision_git_credentials(tmp_path)
+    assert "ghp_old" in _cred_path(tmp_path).read_text()
+
+    _write_env(tmp_path, "GITHUB_PAT=ghp_rotated\n")
+    result = provision_git_credentials(tmp_path)
+
+    assert result.provisioned is True
+    assert "ghp_rotated" in _cred_path(tmp_path).read_text()
+    assert "ghp_old" not in _cred_path(tmp_path).read_text()
+    assert "oauth_token: ghp_rotated" in _gh_hosts_path(tmp_path).read_text()
+
+
+def test_stale_identity_in_our_own_gitconfig_is_corrected(tmp_path, monkeypatch):
+    """The `name = data` fossil, exactly as found on the fleet 2026-08-09.
+
+    HERMES_AGENT_NAME was wired up in a later build, but the .gitconfig written
+    by the earlier one already existed, so the corrected resolution could never
+    reach disk.
+    """
+    _write_env(tmp_path, "GITHUB_PAT=ghp_secret\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    # Byte-shape of a real pre-marker .gitconfig from hermes-matilde.
+    (home / ".gitconfig").write_text(
+        "[credential]\n\thelper = store\n"
+        "[user]\n\tname = data\n\temail = data@users.noreply.github.com\n"
+        '[url "https://github.com/"]\n'
+        "\tinsteadOf = git@github.com:\n"
+        "\tinsteadOf = ssh://git@github.com/\n"
+    )
+    monkeypatch.setenv("HERMES_AGENT_NAME", "matilde")
+
+    provision_all(tmp_path)
+
+    cfg = _cfg_path(tmp_path).read_text()
+    assert "name = matilde" in cfg
+    assert "name = data" not in cfg
+
+
+def test_legacy_unmarked_files_are_recognized_as_ours(tmp_path):
+    """Every already-deployed agent has files written before MANAGED_MARKER
+    existed. If those read as foreign, the fix would freeze the fossil instead
+    of thawing it."""
+    from hermes_cli.git_credentials_boot import (
+        is_managed_gh_hosts,
+        is_managed_git_credentials,
+        is_managed_gitconfig,
+    )
+
+    legacy_cfg = (
+        "[credential]\n\thelper = store\n[user]\n\tname = data\n"
+        '[url "https://github.com/"]\n\tinsteadOf = git@github.com:\n'
+        "\tinsteadOf = ssh://git@github.com/\n"
+    )
+    legacy_app_cfg = (
+        "[credential]\n\thelper =\n"
+        '\thelper = "!/opt/hermes/.venv/bin/python -m hermes_cli.github_app_token get-credential"\n'
+        '[user]\n\tname = data\n[url "https://github.com/"]\n'
+        "\tinsteadOf = git@github.com:\n\tinsteadOf = ssh://git@github.com/\n"
+    )
+    assert is_managed_gitconfig(legacy_cfg)
+    assert is_managed_gitconfig(legacy_app_cfg)
+    assert is_managed_gh_hosts(
+        "github.com:\n    oauth_token: ghs_x\n    git_protocol: https\n    user: x-access-token\n"
+    )
+    assert is_managed_git_credentials("https://x-access-token:ghs_x@github.com\n")
+
+    # …and a human's own files still read as foreign.
+    assert not is_managed_gitconfig("[user]\n\tname = human\n\temail = h@example.com\n")
+    assert not is_managed_gh_hosts(
+        "github.com:\n    oauth_token: gho_x\n    user: a-human\n"
+    )
+    assert not is_managed_git_credentials("https://human:theirpat@github.com\n")
 
 
 def test_force_overwrites_existing(tmp_path):
@@ -306,7 +403,7 @@ def test_gh_provisioned_even_when_git_already_present(tmp_path):
 
     assert result.provisioned is True
     assert "oauth_token: ghp_secret" in _gh_hosts_path(tmp_path).read_text()
-    # git config left untouched (apply-if-absent)
+    # git config left untouched — not ours (no marker, no generated shape)
     assert _cfg_path(tmp_path).read_text() == "# pre-existing git setup\n"
 
 
@@ -320,6 +417,7 @@ def test_gh_provisioned_even_when_git_already_present(tmp_path):
 # ---------------------------------------------------------------------------
 
 import base64 as _b64
+import datetime as _dt
 
 from hermes_cli.git_credentials_boot import build_git_config_content_app
 
@@ -334,12 +432,23 @@ def _write_app_env(home: Path, *, extra: str = "") -> None:
     )
 
 
+def _iso_in(seconds: float) -> str:
+    return (
+        _dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(seconds=seconds)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 @pytest.fixture
 def _stub_mint(monkeypatch):
     """Stub the network mint so boot tests stay offline."""
     import hermes_cli.git_credentials_boot as boot
+    from hermes_cli.github_app_token import InstallationToken
 
-    monkeypatch.setattr(boot, "get_installation_token", lambda home, force=False: "ghs_minted")
+    monkeypatch.setattr(
+        boot,
+        "get_installation_token_detail",
+        lambda home, force=False: InstallationToken("ghs_minted", _iso_in(3600)),
+    )
 
 
 def test_app_mode_writes_helper_gitconfig_not_credentials_file(tmp_path, _stub_mint):
@@ -392,3 +501,248 @@ def test_build_git_config_content_app_shape():
     assert "\thelper =\n" in out
     assert '\thelper = "!/opt/hermes/.venv/bin/python -m hermes_cli.github_app_token get-credential"' in out
     assert "\tname = cryptids" in out
+
+
+# ---------------------------------------------------------------------------
+# gh hosts.yml refresh — driven by the token's lifetime, not the file's existence
+#
+# THE fossil. `_provision_app_mode` gated the gh mint on
+# `not gh_hosts_path.exists()`, so the very first boot's ~1h installation token
+# was the only one an agent ever received. Observed live 2026-08-09 on
+# hermes-matilde / -nimbleco / -cryptids: hosts.yml frozen at 2026-07-23,
+# holding a ghs_ token that had been dead for ~16 days, while `git` kept
+# working perfectly through the mint-on-demand credential helper — so nothing
+# in the container's own view ever said the credential had died.
+# ---------------------------------------------------------------------------
+
+from hermes_cli.git_credentials_boot import (
+    GH_EXPIRY_STAMP_PREFIX,
+    MANAGED_MARKER,
+    gh_hosts_needs_refresh,
+    read_gh_hosts_expiry,
+    refresh_gh_hosts,
+    resolve_root_identity,
+)
+
+
+def _managed_hosts(token: str, expires_at: str) -> str:
+    return (
+        f"{MANAGED_MARKER}\n{GH_EXPIRY_STAMP_PREFIX}{expires_at}\n"
+        f"github.com:\n    oauth_token: {token}\n"
+        "    git_protocol: https\n    user: x-access-token\n"
+    )
+
+
+class TestGhHostsStaleness:
+    def test_absent_needs_refresh(self):
+        assert gh_hosts_needs_refresh(None) is True
+
+    def test_foreign_file_never_refreshed(self):
+        assert (
+            gh_hosts_needs_refresh("github.com:\n    oauth_token: gho_x\n    user: me\n")
+            is False
+        )
+
+    def test_ours_but_unstamped_needs_refresh(self):
+        """Every hosts.yml on the fleet today is in this bucket — written before
+        the expiry stamp existed, holding a token that died within the hour.
+        Unknown lifetime must mean refresh, not skip."""
+        legacy = (
+            "github.com:\n    oauth_token: ghs_fossil\n"
+            "    git_protocol: https\n    user: x-access-token\n"
+        )
+        assert gh_hosts_needs_refresh(legacy) is True
+
+    def test_fresh_stamp_does_not_need_refresh(self):
+        assert gh_hosts_needs_refresh(_managed_hosts("ghs_a", _iso_in(3600))) is False
+
+    def test_expired_stamp_needs_refresh(self):
+        assert gh_hosts_needs_refresh(_managed_hosts("ghs_a", _iso_in(-60))) is True
+
+    def test_refresh_starts_inside_the_margin_not_at_death(self):
+        """A `gh` call may run minutes after the env was built; rolling over only
+        at expiry hands out a token that dies mid-operation."""
+        assert gh_hosts_needs_refresh(_managed_hosts("ghs_a", _iso_in(60))) is True
+
+    def test_unparseable_stamp_needs_refresh(self):
+        assert gh_hosts_needs_refresh(_managed_hosts("ghs_a", "not-a-date")) is True
+
+    def test_expiry_round_trips_through_the_written_file(self, tmp_path, _stub_mint):
+        _write_app_env(tmp_path)
+        provision_git_credentials(tmp_path)
+        text = _gh_hosts_path(tmp_path).read_text()
+        assert read_gh_hosts_expiry(text) is not None
+        assert gh_hosts_needs_refresh(text) is False
+
+
+class TestAppModeBootRefresh:
+    def test_expired_hosts_is_rewritten_not_preserved(self, tmp_path, _stub_mint):
+        """The exact production state: a hosts.yml that exists and is dead."""
+        _write_app_env(tmp_path)
+        gh = _gh_hosts_path(tmp_path)
+        gh.parent.mkdir(parents=True)
+        gh.write_text(_managed_hosts("ghs_fossil", _iso_in(-86400 * 16)))
+
+        result = provision_git_credentials(tmp_path)
+
+        assert result.provisioned is True
+        assert "oauth_token: ghs_minted" in gh.read_text()
+        assert "ghs_fossil" not in gh.read_text()
+
+    def test_legacy_unstamped_hosts_is_healed(self, tmp_path, _stub_mint):
+        _write_app_env(tmp_path)
+        gh = _gh_hosts_path(tmp_path)
+        gh.parent.mkdir(parents=True)
+        gh.write_text(
+            "github.com:\n    oauth_token: ghs_2026_07_23\n"
+            "    git_protocol: https\n    user: x-access-token\n"
+        )
+
+        provision_git_credentials(tmp_path)
+
+        assert "oauth_token: ghs_minted" in gh.read_text()
+
+    def test_still_valid_hosts_is_left_alone_without_minting(self, tmp_path, monkeypatch):
+        """Boot must not mint when the file is fine — a live HTTP call in
+        cont-init.d is a boot-hang risk on a flaky network."""
+        import hermes_cli.git_credentials_boot as boot
+
+        _write_app_env(tmp_path)
+        gh = _gh_hosts_path(tmp_path)
+        gh.parent.mkdir(parents=True)
+        gh.write_text(_managed_hosts("ghs_still_good", _iso_in(3600)))
+        calls = []
+        monkeypatch.setattr(
+            boot,
+            "get_installation_token_detail",
+            lambda home, force=False: calls.append(home),
+        )
+
+        provision_git_credentials(tmp_path)
+
+        assert calls == []
+        assert "ghs_still_good" in gh.read_text()
+
+    def test_mint_failure_leaves_file_and_warns(self, tmp_path, monkeypatch, capsys):
+        """Fail-soft, but audibly: a dead credential left in place must say so."""
+        import hermes_cli.git_credentials_boot as boot
+
+        _write_app_env(tmp_path)
+        gh = _gh_hosts_path(tmp_path)
+        gh.parent.mkdir(parents=True)
+        gh.write_text(_managed_hosts("ghs_fossil", _iso_in(-3600)))
+
+        def _boom(home, force=False):
+            raise RuntimeError("github unreachable")
+
+        monkeypatch.setattr(boot, "get_installation_token_detail", _boom)
+
+        provision_git_credentials(tmp_path)  # must not raise
+
+        assert "ghs_fossil" in gh.read_text()
+        assert "WARNING stale gh hosts.yml" in capsys.readouterr().out
+
+    def test_app_mode_stale_identity_is_corrected(self, tmp_path, _stub_mint, monkeypatch):
+        """The `name = data` fossil on the App-mode path (matilde/nimbleco/cryptids)."""
+        _write_app_env(tmp_path)
+        home = tmp_path / "home"
+        home.mkdir()
+        home.joinpath(".gitconfig").write_text(
+            "[credential]\n\thelper =\n"
+            '\thelper = "!/x/python -m hermes_cli.github_app_token get-credential"\n'
+            "[user]\n\tname = data\n\temail = data@users.noreply.github.com\n"
+            '[url "https://github.com/"]\n\tinsteadOf = git@github.com:\n'
+            "\tinsteadOf = ssh://git@github.com/\n"
+        )
+        monkeypatch.setenv("HERMES_AGENT_NAME", "matilde")
+
+        provision_all(tmp_path)
+
+        cfg = _cfg_path(tmp_path).read_text()
+        assert "name = matilde" in cfg
+        assert "email = matilde@users.noreply.github.com" in cfg
+        assert "name = data" not in cfg
+
+
+class TestRefreshGhHosts:
+    """The out-of-boot half: refresh tied to the token's lifetime, invoked from
+    the subprocess-env boundary so a weeks-long container still rotates."""
+
+    def test_writes_when_absent(self, tmp_path):
+        assert refresh_gh_hosts(tmp_path, "ghs_new", _iso_in(3600)) is True
+        assert (
+            "oauth_token: ghs_new"
+            in (tmp_path / ".config" / "gh" / "hosts.yml").read_text()
+        )
+
+    def test_rewrites_when_expired(self, tmp_path):
+        path = tmp_path / ".config" / "gh" / "hosts.yml"
+        path.parent.mkdir(parents=True)
+        path.write_text(_managed_hosts("ghs_old", _iso_in(-60)))
+
+        assert refresh_gh_hosts(tmp_path, "ghs_new", _iso_in(3600)) is True
+        assert "oauth_token: ghs_new" in path.read_text()
+
+    def test_no_write_while_still_valid(self, tmp_path):
+        path = tmp_path / ".config" / "gh" / "hosts.yml"
+        path.parent.mkdir(parents=True)
+        path.write_text(_managed_hosts("ghs_old", _iso_in(3600)))
+        before = path.read_text()
+
+        assert refresh_gh_hosts(tmp_path, "ghs_new", _iso_in(3600)) is False
+        assert path.read_text() == before
+
+    def test_never_touches_a_foreign_gh_login(self, tmp_path):
+        path = tmp_path / ".config" / "gh" / "hosts.yml"
+        path.parent.mkdir(parents=True)
+        path.write_text("github.com:\n    oauth_token: gho_human\n    user: a-human\n")
+
+        assert refresh_gh_hosts(tmp_path, "ghs_new", _iso_in(3600)) is False
+        assert "gho_human" in path.read_text()
+
+    def test_written_file_is_chmod_600(self, tmp_path):
+        refresh_gh_hosts(tmp_path, "ghs_new", _iso_in(3600))
+        assert _mode(tmp_path / ".config" / "gh" / "hosts.yml") == 0o600
+
+
+# ---------------------------------------------------------------------------
+# Identity resolution — never let a mount basename become an author name
+# ---------------------------------------------------------------------------
+
+
+class TestRootIdentity:
+    def test_process_env_wins(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_AGENT_NAME", "matilde")
+        _write_env(tmp_path, "HERMES_AGENT_NAME=stale-in-file\n")
+        assert resolve_root_identity(tmp_path)[0] == "matilde"
+
+    def test_falls_back_to_the_agents_own_env_file(self, tmp_path, monkeypatch):
+        """HERMES_AGENT_NAME lives in the agent's .env on the mounted volume
+        (verified on hermes-matilde). That file is the durable source when the
+        module runs outside the container's with-contenv environment."""
+        monkeypatch.delenv("HERMES_AGENT_NAME", raising=False)
+        _write_env(tmp_path, "HERMES_AGENT_NAME=matilde\nGITHUB_PAT=ghp_x\n")
+        assert resolve_root_identity(tmp_path)[0] == "matilde"
+
+    def test_generic_mount_basename_is_warned_about(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_AGENT_NAME", raising=False)
+        opt_data = tmp_path / "opt" / "data"
+        opt_data.mkdir(parents=True)
+        name, warning = resolve_root_identity(opt_data)
+        assert name is None
+        assert warning is not None and "data" in warning
+
+    def test_meaningful_basename_is_not_warned_about(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_AGENT_NAME", raising=False)
+        agent_home = tmp_path / "cryptids"
+        agent_home.mkdir()
+        assert resolve_root_identity(agent_home) == (None, None)
+
+    def test_env_file_name_reaches_the_written_gitconfig(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_AGENT_NAME", raising=False)
+        _write_env(tmp_path, "HERMES_AGENT_NAME=matilde\nGITHUB_PAT=ghp_x\n")
+
+        results = provision_all(tmp_path)
+
+        assert "name = matilde" in _cfg_path(tmp_path).read_text()
+        assert results[0].identity == "matilde"

--- a/tests/hermes_cli/test_github_app_token.py
+++ b/tests/hermes_cli/test_github_app_token.py
@@ -215,6 +215,59 @@ def test_remint_when_cache_corrupt(app_env, monkeypatch):
     assert gat.get_installation_token(app_env) == "ghs_recovered"
 
 
+# ---------------------------------------------------------------------------
+# get_installation_token_detail — the expiry travels WITH the token
+#
+# A token handed around as a bare string is a credential whose lifetime is
+# invisible. Every consumer that PERSISTS it (gh's hosts.yml) needs to know
+# when its copy dies, or it cannot tell "still good" from "dead for 16 days".
+# ---------------------------------------------------------------------------
+
+
+def test_detail_carries_expiry_from_a_cache_hit(app_env, monkeypatch):
+    _write_cache(app_env, "ghs_cached", time.time() + 3600)
+    monkeypatch.setattr(
+        gat.httpx, "post", lambda *a, **k: pytest.fail("must not mint on cache hit")
+    )
+
+    detail = gat.get_installation_token_detail(app_env)
+
+    assert detail.token == "ghs_cached"
+    assert detail.expires_epoch - time.time() == pytest.approx(3600, abs=5)
+
+
+def test_detail_carries_expiry_from_a_fresh_mint(app_env, monkeypatch):
+    class FakeResp:
+        status_code = 201
+
+        def json(self):
+            return {"token": "ghs_fresh", "expires_at": "2099-01-01T00:00:00Z"}
+
+    monkeypatch.setattr(gat.httpx, "post", lambda *a, **k: FakeResp())
+
+    detail = gat.get_installation_token_detail(app_env, force=True)
+
+    assert detail.token == "ghs_fresh"
+    assert detail.expires_at == "2099-01-01T00:00:00Z"
+
+
+def test_detail_none_without_app_credentials(tmp_path: Path):
+    (tmp_path / ".env").write_text("OPENAI_API_KEY=sk-x\n")
+    assert gat.get_installation_token_detail(tmp_path) is None
+
+
+def test_string_wrapper_still_matches_detail(app_env, monkeypatch):
+    """get_installation_token stays the string-only convenience path — callers
+    that only authenticate right now must be unaffected."""
+    _write_cache(app_env, "ghs_cached", time.time() + 3600)
+    monkeypatch.setattr(
+        gat.httpx, "post", lambda *a, **k: pytest.fail("must not mint on cache hit")
+    )
+    assert gat.get_installation_token(app_env) == (
+        gat.get_installation_token_detail(app_env).token
+    )
+
+
 def test_cache_written_0600(app_env, monkeypatch):
     import stat
 

--- a/tests/tools/test_gh_token_inject.py
+++ b/tests/tools/test_gh_token_inject.py
@@ -13,7 +13,16 @@ same short-lived installation token and inject it as ``GH_TOKEN`` into the
 sanitized subprocess env. Exposure is not widened — the helper already
 caches this token under the subprocess HOME, readable by any tool.
 
-See hermes_cli/github_app_token.py for the mint/cache layer.
+That fix originally landed on the terminal paths only. ``hermes_subprocess_env``
+— browser worker, ACP/codex/copilot executors, TUI Node host, dep-ensure,
+detached gateway — stripped ``GH_TOKEN`` in Tier 1 and never re-injected, so
+those spawns kept authenticating out of the frozen ``hosts.yml``. Silent by
+construction: the credential was present and merely dead, so the failure
+surfaced as an unexplained 401 inside a tool rather than as missing auth.
+``TestEverySpawnSurface`` is the guard against that gap reopening.
+
+See hermes_cli/github_app_token.py for the mint/cache layer and
+hermes_cli/git_credentials_boot.py for the managed-file refresh.
 """
 
 import time
@@ -23,13 +32,27 @@ from unittest.mock import patch
 import pytest
 
 import tools.environments.local as local_mod
+from hermes_cli.github_app_token import InstallationToken
 from tools.environments.local import (
     _make_run_env,
     _sanitize_subprocess_env,
+    hermes_subprocess_env,
 )
 
 
-MINT_TARGET = "hermes_cli.github_app_token.get_installation_token"
+MINT_TARGET = "hermes_cli.github_app_token.get_installation_token_detail"
+
+# Captured before the autouse neutering fixture can replace it.
+from hermes_cli.git_credentials_boot import refresh_gh_hosts as _REAL_REFRESH_GH_HOSTS
+
+
+def _detail(token="ghs_minted", ttl_seconds=3600):
+    import datetime as _dt
+
+    expires = (
+        _dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(seconds=ttl_seconds)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return InstallationToken(token, expires)
 
 
 @pytest.fixture(autouse=True)
@@ -40,13 +63,23 @@ def _reset_cooldown():
     local_mod._GH_TOKEN_MINT_FAILURE_TS = 0.0
 
 
+@pytest.fixture(autouse=True)
+def _no_real_hosts_writes(monkeypatch):
+    """Injection also refreshes the managed hosts.yml under HOME. Most tests
+    here use a synthetic HOME, so neuter the disk write by default;
+    TestHostsRefreshSideEffect opts back in with a real tmp_path HOME."""
+    import hermes_cli.git_credentials_boot as boot
+
+    monkeypatch.setattr(boot, "refresh_gh_hosts", lambda *a, **k: False)
+
+
 def _base_env(home="/data/agent/home"):
     return {"HOME": home, "PATH": "/usr/bin"}
 
 
 class TestInjection:
     def test_minted_token_injected_as_gh_token(self):
-        with patch(MINT_TARGET, return_value="ghs_minted") as mint:
+        with patch(MINT_TARGET, return_value=_detail()) as mint:
             env = _sanitize_subprocess_env(_base_env())
         assert env.get("GH_TOKEN") == "ghs_minted"
         mint.assert_called_once()
@@ -54,14 +87,14 @@ class TestInjection:
     def test_home_parent_is_the_hermes_home_dir(self):
         """The mint layer's contract: HOME is ``{HERMES_HOME}/home``, so the
         dir holding ``.env`` is HOME's parent (github_app_token._default_home)."""
-        with patch(MINT_TARGET, return_value="ghs_minted") as mint:
+        with patch(MINT_TARGET, return_value=_detail()) as mint:
             env = _sanitize_subprocess_env(_base_env())
         home = Path(env["HOME"])
         assert mint.call_args.args[0] == home.parent
 
     def test_run_env_path_also_injects(self):
         """_make_run_env (foreground terminal) mirrors the sanitize path."""
-        with patch(MINT_TARGET, return_value="ghs_minted"):
+        with patch(MINT_TARGET, return_value=_detail()):
             env = _make_run_env(_base_env())
         assert env.get("GH_TOKEN") == "ghs_minted"
 
@@ -71,7 +104,7 @@ class TestInjection:
             "GITHUB_TOKEN": "ghp_longlived",
             "GITHUB_APP_PRIVATE_KEY_B64": "pem",
         }
-        with patch(MINT_TARGET, return_value="ghs_minted"):
+        with patch(MINT_TARGET, return_value=_detail()):
             env = _sanitize_subprocess_env(base)
         assert env.get("GH_TOKEN") == "ghs_minted"
         assert "GITHUB_TOKEN" not in env
@@ -105,7 +138,7 @@ class TestFailSoft:
         local_mod._GH_TOKEN_MINT_FAILURE_TS = (
             time.time() - local_mod._GH_TOKEN_MINT_COOLDOWN_SECONDS - 1
         )
-        with patch(MINT_TARGET, return_value="ghs_recovered") as mint2:
+        with patch(MINT_TARGET, return_value=_detail("ghs_recovered")) as mint2:
             env = _sanitize_subprocess_env(_base_env())
         assert env.get("GH_TOKEN") == "ghs_recovered"
         assert mint2.call_count == 1
@@ -119,7 +152,7 @@ class TestFailSoft:
         assert mint.call_count == 2
 
     def test_missing_home_skips_quietly(self):
-        with patch(MINT_TARGET, return_value="ghs_minted") as mint:
+        with patch(MINT_TARGET, return_value=_detail()) as mint:
             env = _sanitize_subprocess_env({"PATH": "/usr/bin"})
         # apply_subprocess_home_env may synthesize a HOME; only assert we
         # didn't crash and the mint layer got a real dir if it was called.
@@ -135,14 +168,162 @@ class TestPrecedence:
         from tools.environments.local import _HERMES_PROVIDER_ENV_FORCE_PREFIX
 
         extra = {_HERMES_PROVIDER_ENV_FORCE_PREFIX + "GH_TOKEN": "ghp_forced"}
-        with patch(MINT_TARGET, return_value="ghs_minted") as mint:
+        with patch(MINT_TARGET, return_value=_detail()) as mint:
             env = _sanitize_subprocess_env(_base_env(), extra_env=extra)
         assert env.get("GH_TOKEN") == "ghp_forced"
         mint.assert_not_called()
 
     def test_opt_out_env(self, monkeypatch):
         monkeypatch.setenv("HERMES_GH_TOKEN_INJECT", "off")
-        with patch(MINT_TARGET, return_value="ghs_minted") as mint:
+        with patch(MINT_TARGET, return_value=_detail()) as mint:
             env = _sanitize_subprocess_env(_base_env())
         assert "GH_TOKEN" not in env
         mint.assert_not_called()
+
+
+class TestEverySpawnSurface:
+    """``hermes_subprocess_env`` is the OTHER half of the spawn surface —
+    browser worker, ACP/codex/copilot executors, TUI Node host, dep-ensure,
+    detached gateway. It strips GH_TOKEN in Tier 1 and never re-injected, so
+    every one of those paths silently fell back to the boot-written hosts.yml
+    and authenticated with a token that had been dead for weeks.
+
+    The invariant this class defends: no spawn surface may reach GitHub through
+    a file whose refresh is not tied to the token's lifetime.
+    """
+
+    def test_hermes_subprocess_env_injects(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/data/agent/home")
+        with patch(MINT_TARGET, return_value=_detail()):
+            env = hermes_subprocess_env()
+        assert env.get("GH_TOKEN") == "ghs_minted"
+
+    def test_injected_even_with_inherit_credentials(self, monkeypatch):
+        """Tier 1 strips GH_TOKEN regardless of inherit_credentials, so the
+        re-injection has to be unconditional too — codex/copilot otherwise get
+        the same silent hosts.yml fallback."""
+        monkeypatch.setenv("HOME", "/data/agent/home")
+        monkeypatch.setenv("GH_TOKEN", "ghp_ambient_longlived")
+        with patch(MINT_TARGET, return_value=_detail()):
+            env = hermes_subprocess_env(inherit_credentials=True)
+        assert env.get("GH_TOKEN") == "ghs_minted"
+
+    def test_ambient_long_lived_token_is_still_replaced_not_inherited(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", "/data/agent/home")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_longlived")
+        monkeypatch.setenv("GH_TOKEN", "ghp_longlived")
+        monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_B64", "pem")
+        with patch(MINT_TARGET, return_value=_detail()):
+            env = hermes_subprocess_env()
+        assert env["GH_TOKEN"] == "ghs_minted"
+        assert "GITHUB_TOKEN" not in env
+        assert "GITHUB_APP_PRIVATE_KEY_B64" not in env
+
+    def test_no_app_creds_leaves_env_clean(self, monkeypatch):
+        """App-less installs keep exactly the old behaviour: stripped, not
+        re-injected with somebody's long-lived PAT."""
+        monkeypatch.setenv("HOME", "/data/agent/home")
+        monkeypatch.setenv("GH_TOKEN", "ghp_longlived")
+        with patch(MINT_TARGET, return_value=None):
+            env = hermes_subprocess_env()
+        assert "GH_TOKEN" not in env
+
+    def test_mint_failure_does_not_break_the_spawn(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/data/agent/home")
+        with patch(MINT_TARGET, side_effect=RuntimeError("api down")):
+            env = hermes_subprocess_env()  # must not raise
+        assert "GH_TOKEN" not in env
+        assert env.get("PATH")
+
+
+class TestHostsRefreshSideEffect:
+    """Injection carries the fresh token back into the managed hosts.yml, which
+    is what gives that file a refresh schedule tied to the token's ~1h life
+    rather than to container boot.
+
+    Exercised through ``_inject_github_app_gh_token`` directly so HOME is
+    exactly the tmp_path this test controls — the outer helpers run HOME
+    through the subprocess-home contract, which could point the write at a real
+    user home.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _real_refresh(self, monkeypatch):
+        """Undo the module-level neutering — these tests want the disk write."""
+        import hermes_cli.git_credentials_boot as boot
+
+        monkeypatch.setattr(boot, "refresh_gh_hosts", _REAL_REFRESH_GH_HOSTS)
+
+    def test_stale_hosts_is_rewritten_on_spawn(self, tmp_path):
+        from hermes_cli.git_credentials_boot import (
+            GH_EXPIRY_STAMP_PREFIX,
+            MANAGED_MARKER,
+        )
+
+        home = tmp_path / "home"
+        hosts = home / ".config" / "gh" / "hosts.yml"
+        hosts.parent.mkdir(parents=True)
+        hosts.write_text(
+            f"{MANAGED_MARKER}\n{GH_EXPIRY_STAMP_PREFIX}2026-07-23T23:09:09Z\n"
+            "github.com:\n    oauth_token: ghs_fossil\n"
+            "    git_protocol: https\n    user: x-access-token\n"
+        )
+        env = {"HOME": str(home)}
+
+        with patch(MINT_TARGET, return_value=_detail("ghs_fresh")):
+            local_mod._inject_github_app_gh_token(env)
+
+        assert env["GH_TOKEN"] == "ghs_fresh"
+        assert "oauth_token: ghs_fresh" in hosts.read_text()
+        assert "ghs_fossil" not in hosts.read_text()
+
+    def test_valid_hosts_is_not_rewritten(self, tmp_path):
+        """No per-spawn disk churn: the write happens once per token, not once
+        per subprocess."""
+        from hermes_cli.git_credentials_boot import build_gh_hosts_content
+
+        home = tmp_path / "home"
+        hosts = home / ".config" / "gh" / "hosts.yml"
+        hosts.parent.mkdir(parents=True)
+        detail = _detail("ghs_current")
+        hosts.write_text(
+            build_gh_hosts_content(detail.token, expires_at=detail.expires_at)
+        )
+        before = hosts.stat().st_mtime_ns
+        env = {"HOME": str(home)}
+
+        with patch(MINT_TARGET, return_value=detail):
+            local_mod._inject_github_app_gh_token(env)
+
+        assert hosts.stat().st_mtime_ns == before
+
+    def test_foreign_gh_login_is_never_rotated(self, tmp_path):
+        home = tmp_path / "home"
+        hosts = home / ".config" / "gh" / "hosts.yml"
+        hosts.parent.mkdir(parents=True)
+        hosts.write_text("github.com:\n    oauth_token: gho_human\n    user: a-human\n")
+        env = {"HOME": str(home)}
+
+        with patch(MINT_TARGET, return_value=_detail("ghs_fresh")):
+            local_mod._inject_github_app_gh_token(env)
+
+        assert env["GH_TOKEN"] == "ghs_fresh"  # the env var is still ours to set
+        assert "gho_human" in hosts.read_text()  # the file is not
+
+    def test_refresh_failure_never_costs_the_token(self, tmp_path, monkeypatch):
+        """The env var is the load-bearing path; a file-write problem (read-only
+        mount, wrong owner) must not take GH_TOKEN down with it."""
+        import hermes_cli.git_credentials_boot as boot
+
+        def _boom(*a, **k):
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr(boot, "refresh_gh_hosts", _boom)
+        env = {"HOME": str(tmp_path / "home")}
+
+        with patch(MINT_TARGET, return_value=_detail("ghs_fresh")):
+            local_mod._inject_github_app_gh_token(env)
+
+        assert env["GH_TOKEN"] == "ghs_fresh"

--- a/tests/tools/test_gh_token_inject_coverage.py
+++ b/tests/tools/test_gh_token_inject_coverage.py
@@ -1,0 +1,118 @@
+"""Structural guard: every subprocess-env builder must inject a fresh GH_TOKEN.
+
+The defect this file exists to prevent has already happened once. The GH_TOKEN
+injection was added to the terminal paths (``_sanitize_subprocess_env``,
+``_make_run_env``) and ``hermes_subprocess_env`` — a sibling env builder for
+the browser worker, ACP/codex/copilot executors, the TUI Node host, dep-ensure
+and the detached gateway — was simply not updated. Nothing caught it, because
+the omission does not fail: ``gh`` falls back to the boot-written
+``~/.config/gh/hosts.yml``, whose GitHub App token is dead within the hour. The
+symptom is a 401 deep inside a tool, weeks later, with a credential file
+sitting right there looking perfectly plausible.
+
+A behavioural test per known builder cannot catch the NEXT builder somebody
+adds. This one reads the source instead: any function that finalizes HOME via
+``apply_subprocess_home_env`` is, by definition, building an environment for a
+spawned process, and must therefore also call ``_inject_github_app_gh_token``.
+
+Non-vacuity is asserted explicitly — a test that silently finds zero builders
+would pass forever after a rename.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import tools.environments.local as local_mod
+
+HOME_FINALIZER = "apply_subprocess_home_env"
+INJECTOR = "_inject_github_app_gh_token"
+
+# Builders known to exist today. Kept as a floor, not as the definition: the
+# scan finds builders, this set only proves the scan is actually finding them.
+KNOWN_BUILDERS = {
+    "_sanitize_subprocess_env",
+    "hermes_subprocess_env",
+    "_make_run_env",
+}
+
+
+def _called_names(node: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            func = child.func
+            if isinstance(func, ast.Name):
+                names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                names.add(func.attr)
+    return names
+
+
+def _env_builders() -> dict[str, set[str]]:
+    source = Path(local_mod.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    builders: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        calls = _called_names(node)
+        if HOME_FINALIZER in calls:
+            builders[node.name] = calls
+    return builders
+
+
+def test_scan_finds_the_known_builders():
+    """Non-vacuity floor. Without this, a rename of the finalizer would make
+    every assertion below pass over an empty set."""
+    found = set(_env_builders())
+    assert KNOWN_BUILDERS <= found, f"scan lost builders: {KNOWN_BUILDERS - found}"
+
+
+def test_every_env_builder_injects_a_fresh_gh_token():
+    offenders = sorted(
+        name for name, calls in _env_builders().items() if INJECTOR not in calls
+    )
+    assert not offenders, (
+        f"{offenders} build a subprocess environment but never call {INJECTOR}(). "
+        f"Without it the spawn authenticates to GitHub out of the boot-written "
+        f"~/.config/gh/hosts.yml, which holds a GitHub App token that expires "
+        f"within the hour and is refreshed on no schedule the spawn controls. "
+        f"That failure is silent — the credential is present, merely dead."
+    )
+
+
+def test_injection_runs_after_home_is_final():
+    """Ordering is load-bearing: the mint layer derives the agent's .env dir as
+    HOME's parent, so injecting before HOME is finalized reads the wrong home
+    (or none) and silently declines to inject."""
+    source = Path(local_mod.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    checked = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        finalize_lines = [
+            c.lineno
+            for c in ast.walk(node)
+            if isinstance(c, ast.Call)
+            and isinstance(c.func, ast.Name)
+            and c.func.id == HOME_FINALIZER
+        ]
+        inject_lines = [
+            c.lineno
+            for c in ast.walk(node)
+            if isinstance(c, ast.Call)
+            and isinstance(c.func, ast.Name)
+            and c.func.id == INJECTOR
+        ]
+        if not finalize_lines or not inject_lines:
+            continue
+        checked += 1
+        assert min(inject_lines) > max(finalize_lines), (
+            f"{node.name}: {INJECTOR}() must run after {HOME_FINALIZER}()"
+        )
+    assert checked == len(KNOWN_BUILDERS), (
+        f"ordering was only checked in {checked} builders; expected "
+        f"{len(KNOWN_BUILDERS)}"
+    )

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -481,6 +481,18 @@ def _inject_github_app_gh_token(env: dict) -> None:
     passes (an explicit force-passed ``GH_TOKEN`` must win — presence in
     ``env`` here means the operator asked for that exact token).
 
+    This must run on EVERY spawn surface. A path that skips it does not merely
+    lose the fresh token — it silently falls back to the boot-written
+    ``hosts.yml``, whose token is dead within the hour, so the failure
+    presents as an unexplained 401 deep inside a tool rather than as missing
+    auth. ``hermes_subprocess_env`` was such a path.
+
+    Side effect by design: the freshly minted token is also written back into
+    the managed ``hosts.yml`` (see ``git_credentials_boot.refresh_gh_hosts``),
+    which is what ties that file's refresh to the token's lifetime instead of
+    to container boot. Free — the token is already in hand — and a no-op while
+    the file is still valid.
+
     Fail-soft: no App creds → no injection (App-less installs see the old
     behavior exactly); mint failure → cooldown, no retry storm. Opt out with
     ``HERMES_GH_TOKEN_INJECT=off``.
@@ -498,14 +510,21 @@ def _inject_github_app_gh_token(env: dict) -> None:
     if not home:
         return
     try:
-        from hermes_cli.github_app_token import get_installation_token
+        from hermes_cli.github_app_token import get_installation_token_detail
 
-        token = get_installation_token(Path(home).parent)
+        detail = get_installation_token_detail(Path(home).parent)
     except Exception:
         _GH_TOKEN_MINT_FAILURE_TS = time.time()
         return
-    if token:
-        env["GH_TOKEN"] = token
+    if not detail:
+        return
+    env["GH_TOKEN"] = detail.token
+    try:
+        from hermes_cli.git_credentials_boot import refresh_gh_hosts
+
+        refresh_gh_hosts(Path(home), detail.token, detail.expires_at)
+    except Exception:
+        pass  # the env var is the load-bearing path; the file is belt-and-braces
 
 
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
@@ -662,6 +681,15 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     _inject_context_hermes_home(env)
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(env)
+
+    # Tier-1 stripped GH_TOKEN/GITHUB_TOKEN above, same as the terminal paths —
+    # so hand back the short-lived App token here too. Without this, every
+    # non-terminal spawn (browser worker, ACP/codex/copilot executor, TUI Node
+    # host, dep-ensure, detached gateway) reached GitHub through the boot-written
+    # hosts.yml instead: silent, unrefreshable, and dead within an hour of the
+    # container's first boot. Ordering is the same contract as
+    # _sanitize_subprocess_env — after apply_subprocess_home_env, after strips.
+    _inject_github_app_gh_token(env)
 
     # Active-venv markers must not clobber another project's environment.
     for _marker in _ACTIVE_VENV_MARKER_VARS:


### PR DESCRIPTION
## What

- Replace **apply-if-absent** with **manage-if-ours** in `hermes_cli/git_credentials_boot.py`. Files this module writes carry a `# managed-by:` marker (plus shape-recognition for the unmarked files already on the fleet); ownership is now the gate instead of existence, so a file we own is reconciled to current content every boot. The "never clobber a human's config" intent is preserved and tested directly.
- Tie the `gh` credential to the **token's** lifetime instead of the container's: `hosts.yml` records `# token-expires-at:`, `_provision_app_mode` refreshes on that stamp rather than on `not gh_hosts_path.exists()`, and `_inject_github_app_gh_token` carries each freshly minted token back into the file on every spawn (no-op while it is still valid). Boot warns out loud when it must leave a stale file in place.
- Wire `_inject_github_app_gh_token` into `hermes_subprocess_env` (`tools/environments/local.py`), the one spawn surface that stripped `GH_TOKEN` and never re-injected it. Added `tests/tools/test_gh_token_inject_coverage.py`: an AST guard asserting every function that finalizes HOME also injects, with an explicit non-vacuity floor.
- Fix the `data <data@users.noreply.github.com>` author identity — same apply-if-absent gate — and harden resolution: process env → the agent's own `.env` → mount basename, with a warning when a generic mount basename (`/opt/data` → `data`) would become an author name. Boot now logs `identity=<name>`.

## Why

Three symptoms, one mechanism. Provisioning treated "a file exists here" as "this file is correct", so everything it wrote became permanent on the first boot that wrote it. On the fleet 2026-08-09, `hermes-matilde` / `-nimbleco` / `-cryptids` each held a `hosts.yml` frozen at 2026-07-23 with a `ghs_` installation token dead for ~16 days, and a `.gitconfig` still authoring as `data` even though `HERMES_AGENT_NAME` resolution had been fixed in e217ae2dc. `git` kept working throughout via the mint-on-demand credential helper, so nothing inside the container ever said the credential had died — the failure surfaced only as an unexplained 401 in whichever tool reached for `gh`.

## Verification

Fleet state confirmed read-only over SSH before writing any code — `hosts.yml` mtime `2026-07-23 22:09:09 +0000` on hermes-matilde with `HERMES_AGENT_NAME=matilde` in both the container env and `/opt/data/.env`, and `name = data` in `.gitconfig`.

Replayed the **exact production bytes** from hermes-matilde through the new boot path with the mint stubbed (`HERMES_AGENT_NAME` deliberately removed from the process env to exercise the `.env`-file fallback):

```
=== BOOT ===
git-credentials: home=/var/folders/.../tmp8i4wwptb identity=matilde provisioned (source=GITHUB_APP, wrote git(app)+gh(expires 2026-08-09T08:28:49Z))
=== AFTER ===
# managed-by: hermes git_credentials_boot
[credential]
	helper =
	helper = "!/.../python -m hermes_cli.github_app_token get-credential"
[user]
	name = matilde
	email = matilde@users.noreply.github.com
...
# managed-by: hermes git_credentials_boot
# token-expires-at: 2026-08-09T08:28:49Z
github.com:
    oauth_token: ghs_FRESH_MINT
    git_protocol: https
    user: x-access-token
=== SECOND BOOT (must be a no-op) ===
git-credentials: ... identity=matilde skipped (git+gh already current)
```

Marker lines confirmed inert to the real consumers — `yaml.safe_load` parses `hosts.yml` to the same dict as before, and real `git config --global --list` reads the marked `.gitconfig` identically in both PAT and App shapes.

Targeted suites, all green:

```
tests/hermes_cli/test_git_credentials_boot.py
tests/hermes_cli/test_github_app_token.py
tests/tools/test_gh_token_inject.py
tests/tools/test_gh_token_inject_coverage.py
tests/tools/test_hermes_subprocess_env.py
tests/tools/test_local_env_blocklist.py
tests/tools/test_local_env_session_leak.py
  → 188 passed in 3.16s
```

Guard checked non-vacuous by mutation: reverting only the `hermes_subprocess_env` injection makes `test_gh_token_inject_coverage.py` and three `TestEverySpawnSurface` cases fail (`5 failed, 19 passed`); restored and re-run green.

Full-suite comparison against the merge base (`c4978866d`), same runner, same flags:

| Suite | Base | This branch | Delta |
|---|---|---|---|
| `tests/tools/` | 50 failed, 8335 passed, 56 skipped | 51 failed, 8346 passed, 56 skipped | +11 passing, +1 failing |
| `tests/hermes_cli/ -k "credential or github_app or auth or boot"` | 49 failed, 1227 passed | 49 failed, 1258 passed | +31 passing, ±0 failing |

Both pre-existing failure sets are unrelated to this diff — `test_approval.py`, `test_tool_search.py`, `test_voice_mode.py` in `tests/tools/`, and `test_web_server*` in `tests/hermes_cli/`. The one extra `tests/tools/` failure is `test_voice_mode.py::TestPulseSocketReachable`, which is flaky on this machine across runs (it appears in the base run's list too, at a different count); every test in the files this PR touches passes.

`ruff check` clean on all changed files.

**CI on this PR:** 19 pass, 11 skipped, 1 real failure — `Python tests / Run tests slice 5/8`, which fails on `tests/hermes_cli/test_models.py::TestFetchOpenRouterModels` (a live OpenRouter model-list fetch asserting `qwen/qwen3.7-max` is present). Reproduced identically on a clean checkout of the base commit `c4978866d`; not caused by this diff. `Python lints / ruff enforcement`, `e2e`, and slices 1–4 and 6–8 all pass.

## Risk

- **Behavioural change on boot:** files this module previously left alone are now rewritten when they carry the marker or our generated shape. Legacy detection is deliberately narrow (the `insteadOf` rewrite pair plus one of our two credential-helper forms; `user: x-access-token` for `hosts.yml`; the `x-access-token` username for `.git-credentials`), and a human's own config is covered by tests on all three files. A false positive would overwrite someone's `.gitconfig` — worth a reviewer's eye on `is_managed_gitconfig`.
- **`hermes_subprocess_env` now hands `GH_TOKEN` to `inherit_credentials=True` spawns** (codex/copilot/TUI host). This narrows exposure rather than widening it: those spawns were already reaching the same token through `hosts.yml` and the helper's on-disk cache, and it is now short-lived, App-scoped and revocable instead of a frozen one. The long-lived PAT and the App private key stay stripped.
- **`_inject_github_app_gh_token` now writes to disk.** Guarded to at most one write per token (~50 min), skipped entirely for foreign `hosts.yml`, and wrapped so any failure leaves `GH_TOKEN` intact — the env var is the load-bearing path.
- Running containers keep the fossil until they restart; no deploy or restart is performed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
