### PR TITLE
fix(agent): make tool_call ids conversation-unique before anything keys on them

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -58,6 +58,10 @@ from agent.model_metadata import (
     save_context_length,
 )
 from agent.process_bootstrap import _install_safe_stdio
+from agent.tool_call_ids import (
+    count_visible_tool_results,
+    repair_conversation_tool_call_ids,
+)
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
@@ -850,6 +854,29 @@ def run_conversation(
                 agent.session_id or "-",
             )
 
+        # Make tool_call ids conversation-unique BEFORE anything keys on them.
+        # Some providers scope ids to the assistant message that issued them and
+        # restart the numbering every round (Moonshot kimi-k3 via OpenRouter:
+        # "read_file:0", "read_file:1", "terminal:0", ...).  Every id-keyed pass
+        # downstream — the pre-call orphan/duplicate sanitizer, the compressor's
+        # tool-pair sanitizer, the Codex Responses adapter — assumes ids are
+        # unique across the conversation, so a round-scoped provider makes every
+        # later round look like a duplicate of the first and its results get
+        # deleted before the request.  Repairing the stored list (not a per-call
+        # copy) means the session DB, the compressor and a resumed transcript all
+        # see clean ids too.  See agent/tool_call_ids.py for the incident.
+        renamed_ids = repair_conversation_tool_call_ids(
+            messages,
+            logger=request_logger,
+            model=agent.model,
+            provider=agent.provider,
+            session_id=agent.session_id or "",
+        )
+        if renamed_ids:
+            agent._tool_call_ids_renamed = (
+                getattr(agent, "_tool_call_ids_renamed", 0) + renamed_ids
+            )
+
         api_messages = []
         for idx, msg in enumerate(messages):
             api_msg = msg.copy()
