### PR TITLE
ci(upstream-sync): track release tags, auto-take upstream-owned areas

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -7,11 +7,32 @@ name: Upstream Sync
 # overlaps upstream's churn — so it failed every week. A merge only conflicts
 # on files BOTH sides actually changed (a far smaller surface), and records
 # our divergence as a single merge commit rather than rewriting it each run.
+#
+# Syncs to the latest upstream RELEASE TAG, not the moving `main`. Upstream
+# ships tags like v2026.8.3; `main` is whatever landed minutes ago. Tracking
+# tags means we merge something upstream has itself decided is coherent, and
+# each sync is a nameable version rather than "whatever Monday 06:00 caught".
+# Override with the `ref` input to sync to an arbitrary ref (e.g. `main`) when
+# a specific fix is needed before it is tagged.
+#
+# Files under AUTO_TAKE_UPSTREAM below are resolved automatically in upstream's
+# favour. These are areas this fork does not meaningfully diverge in (~5 commits
+# total), where a conflict is noise that buries the handful of real ones.
+# Everything else — agent, gateway, hermes_cli, plugins, tools, AND tests and
+# ui-tui — always goes to a human. tests/ is deliberately excluded: this fork has
+# 63 test files of its own and has modified 43 of upstream's, so auto-taking there
+# would silently delete our own regression tests. Adding a path here is a decision
+# to discard fork changes in it, so measure the fork delta before you do.
 
 on:
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Upstream ref to sync to (default: latest release tag)'
+        required: false
+        type: string
 
 jobs:
   sync:
@@ -35,45 +56,137 @@ jobs:
       - name: Fetch upstream
         run: |
           git remote add upstream https://github.com/NousResearch/hermes-agent.git || true
-          git fetch upstream main
+          git fetch upstream main --tags --force
+
+      - name: Resolve target ref
+        id: target
+        env:
+          # Via env, never interpolated into the script body: a workflow_dispatch
+          # input is attacker-controllable text and `${{ }}` splices it in before
+          # bash ever sees it.
+          REF: ${{ inputs.ref }}
+        run: |
+          if [ -n "$REF" ]; then
+            TARGET="$REF"
+            echo "Using explicitly requested ref: $TARGET"
+          else
+            # Latest upstream release tag by version order. Upstream tags look
+            # like v2026.8.3 / v2026.7.7.2 — `--sort=-v:refname` orders those
+            # correctly, where a plain lexical sort would put v2026.7.7 above
+            # v2026.7.30.
+            TARGET=$(git tag -l 'v*' --sort=-v:refname --merged upstream/main | head -1)
+            if [ -z "$TARGET" ]; then
+              echo "::warning::No upstream release tag found; falling back to upstream/main"
+              TARGET="upstream/main"
+            fi
+            echo "Latest upstream release tag: $TARGET"
+          fi
+          echo "ref=$TARGET" >> "$GITHUB_OUTPUT"
+
+          # Tracking tags means the noop path is now reachable for weeks at a time
+          # BY DESIGN, which makes "green and quiet" indistinguishable from "upstream
+          # stopped tagging" or "our tag fetch broke". Say how far behind the tag is.
+          BEHIND=$(git rev-list --count "$TARGET..upstream/main" 2>/dev/null || echo 0)
+          echo "$TARGET is $BEHIND commit(s) behind upstream/main"
+          if [ "$BEHIND" -gt 3000 ]; then
+            echo "::warning::${TARGET} is ${BEHIND} commits behind upstream/main — upstream may have stopped tagging releases, or tag fetching is broken. Sync is tracking a stale target."
+          fi
 
       - name: Attempt merge
         id: merge
+        env:
+          TARGET: ${{ steps.target.outputs.ref }}
         run: |
           BRANCH="upstream-sync-$(date +%Y%m%d)"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           git checkout -b "$BRANCH"
 
           # Nothing new upstream → no-op (avoids empty PRs/issues every week).
-          if git merge-base --is-ancestor upstream/main HEAD; then
+          if git merge-base --is-ancestor "$TARGET" HEAD; then
             echo "status=noop" >> "$GITHUB_OUTPUT"
-            echo "Already up to date with upstream/main."
+            echo "Already up to date with $TARGET."
             exit 0
           fi
 
-          if git merge --no-edit upstream/main; then
+          if git merge --no-edit "$TARGET"; then
             echo "status=clean" >> "$GITHUB_OUTPUT"
