### PR TITLE
test(models): make the OpenRouter picker tests hermetic

### DIFF
--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -1,5 +1,6 @@
 """Tests for the hermes_cli models module."""
 
+from contextlib import ExitStack, contextmanager
 from unittest.mock import patch, MagicMock
 
 from hermes_cli.nous_account import NousPortalAccountInfo
@@ -17,6 +18,48 @@ LIVE_OPENROUTER_MODELS = [
     ("qwen/qwen3.7-max", ""),
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
 ]
+
+# A model id that no real catalog will ever label as the silent default, so
+# pinning it keeps the "default" badge branch out of tests that aren't about it.
+_NEVER_THE_SILENT_DEFAULT = "sentinel/not-a-real-model"
+
+# Description stamped on the pinned curated entries. ``fetch_openrouter_models``
+# recomputes every description on the live path, so this string can only ever
+# reach a caller through the "live refresh produced nothing, return the curated
+# fallback" branch. That makes it a vacuity marker: a test that wants to prove
+# it exercised the live path asserts this string is absent from the result.
+CURATED_FALLBACK_MARKER = "curated-fallback"
+
+
+@contextmanager
+def _pinned_curated_openrouter(ids, *, silent_default=_NEVER_THE_SILENT_DEFAULT):
+    """Make ``fetch_openrouter_models`` depend only on its stubbed live payload.
+
+    ``fetch_openrouter_models`` intersects the live OpenRouter ``/v1/models``
+    response against a *curated* preference list, and that list is fetched over
+    the network from the hosted ``model-catalog.json`` manifest. Stubbing only
+    ``_urlopen_model_catalog_request`` therefore leaves the test asserting on
+    whichever models the manifest happens to publish today: when
+    ``qwen/qwen3.7-max`` was dropped upstream, two tests here went red on
+    ``main`` and stayed red, with no change on our side. The badge the first
+    entry receives leaks the same way, via the catalog's ``"default": true``
+    label read out of ``~/.hermes/cache``.
+
+    Pinning both inputs makes these tests exercise OUR filtering, ordering and
+    badge logic against a fixed catalog. Regressions in that logic still fail
+    the tests; upstream catalog churn no longer does.
+    """
+    curated = [(mid, CURATED_FALLBACK_MARKER) for mid in ids]
+    with ExitStack() as stack:
+        stack.enter_context(patch(
+            "hermes_cli.model_catalog.get_curated_openrouter_models",
+            return_value=curated,
+        ))
+        stack.enter_context(patch(
+            "hermes_cli.models.get_preferred_silent_default_model",
+            return_value=silent_default,
+        ))
+        yield
 
 
 
@@ -70,13 +113,50 @@ class TestFetchOpenRouterModels:
                 return b'{"data":[{"id":"anthropic/claude-opus-4.8","pricing":{"prompt":"0.000015","completion":"0.000075"}},{"id":"qwen/qwen3.7-max","pricing":{"prompt":"0.000000325","completion":"0.00000195"}},{"id":"nvidia/nemotron-3-super-120b-a12b:free","pricing":{"prompt":"0","completion":"0"}}]}'
 
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
+        with _pinned_curated_openrouter(
+            ["anthropic/claude-opus-4.8", "qwen/qwen3.7-max", "nvidia/nemotron-3-super-120b-a12b:free"]
+        ), patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
             models = fetch_openrouter_models(force_refresh=True)
 
         assert models == [
             ("anthropic/claude-opus-4.8", "recommended"),
             ("qwen/qwen3.7-max", ""),
             ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
+        ]
+
+    def test_silent_default_keeps_its_badge_through_the_live_refresh(self, monkeypatch):
+        """The catalog-labeled silent default is badged "default", not "recommended".
+
+        Guards the branch that ``_pinned_curated_openrouter`` pins away in the
+        tests above: entry [0] normally gets the "recommended" badge, but when
+        it is the silent default the "default" badge must win so the picker
+        shows which model Hermes lands on when the user never picks one.
+        """
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"data":['
+                    b'{"id":"anthropic/claude-opus-4.8","pricing":{"prompt":"0.000015","completion":"0.000075"}},'
+                    b'{"id":"qwen/qwen3.7-max","pricing":{"prompt":"0.000000325","completion":"0.00000195"}}'
+                    b']}'
+                )
+
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        with _pinned_curated_openrouter(
+            ["anthropic/claude-opus-4.8", "qwen/qwen3.7-max"],
+            silent_default="anthropic/claude-opus-4.8",
+        ), patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
+            models = fetch_openrouter_models(force_refresh=True)
+
+        assert models == [
+            ("anthropic/claude-opus-4.8", "default"),
+            ("qwen/qwen3.7-max", ""),
         ]
 
 
@@ -167,12 +247,21 @@ class TestFetchOpenRouterModels:
                 )
 
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
+        with _pinned_curated_openrouter(
+            ["anthropic/claude-opus-4.8", "qwen/qwen3.7-max"]
+        ), patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
             models = fetch_openrouter_models(force_refresh=True)
 
+        # Both models survive the tool-support filter...
         ids = [mid for mid, _ in models]
         assert "anthropic/claude-opus-4.8" in ids
         assert "qwen/qwen3.7-max" in ids
+        # ...and did so on the LIVE path. Without this, a regression that made
+        # the filter restrictive would drop every model, leave `curated` empty,
+        # and return the curated fallback — which contains both ids, so the
+        # assertions above would still pass while the behaviour under test was
+        # gone. The marker only ever survives on the fallback path.
+        assert CURATED_FALLBACK_MARKER not in [desc for _, desc in models]
 
 
 class TestOpenRouterToolSupportHelper:


### PR DESCRIPTION
## Why

`Python tests / Run tests slice 3/8` fails on `main`, so **every PR ships with a red required check**. That trains everyone to ignore red, which is how the next real failure gets missed.

## What was actually wrong

Two tests in `tests/hermes_cli/test_models.py` were reaching the network and asserting on live OpenRouter model ids. When `qwen/qwen3.7-max` was dropped from the hosted catalog, they broke:

```
AssertionError: assert 'qwen/qwen3.7-max' in ['anthropic/claude-opus-4.8']
```

The decisive evidence: **with the network blocked the old tests pass, with the network on they fail.** The outcome was decided by wifi, not by our code.

## What changed

Test file only — no production code. The model list is now a fixture, so the tests assert on *our parsing logic* rather than on whatever OpenRouter serves today. They pass with or without a network.

## Verification

Mutation-tested, because a test that cannot fail is worse than a skipped one: 8 of 8 sabotage mutants to the production function are still caught. Baseline green before and after.

## Known gap, pre-existing

Nothing in this file proves the model catalog is fetched *at all* — deleting the fetch call keeps every test green. That hole predates this change and is not addressed here; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVGWjkFfMfWq6eHktrjSQk