@@ -1041,6 +1068,30 @@ def run_conversation(
         # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
+
+        # Invariant: whatever assembly did to the payload, the model must still
+        # see the tool output it asked for.  A tool result that vanishes here is
+        # invisible from the model's side — it requests a file, gets nothing back,
+        # and requests it again until the turn burns its api_call budget.  That
+        # failure used to be a debug line, which is why the production incident
+        # presented as "the model is stuck in a read loop" instead of "the harness
+        # deleted the answer".  Say it loudly, with the numbers.
+        _live_results, _live_chars = count_visible_tool_results(messages)
+        _api_results, _api_chars = count_visible_tool_results(api_messages)
+        if _api_results < _live_results:
+            _lost_chars = max(0, _live_chars - _api_chars)
+            _log = request_logger.error if _lost_chars >= 500 else request_logger.info
+            _log(
+                "Request assembly dropped %d of %d tool result(s) (%d characters "
+                "of tool output the model will not see) — model=%s provider=%s "
+                "session=%s. The model is likely to re-request this output.",
+                _live_results - _api_results,
+                _live_results,
+                _lost_chars,
+                agent.model,
+                agent.provider or "unknown",
+                agent.session_id or "-",
+            )
 
         # Calculate approximate request size for logging and pressure checks.
         # estimate_messages_tokens_rough(api_messages) includes the system

--- a/agent/tool_call_ids.py
+++ b/agent/tool_call_ids.py
@@ -1,0 +1,263 @@
+"""Keep ``tool_call_id`` unique across a whole conversation.
+
+Every OpenAI-compatible pairing rule in Hermes — the pre-call sanitizer's
+orphan/duplicate passes, the compressor's ``_sanitize_tool_pairs`` and
+``_prune_old_tool_results``, the Codex Responses adapter — keys a tool result
+to the assistant call that produced it by ``tool_call_id``.  All of them treat
+that id as unique *within the conversation*, because that is what the OpenAI
+schema implies.
+
+Some providers do not honour that.  They mint ids scoped to the assistant
+message that issued them and restart the numbering on every round.  Moonshot
+``kimi-k3`` served through OpenRouter returns::
+
+    round 1:  read_file:0   read_file:1   terminal:0
+    round 2:  read_file:0   read_file:1
+    round 3:  read_file:0
+
+Locally each result still follows its own call, so the transcript looks fine.
+Conversation-wide it is a catastrophe: every id-keyed pass sees round 2 and 3
+as duplicates of round 1.  In production session ``20260809_040444_3aca1c0f``
+that collapsed 191 tool results onto 10 distinct ids.  The pre-call sanitizer
+deleted the later 181, so the model received the FIRST ``read_file`` output
+and nothing afterwards — its prompt grew a constant ~23 tokens per API call
+whether the tool returned 286 characters or 10,533.  The model did the correct
+thing (re-read the file it could not see), the anti-repeat guard blocked it,
+and the turn ended at ``api_calls=60/60`` with ``response_len=0``.
+
+This module fixes the collision **at the source**: it rewrites the stored
+conversation so ids are conversation-unique before anything keys on them.
+That is deliberately upstream of every consumer, so the compressor and the
+persistence layer see clean ids too, and a resumed session whose transcript
+already carries colliding ids is repaired on its next request.
+
+Pairing is positional, which is the adjacency the rest of the pipeline
+already enforces: the tool results of a round immediately follow the
+assistant message that opened it, and no non-tool message intervenes.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, List, Optional, Tuple
+
+# Several OpenAI-compatible providers validate the length of tool_call_id.
+# Keep rewritten ids comfortably inside the smallest limit we have seen (64).
+MAX_TOOL_CALL_ID_LEN = 64
+
+# Suffix marker for a rewritten id.  ``[A-Za-z0-9_]`` only, so a provider that
+# accepted the original id accepts the rewrite.
+_SUFFIX_MARKER = "_r"
+
+
+def _tool_call_id(tc: Any) -> str:
+    """Read the id off a tool_call in dict or SDK-object form."""
+    if isinstance(tc, dict):
+        raw = tc.get("call_id") or tc.get("id") or ""
+    else:
+        raw = getattr(tc, "call_id", None) or getattr(tc, "id", None) or ""
+    return raw.strip() if isinstance(raw, str) else ""
+
+
+def _rewrite_tool_call_id(tc: Any, old_id: str, new_id: str) -> Any:
+    """Return a copy of ``tc`` whose id fields read ``new_id``.
+
+    Copies rather than mutates: an SDK tool_call object can be shared with the
+    live response object and the trajectory writer.  Only fields that actually
+    hold ``old_id`` are touched, so the Codex Responses split of
+    ``id``/``call_id`` (where the two differ on purpose) survives intact.
+    """
+    if isinstance(tc, dict):
+        clone = dict(tc)
+        for key in ("id", "call_id"):
+            value = clone.get(key)
+            if isinstance(value, str) and value.strip() == old_id:
+                clone[key] = new_id
+        return clone
+    try:
+        clone = copy.copy(tc)
+    except Exception:  # pragma: no cover — exotic provider object
+        return tc
+    for key in ("id", "call_id"):
+        value = getattr(clone, key, None)
+        if isinstance(value, str) and value.strip() == old_id:
+            try:
+                setattr(clone, key, new_id)
+            except Exception:  # pragma: no cover — frozen model
+                return tc
+    return clone
+
+
+def _mint_unique_id(base_id: str, used: set, counters: Dict[str, int]) -> str:
+    """Derive an unused id from ``base_id``.
+
+    Deterministic by construction: the same conversation prefix always yields
+    the same ids, so the provider's prompt cache still hits after a repair.
+    ``counters`` carries the next ordinal per stem, keeping a session with
+    thousands of collisions linear instead of rescanning from 2 each time.
+    """
+    stem = base_id or "tool_call"
+    budget = MAX_TOOL_CALL_ID_LEN - len(_SUFFIX_MARKER) - 6
+    if len(stem) > budget:
+        stem = stem[:budget]
+    n = counters.get(stem, 2)
+    while True:
+        candidate = f"{stem}{_SUFFIX_MARKER}{n}"
+        n += 1
+        if candidate not in used:
+            counters[stem] = n
+            return candidate
+
+
+def audit_tool_call_ids(messages: List[Dict[str, Any]]) -> Tuple[int, int, int]:
+    """Return ``(tool_results, distinct_ids, results_that_would_be_dropped)``.
+
+    A pure read used for logging and for tests.  ``results_that_would_be_dropped``
+    counts tool results whose id was already claimed by an earlier tool result
+    — exactly the set the pre-call de-duplication pass deletes.
+    """
+    seen: set = set()
+    total = 0
+    dropped = 0
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "tool":
+            continue
+        total += 1
+        cid = (msg.get("tool_call_id") or "").strip()
+        if not cid:
+            continue
+        if cid in seen:
+            dropped += 1
+        else:
+            seen.add(cid)
+    return total, len(seen), dropped
+
+
+def repair_conversation_tool_call_ids(
+    messages: List[Dict[str, Any]],
+    *,
+    logger: Optional[Any] = None,
+    model: str = "",
+    provider: str = "",
+    session_id: str = "",
+) -> int:
+    """Make every ``tool_call_id`` in ``messages`` conversation-unique.
+
+    Walks the conversation in order.  The first use of an id is kept verbatim
+    (so an already-correct transcript is byte-identical afterwards and the
+    prompt cache is untouched).  A later assistant round that reuses an id
+    gets a freshly minted one, and the tool results that follow that round are
+    repointed to it.
+
+    Mutates ``messages`` in place — the list is the live conversation, so the
+    repair also lands in the session DB, in the compressor's view, and in the
+    trajectory.  That is the point: the collision never reaches a consumer.
+
+    Duplicate ids *within a single assistant message* are left alone.  Their
+    results are genuinely indistinguishable, so inventing a pairing would be a
+    guess; the existing de-duplication pass still handles them.
+
+    Returns the number of tool_calls renamed.
+    """
+    # Snapshot the damage before repairing it — after the walk every id is
+    # unique by construction, so the "what would have been deleted" numbers
+    # are only observable from here.
+    pre_total, pre_distinct, pre_dropped = audit_tool_call_ids(messages)
+
+    used: set = set()
+    counters: Dict[str, int] = {}
+    renamed = 0
+    # Original id -> queue of ids minted for it in the round being walked.
+    # Cleared by every assistant/user/system boundary, which is what makes the
+    # pairing positional rather than global.
+    round_map: Dict[str, List[str]] = {}
+
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role == "tool":
+            cid = (msg.get("tool_call_id") or "").strip()
+            queue = round_map.get(cid)
+            if queue:
+                msg["tool_call_id"] = queue.pop(0)
+            continue
+
+        round_map = {}
+        if role != "assistant":
+            continue
+        tcs = msg.get("tool_calls")
+        if not isinstance(tcs, list) or not tcs:
+            continue
+
+        new_tcs: List[Any] = []
+        within: set = set()
+        changed = False
+        for tc in tcs:
+            cid = _tool_call_id(tc)
+            if not cid or cid in within:
+                # Nothing to key on, or a within-round duplicate.
+                new_tcs.append(tc)
+                continue
+            within.add(cid)
+            if cid in used:
+                new_id = _mint_unique_id(cid, used, counters)
+                new_tcs.append(_rewrite_tool_call_id(tc, cid, new_id))
+                round_map.setdefault(cid, []).append(new_id)
+                used.add(new_id)
+                renamed += 1
+                changed = True
+            else:
+                new_tcs.append(tc)
+                used.add(cid)
+        if changed:
+            msg["tool_calls"] = new_tcs
+
+    if renamed and logger is not None:
+        logger.error(
+            "Provider reuses tool_call ids across rounds (model=%s provider=%s "
+            "session=%s): renamed %d tool_call id(s). Before the repair this "
+            "conversation held %d tool result(s) on only %d distinct id(s), and "
+            "%d result(s) would have been deleted before the request — the model "
+            "would have re-requested output it could not see.",
+            model or "?",
+            provider or "?",
+            session_id or "-",
+            renamed,
+            pre_total,
+            pre_distinct,
+            pre_dropped,
+        )
+    return renamed
+
+
+def count_visible_tool_results(messages: List[Dict[str, Any]]) -> Tuple[int, int]:
+    """Return ``(tool_result_count, total_content_chars)`` for ``messages``.
+
+    Used as a request-time invariant: whatever the assembly pipeline does to
+    the payload, the number of tool results and the volume of tool output the
+    model can see must not silently collapse.
+    """
+    count = 0
+    chars = 0
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "tool":
+            continue
+        count += 1
+        content = msg.get("content")
+        if isinstance(content, str):
+            chars += len(content)
+        elif content is not None:
+            try:
+                chars += len(str(content))
+            except Exception:  # pragma: no cover — defensive
+                pass
+    return count, chars
+
+
+__all__ = [
+    "MAX_TOOL_CALL_ID_LEN",
+    "audit_tool_call_ids",
+    "count_visible_tool_results",
+    "repair_conversation_tool_call_ids",
+]

--- a/contributors/emails/frontdoor@nimbleco.ai
+++ b/contributors/emails/frontdoor@nimbleco.ai
@@ -1,0 +1,1 @@
+juniperbevensee

--- a/tests/agent/test_tool_call_id_uniqueness.py
+++ b/tests/agent/test_tool_call_id_uniqueness.py
@@ -1,0 +1,363 @@
+"""Regression: round-scoped tool_call ids must not delete the conversation.
+
+Reproduces production session ``20260809_040444_3aca1c0f`` (hermes-matilde,
+moonshotai/kimi-k3 via OpenRouter, 2026-08-09).  The provider mints tool_call
+ids scoped to the assistant message that issued them and restarts the
+numbering every round, so the session's 191 tool results landed on 10 distinct
+ids::
+
+    read_file:0   x102      execute_code:0  x7      terminal:1      x1
+    read_file:1   x 38      skill_view:0    x2      terminal:2      x1
+    terminal:0    x 36      search_files:0  x2      read_file:2     x1
+                            discord:0       x1
+
+Every id-keyed pass in the request pipeline assumes conversation-unique ids, so
+the pre-call sanitizer deleted the 181 later results — 386k of the session's
+395,594 characters of tool output — before the request.  The model's prompt
+grew ~23 tokens per API call whether the tool returned 286 characters or
+10,533, it re-read files it could not see, the anti-repeat guard blocked it,
+and the turn ended at api_calls=60/60 with response_len=0.
+"""
+
+import logging
+
+import pytest
+
+from agent.tool_call_ids import (
+    MAX_TOOL_CALL_ID_LEN,
+    audit_tool_call_ids,
+    count_visible_tool_results,
+    repair_conversation_tool_call_ids,
+)
+
+# --- The real incident, to the digit -------------------------------------
+
+INCIDENT_ROUNDS = 150
+INCIDENT_TOOL_RESULTS = 191
+INCIDENT_DISTINCT_IDS = 10
+INCIDENT_DELETED_RESULTS = INCIDENT_TOOL_RESULTS - INCIDENT_DISTINCT_IDS  # 181
+INCIDENT_TOOL_CHARS = 395_594
+
+
+def _incident_round_shapes():
+    """The per-round tool_call shapes that reproduce the incident histogram."""
+    shapes = []
+    shapes.append([("discord", 0)])
+    shapes.extend([[("read_file", 0), ("read_file", 1)] for _ in range(37)])
+    shapes.append([("read_file", 0), ("read_file", 1), ("read_file", 2)])
+    shapes.extend([[("read_file", 0)] for _ in range(64)])
+    shapes.extend([[("terminal", 0)] for _ in range(35)])
+    shapes.append([("terminal", 0), ("terminal", 1), ("terminal", 2)])
+    shapes.extend([[("execute_code", 0)] for _ in range(7)])
+    shapes.extend([[("skill_view", 0)] for _ in range(2)])
+    shapes.extend([[("search_files", 0)] for _ in range(2)])
+    return shapes
+
+
+def build_incident_transcript(separator=":"):
+    """A conversation shaped exactly like the wedged session.
+
+    ``separator`` selects the id flavour kimi-k3 emits: ``read_file:0`` (the
+    round-scoped form that wedged) or ``read_file_0``.
+    """
+    shapes = _incident_round_shapes()
+    total_results = sum(len(s) for s in shapes)
+    per_result = INCIDENT_TOOL_CHARS // total_results
+    remainder = INCIDENT_TOOL_CHARS - per_result * total_results
+
+    messages = [{"role": "user", "content": "keep going with the corollaries!"}]
+    emitted = 0
+    for round_idx, shape in enumerate(shapes):
+        tool_calls = []
+        for tool, index in shape:
+            tool_calls.append({
+                "id": f"{tool}{separator}{index}",
+                "type": "function",
+                "function": {"name": tool, "arguments": '{"path":"a.py"}'},
+            })
+        messages.append({
+            "role": "assistant",
+            "content": "",
+            "tool_calls": tool_calls,
+        })
+        for tool, index in shape:
+            emitted += 1
+            size = per_result + (remainder if emitted == total_results else 0)
+            messages.append({
+                "role": "tool",
+                "name": tool,
+                "tool_call_id": f"{tool}{separator}{index}",
+                "content": f"r{round_idx}:{tool}:{index}:".ljust(size, "x")[:size],
+            })
+    return messages
+
+
+def _sanitize(messages):
+    from agent.agent_runtime_helpers import sanitize_api_messages
+    return sanitize_api_messages([dict(m) for m in messages])
+
+
+def _assistant_round_ids(messages):
+    """[(assistant_index, [ids]), ...] in order."""
+    out = []
+    for i, m in enumerate(messages):
+        if m.get("role") == "assistant" and m.get("tool_calls"):
+            out.append((i, [tc["id"] for tc in m["tool_calls"]]))
+    return out
+
+
+# --- The transcript really is the incident -------------------------------
+
+
+def test_fixture_reproduces_the_incident_numbers():
+    messages = build_incident_transcript()
+    total, distinct, would_drop = audit_tool_call_ids(messages)
+    assert total == INCIDENT_TOOL_RESULTS
+    assert distinct == INCIDENT_DISTINCT_IDS
+    assert would_drop == INCIDENT_DELETED_RESULTS
+    assert len(_assistant_round_ids(messages)) == INCIDENT_ROUNDS
+    count, chars = count_visible_tool_results(messages)
+    assert (count, chars) == (INCIDENT_TOOL_RESULTS, INCIDENT_TOOL_CHARS)
+
+
+# --- The bug: unrepaired, the pipeline deletes the session ---------------
+
+
+def test_unrepaired_transcript_loses_almost_every_tool_result():
+    """Documents the pre-fix behaviour this change exists to prevent."""
+    messages = build_incident_transcript()
+    sanitized = _sanitize(messages)
+    count, chars = count_visible_tool_results(sanitized)
+    assert count == INCIDENT_DISTINCT_IDS, (
+        "without the repair the request carries one result per distinct id"
+    )
+    assert INCIDENT_TOOL_CHARS - chars == 374_884, (
+        "the model loses essentially all of its tool output"
+    )
+
+
+# --- The fix -------------------------------------------------------------
+
+
+def test_repair_preserves_every_tool_result_through_assembly():
+    messages = build_incident_transcript()
+    renamed = repair_conversation_tool_call_ids(messages)
+    assert renamed == INCIDENT_TOOL_RESULTS - INCIDENT_DISTINCT_IDS
+
+    total, distinct, would_drop = audit_tool_call_ids(messages)
+    assert (total, distinct, would_drop) == (INCIDENT_TOOL_RESULTS, INCIDENT_TOOL_RESULTS, 0)
+
+    sanitized = _sanitize(messages)
+    count, chars = count_visible_tool_results(sanitized)
+    assert count == INCIDENT_TOOL_RESULTS
+    assert chars == INCIDENT_TOOL_CHARS
+
+
+def test_repair_keeps_each_result_paired_with_its_own_call():
+    messages = build_incident_transcript()
+    repair_conversation_tool_call_ids(messages)
+
+    open_ids = None
+    round_idx = -1
+    seen_ids = set()
+    pairs = 0
+    for msg in messages:
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            round_idx += 1
+            open_ids = [tc["id"] for tc in msg["tool_calls"]]
+            for cid in open_ids:
+                assert cid not in seen_ids, f"duplicate id survived: {cid}"
+                seen_ids.add(cid)
+        elif msg.get("role") == "tool":
+            assert open_ids is not None
+            assert msg["tool_call_id"] in open_ids, (
+                "a result was repointed to a call from another round"
+            )
+            # The synthetic content encodes the round that produced it, so a
+            # mis-pairing across rounds is visible rather than plausible.
+            assert msg["content"].startswith(f"r{round_idx}:")
+            pairs += 1
+    assert pairs == INCIDENT_TOOL_RESULTS
+
+
+def test_repair_preserves_result_content_order():
+    """Result N after the repair is still the same bytes as result N before."""
+    before = [m["content"] for m in build_incident_transcript() if m["role"] == "tool"]
+    messages = build_incident_transcript()
+    repair_conversation_tool_call_ids(messages)
+    after = [m["content"] for m in messages if m["role"] == "tool"]
+    assert before == after
+
+
+def test_repair_is_idempotent():
+    messages = build_incident_transcript()
+    first = repair_conversation_tool_call_ids(messages)
+    ids_after_first = [ids for _, ids in _assistant_round_ids(messages)]
+    second = repair_conversation_tool_call_ids(messages)
+    assert first > 0
+    assert second == 0
+    assert [ids for _, ids in _assistant_round_ids(messages)] == ids_after_first
+
+
+def test_clean_transcript_is_left_byte_identical():
+    """A provider with conversation-unique ids must not be touched at all.
+
+    Rewriting ids on a healthy session would break the upstream prompt cache
+    for no reason — the same model on 2026-08-06 emitted ``session_search:0``,
+    ``session_search:1``, ``terminal:2`` (a counter that keeps climbing) and
+    ran fine.
+    """
+    messages = []
+    for r in range(20):
+        messages.append({
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": f"read_file_{r}",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }],
+        })
+        messages.append({
+            "role": "tool",
+            "name": "read_file",
+            "tool_call_id": f"read_file_{r}",
+            "content": "x" * 100,
+        })
+    snapshot = [dict(m) for m in messages]
+    assert repair_conversation_tool_call_ids(messages) == 0
+    assert messages == snapshot
+
+
+def test_within_round_duplicates_are_left_to_the_dedupe_pass():
+    """Two identical ids inside ONE assistant message are not repairable.
+
+    Their results are indistinguishable, so inventing a pairing would be a
+    guess.  The repair must leave them alone rather than mis-pair them.
+    """
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "read_file:0", "type": "function",
+                 "function": {"name": "read_file", "arguments": "{}"}},
+                {"id": "read_file:0", "type": "function",
+                 "function": {"name": "read_file", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "name": "read_file", "tool_call_id": "read_file:0", "content": "a"},
+        {"role": "tool", "name": "read_file", "tool_call_id": "read_file:0", "content": "b"},
+    ]
+    assert repair_conversation_tool_call_ids(messages) == 0
+    assert [tc["id"] for tc in messages[0]["tool_calls"]] == ["read_file:0", "read_file:0"]
+
+
+def test_a_user_turn_closes_a_round():
+    """A result must never be repointed across a user turn."""
+    messages = [
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "terminal:0", "type": "function",
+             "function": {"name": "terminal", "arguments": "{}"}}]},
+        {"role": "tool", "name": "terminal", "tool_call_id": "terminal:0", "content": "first"},
+        {"role": "user", "content": "sigue"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "terminal:0", "type": "function",
+             "function": {"name": "terminal", "arguments": "{}"}}]},
+        {"role": "tool", "name": "terminal", "tool_call_id": "terminal:0", "content": "second"},
+    ]
+    assert repair_conversation_tool_call_ids(messages) == 1
+    assert messages[1]["tool_call_id"] == "terminal:0"
+    assert messages[1]["content"] == "first"
+    new_id = messages[3]["tool_calls"][0]["id"]
+    assert new_id != "terminal:0"
+    assert messages[4]["tool_call_id"] == new_id
+    assert messages[4]["content"] == "second"
+
+
+def test_minted_ids_stay_inside_the_provider_length_limit():
+    """A rewritten id must fit the strictest provider limit we have seen.
+
+    The provider's own first id is left verbatim however long it is — that
+    one already round-tripped successfully, and shortening it would break
+    pairing for no reason.
+    """
+    long_stem = "a" * 120
+    messages = []
+    for _ in range(3):
+        messages.append({"role": "assistant", "content": "", "tool_calls": [
+            {"id": long_stem, "type": "function",
+             "function": {"name": "read_file", "arguments": "{}"}}]})
+        messages.append({"role": "tool", "tool_call_id": long_stem, "content": "x"})
+    assert repair_conversation_tool_call_ids(messages) == 2
+    minted = [
+        cid
+        for _, ids in _assistant_round_ids(messages)
+        for cid in ids
+        if cid != long_stem
+    ]
+    assert len(minted) == 2
+    for cid in minted:
+        assert len(cid) <= MAX_TOOL_CALL_ID_LEN
+    # The results follow their own calls.
+    assert [m["tool_call_id"] for m in messages if m["role"] == "tool"] == [
+        long_stem, minted[0], minted[1],
+    ]
+
+
+# --- The loud guard ------------------------------------------------------
+
+
+def test_repair_logs_an_error_naming_the_real_numbers(caplog):
+    messages = build_incident_transcript()
+    logger = logging.getLogger("test.tool_call_ids")
+    with caplog.at_level(logging.ERROR, logger="test.tool_call_ids"):
+        repair_conversation_tool_call_ids(
+            messages,
+            logger=logger,
+            model="moonshotai/kimi-k3",
+            provider="openrouter",
+            session_id="20260809_040444_3aca1c0f",
+        )
+    assert caplog.records, "a silent repair is how this went unnoticed for a whole turn"
+    text = caplog.records[0].getMessage()
+    assert "moonshotai/kimi-k3" in text
+    assert "20260809_040444_3aca1c0f" in text
+    assert str(INCIDENT_TOOL_RESULTS) in text
+    assert str(INCIDENT_DISTINCT_IDS) in text
+    assert str(INCIDENT_DELETED_RESULTS) in text
+
+
+# --- The wiring ----------------------------------------------------------
+
+
+def test_repair_runs_before_the_request_payload_is_assembled():
+    """The repair is worthless if it lands after api_messages is built."""
+    import inspect
+
+    from agent import conversation_loop
+
+    src = inspect.getsource(conversation_loop.run_conversation)
+    repair_at = src.find("repair_conversation_tool_call_ids(")
+    assemble_at = src.find("api_messages = []")
+    assert repair_at != -1, "run_conversation no longer repairs tool_call ids"
+    assert assemble_at != -1
+    assert repair_at < assemble_at, (
+        "tool_call ids must be made unique before the request copy is built"
+    )
+
+
+def test_dropped_tool_results_are_reported_loudly():
+    """The request-assembly invariant fires when results go missing."""
+    import inspect
+
+    from agent import conversation_loop
+
+    src = inspect.getsource(conversation_loop.run_conversation)
+    assert "count_visible_tool_results(messages)" in src
+    assert "count_visible_tool_results(api_messages)" in src
+    assert "Request assembly dropped" in src
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

- Add `agent/tool_call_ids.py` and call it from `run_conversation` before the request copy is assembled: any tool_call id a provider reuses across assistant rounds is renamed so ids are unique across the whole conversation. The repair runs on the stored message list, so the session DB, the compressor and a resumed transcript all see clean ids — not just the wire copy.
- Keep the first use of every id verbatim, so a provider that already mints conversation-unique ids is byte-identical after the pass and the upstream prompt cache is untouched. Duplicates *within* one assistant message are deliberately left alone (their results are indistinguishable, so a pairing would be a guess).
- Log an ERROR the first time a provider is caught reusing ids, naming model, provider, session, the tool-result count, the distinct-id count and how many results would have been deleted.
- Add a request-assembly invariant: if the API payload carries fewer tool results than the live conversation, log an ERROR with the number of results and characters of tool output the model will not see.
- Regression test built from the real incident (`tests/agent/test_tool_call_id_uniqueness.py`): 150 rounds, 191 tool results, 10 distinct ids, 395,594 characters.

## Why

Moonshot `kimi-k3` served through OpenRouter mints tool_call ids scoped to the assistant message that issued them (`read_file:0`, `read_file:1`, `terminal:0`) and restarts the numbering every round. Every id-keyed pass in Hermes assumes ids are unique across the conversation, so in hermes-matilde session `20260809_040444_3aca1c0f` the pre-call sanitizer deleted 181 of 191 tool results — 374,884 of 395,594 characters — before the request. The prompt grew a constant +23 tokens per API call whether `read_file` returned 286 characters or 10,533; the model correctly re-read the file it could not see, the anti-repeat guard blocked it, and the turn ended at `api_calls=60/60` with `response_len=0`. Fixing the ids at the source means no consumer downstream — sanitizer, compressor, adapter — has to know the provider is unusual.

## Verification

Ran with `.venv/bin/python -m pytest`:

```
tests/agent/test_tool_call_id_uniqueness.py ....... 13 passed in 0.61s
tests/agent/test_context_compressor.py
tests/agent/test_context_engine.py
tests/agent/test_tool_call_id_uniqueness.py ....... 219 passed in 7.22s
tests/run_agent ................................... 2078 passed, 4 skipped, 3 deselected in 125.14s
```

Fails before the change:

- With `agent/tool_call_ids.py` removed and `agent/conversation_loop.py` reverted: `ModuleNotFoundError: No module named 'agent.tool_call_ids'` — collection error.
- With the module present but the `conversation_loop` wiring reverted: `2 failed, 11 passed` (`test_repair_runs_before_the_request_payload_is_assembled`, `test_dropped_tool_results_are_reported_loudly`).

`test_unrepaired_transcript_loses_almost_every_tool_result` runs the unrepaired incident transcript through the real `sanitize_api_messages` and asserts the exact pre-fix loss (10 of 191 results survive, 374,884 characters gone). It passes on both sides — it is the executable statement of the bug, not the fix.

Diagnosis evidence is read-only production observation: `/opt/data/logs/agent.log` on `hermes-matilde` (the +23-token-per-call sequence, the BLOCKED escalation, `api_calls=60/60 response_len=0`) and a read-only query of `/opt/data/state.db` for the id histogram (`read_file:0` ×102, `read_file:1` ×38, `terminal:0` ×36, …) and totals. Healthy sessions on the same model on 2026-08-06 carry `session_search:0`, `session_search:1`, `terminal:2` — a counter that keeps climbing — and show 51/51 and 66/66 unique ids.

Not verified: no live agent run against OpenRouter. The fix is exercised only by the reconstructed transcript and the existing suites.

## Risk

- The repair mutates the live message list, so a session whose transcript already carries colliding ids changes ids once on its next request. That invalidates the upstream prompt-cache prefix for exactly one call on affected sessions; a healthy session is untouched.
- Rows already flushed to the session DB keep their original ids. Re-loading such a session re-applies the same deterministic repair, so the in-memory view converges to the same ids every time.
- The request-assembly invariant can fire on a genuine orphan drop after a session resume. It is rate-limited by content: ERROR only when ≥500 characters of tool output are lost, INFO otherwise.

## Links

- Overlaps by design with `dev/juniperbevensee/tool-call-id-collision-drops-results`, which repairs the same collision in the per-request copy inside `sanitize_api_messages`. If both land, that pass becomes a no-op safety net — this change removes the collision before it reaches it. Worth deciding which layer to keep before merging either.