-          else
-            git diff --name-only --diff-filter=U > /tmp/conflicts.txt || true
-            git merge --abort
-            echo "status=conflict" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          # Auto-resolve conflicts in areas this fork does not meaningfully
+          # diverge in. Every path here is one where taking upstream wholesale is
+          # the answer we would give by hand anyway, and where leaving them in
+          # buries the few real conflicts. Deliberately EXCLUDES agent/, gateway/,
+          # hermes_cli/, plugins/ and tools/ — the fork's actual surface.
+          # NOT tests/ and NOT ui-tui/. The fork is heavily divergent in both —
+          # 63 fork-authored test files and 43 upstream test files this fork has
+          # modified — so auto-taking upstream there would silently delete our own
+          # regression tests, including the ones guarding fork-only behaviour. The
+          # areas kept below carry a fork delta of ~5 commits total.
+          AUTO_TAKE_UPSTREAM='apps/ website/ nix/ docs/'
+          AUTO_RESOLVED=0
+          for area in $AUTO_TAKE_UPSTREAM; do
+            # NUL-delimited, and fed by process substitution rather than a pipe, so
+            # (a) paths with spaces and non-ASCII paths (git quotes those by default
+            # under core.quotePath) survive, and (b) AUTO_RESOLVED is incremented in
+            # this shell rather than a subshell that discards it.
+            while IFS= read -r -d '' f; do
+              # --theirs during a merge is the incoming side (upstream).
+              if git checkout --theirs -- "$f" 2>/dev/null; then
+                git add -- "$f"
+                AUTO_RESOLVED=$((AUTO_RESOLVED+1))
+              elif git rm -q --force -- "$f" 2>/dev/null; then
+                # Deleted-by-upstream conflicts have no --theirs blob to take.
+                AUTO_RESOLVED=$((AUTO_RESOLVED+1))
+              else
+                # Neither path worked — leave it conflicted for a human rather than
+                # reporting it as resolved.
+                echo "::warning::could not auto-resolve $f; leaving it for manual review"
+              fi
+            done < <(git diff -z --name-only --diff-filter=U -- "$area" 2>/dev/null)
+          done
+          echo "auto_resolved=$AUTO_RESOLVED" >> "$GITHUB_OUTPUT"
+
+          REMAINING=$(git diff --name-only --diff-filter=U | wc -l | tr -d ' ')
+          if [ "$REMAINING" -eq 0 ]; then
+            # Everything left was auto-take territory. Still a PR, never a
+            # silent push — CI gates it and a human reviews it.
+            git commit --no-edit -m "chore: sync with upstream $TARGET" -m "Auto-resolved $AUTO_RESOLVED conflict(s) in upstream-owned areas ($AUTO_TAKE_UPSTREAM) by taking upstream's version. No conflicts remained in this fork's own surface."
+            echo "status=clean" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git diff --name-only --diff-filter=U > /tmp/conflicts.txt || true
+          git merge --abort
+          echo "status=conflict" >> "$GITHUB_OUTPUT"
 
       - name: Create PR on clean merge
         if: steps.merge.outputs.status == 'clean'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET: ${{ steps.target.outputs.ref }}
+          AUTO_RESOLVED: ${{ steps.merge.outputs.auto_resolved }}
         run: |
           BRANCH="${{ steps.merge.outputs.branch }}"
           git push origin "$BRANCH"
+
+          # State auto-resolution in the PR body. A silent auto-take would be the
+          # same class of mistake as the swallowed 403s below: a green result that
+          # hides what it did.
+          if [ "${AUTO_RESOLVED:-0}" -gt 0 ]; then
+            RESOLVED_NOTE="$(printf '\n\n⚠ **%s conflict(s) were auto-resolved** by taking upstream'"'"'s version in \x60apps/\x60, \x60website/\x60, \x60nix/\x60 and \x60docs/\x60. No conflict remained in this fork'"'"'s own surface (\x60agent/\x60, \x60gateway/\x60, \x60hermes_cli/\x60, \x60plugins/\x60, \x60tools/\x60, \x60tests/\x60, \x60ui-tui/\x60). If this fork has started diverging in an auto-take area, that divergence was just discarded — check the diff before merging.' "$AUTO_RESOLVED")"
+          else
+            RESOLVED_NOTE=""
+          fi
+
           # --repo is REQUIRED: the job adds an `upstream` remote, and without
           # an explicit repo gh resolves against NousResearch/hermes-agent,
           # where the workflow token 403s. That 403 was then swallowed by the
           # fallback echo, so the run went green with nothing created.
           if ! gh pr create \
             --repo "$GITHUB_REPOSITORY" \
-            --title "chore: sync with upstream $(date +%Y-%m-%d)" \
-            --body "Automated weekly merge of \`upstream/main\` (NousResearch/hermes-agent). Merged cleanly — no conflicts. **Review CI before merging**; a clean text merge can still silently drop a fork patch where upstream rewrote the same region, so let the test suite gate it." \
+            --title "chore: sync with upstream $TARGET" \
+            --body "$(printf 'Automated weekly merge of \x60%s\x60 (NousResearch/hermes-agent).%s\n\n**Review CI before merging**; a clean text merge can still silently drop a fork patch where upstream rewrote the same region, so let the test suite gate it.\n' "$TARGET" "$RESOLVED_NOTE")" \
             --base main \
             --head "$BRANCH"; then
             # Only tolerate the duplicate-PR case; any other failure must fail the run.
@@ -85,6 +198,8 @@ jobs:
         if: steps.merge.outputs.status == 'conflict'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET: ${{ steps.target.outputs.ref }}
+          AUTO_RESOLVED: ${{ steps.merge.outputs.auto_resolved }}
         run: |
           # Ensure the label exists first — a missing label used to fail the
           # whole job (could not add label: 'upstream-sync' not found), so the
@@ -99,8 +214,12 @@ jobs:
             --force || true
 
           CONFLICTS="$(cat /tmp/conflicts.txt 2>/dev/null || echo '(see workflow logs)')"
+          COUNT="$(wc -l < /tmp/conflicts.txt 2>/dev/null | tr -d ' ' || echo '?')"
           DATE="$(date +%Y%m%d)"
-          TITLE="Upstream sync conflict $(date +%Y-%m-%d)"
+          # Dedupe key must be STABLE across re-runs on the same day. It deliberately
+          # excludes the conflict count: a re-run that resolves a different number of
+          # files is the same sync, and keying on the count would file a duplicate.
+          TITLE="Upstream sync conflict $(date +%Y-%m-%d) ($TARGET)"
           # Skip only a true duplicate; otherwise let a create failure fail the run
           # instead of masking it (masked 403s hid three weeks of conflicts).
           if gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "in:title \"$TITLE\"" --json number -q '.[0].number' | grep -q .; then
@@ -110,5 +229,5 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --title "$TITLE" \
               --label upstream-sync \
-              --body "$(printf 'Weekly merge of \x60upstream/main\x60 hit conflicts in:\n\n\x60\x60\x60\n%s\n\x60\x60\x60\n\nResolve locally:\n\n\x60\x60\x60bash\ngit fetch upstream main\ngit checkout -b upstream-sync-%s origin/main\ngit merge upstream/main   # resolve the files above\nuv lock                   # if pyproject changed\n# run the full suite, then open a PR to main\n\x60\x60\x60\n' "$CONFLICTS" "$DATE")"
+              --body "$(printf 'Weekly merge of \x60%s\x60 hit **%s** conflicting file(s) this fork owns, after auto-resolving %s in upstream-owned areas (\x60apps/\x60, \x60website/\x60, \x60nix/\x60, \x60docs/\x60):\n\n\x60\x60\x60\n%s\n\x60\x60\x60\n\nReproduce locally — the auto-resolution below is what CI did, so run it too or your counts will not match:\n\n\x60\x60\x60bash\ngit fetch upstream main --tags\ngit checkout -b upstream-sync-%s origin/main\ngit merge %s || true\nfor area in apps/ website/ nix/ docs/; do\n  git diff -z --name-only --diff-filter=U -- \"$area\" \\\n    | xargs -0 -r -I{} sh -c \x27git checkout --theirs -- \"{}\" && git add -- \"{}\"\x27\ndone\n# the files listed above are what remains — resolve those by hand\nuv lock                   # if pyproject changed\n# run the full suite, then open a PR to main\n\x60\x60\x60\n\n---\n\n**If this list runs to hundreds or thousands of files, stop — do not resolve it.** That is the signature of lost ancestry, not real divergence: a merge landed as content without recording upstream as a parent, so git is re-offering changes we already have.\n\nDo **not** reach for \x60git merge -s ours\x60 to fix it. An audit on 2026-08-12 showed why: recording an anchor the fork has not fully absorbed permanently and silently strands every upstream change missing from our tree — measured at ~54 files, including a Windows-sandbox security fix — and those files then auto-merge cleanly forever after, so no reviewer ever sees them again. It is irreversible in practice.\n\nInstead do a **real merge** of the already-absorbed upstream point and resolve its conflicts, so the tree and the history agree. See \x60knowledge/plans/\x60 in the memory repo for the 2026-08 write-up.\n' "$TARGET" "$COUNT" "${AUTO_RESOLVED:-0}" "$CONFLICTS" "$DATE" "$TARGET")"
           fi


### PR DESCRIPTION
> **Rewritten 2026-08-12 after an adversarial audit.** This PR originally also carried a `git merge -s ours` ancestry commit and 9 contributor mappings. The audit found the ancestry commit unsafe; it and its dependent commits have been dropped. What remains is the workflow change alone, with six defects the audit found in it fixed. See "What was dropped and why".

## The problem

Six weekly upstream-sync conflict issues are open and none is workable: #74, #82, #99, #122, #133, #145. The most recent listed 1,113 conflicting files, so the fork has taken nothing from upstream since 19 July.

## What this does

**1. Sync to the latest upstream release tag, not `main`.** `main` is whatever landed minutes before the cron fired; a tag is something upstream considers coherent. A `ref` dispatch input overrides it when a fix is needed pre-tag.

Tag selection uses `--sort=-v:refname`. Verified this matters: on `{v2026.7.7, v2026.7.30, v2026.8.3, v2026.10.1}` a lexical sort picks `v2026.8.3`; version sort correctly picks `v2026.10.1`.

**2. Auto-take upstream in `apps/ website/ nix/ docs/`** — and deliberately **not** `tests/` or `ui-tui/`.

This is the audit's most important catch. Measured fork divergence per area: ~5 commits across the four kept paths, versus **63 fork-authored test files and 43 upstream test files this fork has modified**. Auto-taking `tests/` would have silently deleted our own regression tests — precisely the invisible-loss failure this workflow exists to prevent.

## Other defects the audit found, now fixed

| defect | why it mattered |
|---|---|
| `ref` interpolated into the `run:` body | a dispatch input is attacker-controllable; `${{ }}` splices it in before bash sees it. Now passed via `env:` |
| `for f in $(git diff …)` | word-split on paths with spaces, and git quotes non-ASCII paths. Both failed, `\|\| true` swallowed it, files left unmerged but counted as resolved. Now NUL-delimited |
| loop ran in a subshell | `AUTO_RESOLVED` was discarded. Now fed by process substitution |
| unresolvable path counted as resolved | now warns and stays conflicted for a human |
| noop path silent | tag tracking makes "green and quiet" reachable for weeks by design, so it could no longer be distinguished from "upstream stopped tagging". Now reports how far behind the tag is |
| dedupe key embedded the conflict count | a same-day re-run filed a duplicate issue. Now keyed on date + target |
| issue remediation didn't reproduce CI | the auto-take is discarded by `merge --abort`, so the reported counts were unreachable locally. The issue now emits what CI actually ran |

## What was dropped and why

The dropped commit recorded upstream ancestry with `git merge -s ours`, cutting a trial merge from **1,113 conflicts to 102**. That number was real; the commit was still wrong.

The fork has **not** absorbed everything up to that anchor. ~54 files upstream changed are missing from our tree, and recording the anchor makes them **permanently and silently unreachable** — including a Windows-sandbox security fix, and a partial content loss in `hermes_cli/browser_connect.py` that would leave a surviving upstream test importing three functions that no longer exist.

The irreversible part: after such an anchor those files auto-merge cleanly forever, raising no conflict, so no reviewer ever sees them again.

My original justification claimed the cost was "five billing files … the only content this commit forgoes." That was wrong by an order of magnitude — 21 files sit at pre-merge content, 7 unrelated to billing, and the sampling method I used put most of the real loss in a bucket I described as benign.

The ancestry repair is still worth doing. It needs to be a **real merge** with its ~35 conflicts resolved, so tree and history agree — not an assertion that we already have the content. Tracked separately.

## Verification

- Auto-take loop exercised against real merge conflicts in a scratch repo — a path with a space, a non-ASCII path, and a delete/modify conflict. All three resolve, the count survives the loop, `agent/` is left conflicted for a human, and the fork's content in it is untouched.
- Tag ordering verified on the ambiguous tag set above.
- YAML parses.
- **Not verified:** the workflow has not run end-to-end on GitHub. First scheduled run is the real test; every outcome is a PR or an issue, never a direct push, so a bad merge cannot land unreviewed.

## Follow-up

Close #74, #82, #99, #122, #133 and #145 only once the ancestry repair actually lands — they describe a state this PR does not by itself fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVGWjkFfMfWq6eHktrjSQk
