### PR TITLE
lint(ruff): enable F811 and fix the redefinitions it surfaces

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -757,7 +757,6 @@ class HindsightMemoryProvider(MemoryProvider):
         """Custom setup wizard — installs only the deps needed for the selected mode."""
         import subprocess
         import shutil
-        import sys
         from pathlib import Path
 
         from hermes_cli.config import save_config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -389,17 +389,36 @@ preview = true  # required for PLW1514 (unspecified-encoding) — preview rule
 # which silently corrupts any non-ASCII file content.  We had three
 # separate Windows sandbox regressions in one debug session before
 # adding the explicit encoding.  This rule keeps new code honest.
-# NOTE (2026-08-12): F811 (redefinition-of-unused-name) is worth enabling and is
-# NOT enabled here on purpose. This merge silently produced two byte-identical
-# duplicate definitions from "keep both sides" conflict resolution — a function in
-# plugins/platforms/discord/adapter.py and a 183-line test class in
-# tests/hermes_cli/test_web_server.py — and nothing caught them: identical
-# duplicates still pass their tests, and `ruff check .` is only ever asked about
-# PLW1514. Every future upstream merge has that same failure mode.
-# Turning F811 on today surfaces 18 pre-existing hits (mostly function-local
-# import shadowing), so it needs its own cleanup PR rather than riding along with
-# an ancestry merge. Do it.
-select = ["PLW1514"]
+#
+# F811 (redefinition-of-unused-name) guards the merge failure mode: when a
+# conflict is resolved by "keep both sides", the second definition silently
+# shadows the first.  Nothing else catches this.  If the two copies are
+# identical it is dead code that no test can detect — every test still passes
+# because the surviving copy behaves the same.  If they have *drifted*, it is
+# worse: the first definition stops running entirely and its coverage
+# disappears without a single red test.  The 2026-08-12 upstream ancestry
+# merge produced both kinds — a duplicated function in
+# plugins/platforms/discord/adapter.py, a duplicated 183-line test class in
+# tests/hermes_cli/test_web_server.py, and four same-name-different-body test
+# definitions whose earlier copies had not executed in some time.
+#
+# This rule is deliberately NOT in per-file-ignores below: tests and plugins
+# are exactly where shadowed definitions hide, since a shadowed test is
+# invisible by construction.  A genuinely intentional redefinition (a lazy
+# import to break a cycle, a conditional re-export) should carry a targeted
+# `# noqa: F811` with a one-line reason rather than reopening the rule.
+select = ["PLW1514", "F811"]
+
+# F811 skips any name matching dummy-variable-rgx, and ruff's default for that
+# regex is "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$" — which matches *every*
+# underscore-prefixed name, not just throwaways.  With the default, F811 stays
+# silent on a duplicated `_truncate_discord_component_text`, i.e. exactly the
+# production duplicate this rule was turned on to catch; it would only have
+# flagged the duplicated test class.  Narrow the regex to bare underscores
+# (`_`, `__`), which is what "dummy" is actually meant to mean, so module-private
+# helpers are covered.  Only PLW1514 and F811 are selected, so this setting
+# changes nothing else today.
+dummy-variable-rgx = "^_+$"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can intentionally exercise locale-encoding edge cases.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -65,6 +65,7 @@ def _clean_env(monkeypatch):
         "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_KEY",
         "OPENAI_MODEL", "LLM_MODEL", "NOUS_INFERENCE_BASE_URL",
         "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
+        "NVIDIA_API_KEY", "NVIDIA_BASE_URL",
     ):
         monkeypatch.delenv(key, raising=False)
     # Module-level unhealthy cache (10-min TTL) leaks between tests;
@@ -98,7 +99,7 @@ def codex_auth_dir(tmp_path, monkeypatch):
     return codex_dir
 
 
-class TestAuxiliaryMaxTokensParam:
+class TestAuxiliaryMaxTokensParamCustomRuntime:
     def test_uses_max_completion_tokens_for_github_copilot_custom_base(self):
         with patch("agent.auxiliary_client._resolve_custom_runtime", return_value=("https://api.githubcopilot.com", "key", None)), \
              patch("agent.auxiliary_client._read_nous_auth", return_value=None):
@@ -5160,16 +5161,6 @@ class TestBuildCallKwargsToolDedup:
             provider="openai", model="gpt-4o", messages=[], tools=None,
         )
         assert "tools" not in kwargs
-
-
-@pytest.fixture(autouse=True)
-def _clean_env(monkeypatch):
-    """Strip provider env vars so each test starts clean."""
-    for key in (
-        "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_KEY",
-        "NVIDIA_API_KEY", "NVIDIA_BASE_URL",
-    ):
-        monkeypatch.delenv(key, raising=False)
 
 
 class TestNvidiaBillingHeaders:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -3047,21 +3047,6 @@ def test_xai_oauth_concurrent_pool_instances_refresh_single_use_token_once(
 # ---------------------------------------------------------------------------
 
 
-def _codex_auth_store(access_token: str, refresh_token: str) -> dict:
-    return {
-        "version": 1,
-        "active_provider": "openai-codex",
-        "providers": {
-            "openai-codex": {
-                "tokens": {
-                    "access_token": access_token,
-                    "refresh_token": refresh_token,
-                },
-            }
-        },
-    }
-
-
 def test_is_terminal_codex_oauth_refresh_error():
     from hermes_cli.auth import AuthError, _is_terminal_codex_oauth_refresh_error
 

--- a/tests/docker/test_zombie_reaping.py
+++ b/tests/docker/test_zombie_reaping.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import time
 
-from tests.docker.conftest import docker_exec, docker_exec_sh, start_container, start_container
+from tests.docker.conftest import docker_exec, docker_exec_sh, start_container
 
 
 def test_orphan_zombies_reaped(

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -153,7 +153,7 @@ class TestDingTalkAdapterInit:
 # ---------------------------------------------------------------------------
 
 
-class TestExtractText:
+class TestExtractTextLegacyShapes:
 
     def test_extracts_dict_text(self):
         from plugins.platforms.dingtalk.adapter import DingTalkAdapter
@@ -173,6 +173,10 @@ class TestExtractText:
         from plugins.platforms.dingtalk.adapter import DingTalkAdapter
         msg = MagicMock()
         msg.text = ""
+        # Must be explicit: an unset MagicMock attribute auto-creates a truthy
+        # Mock, which would satisfy the `rich_text_content` branch and stop the
+        # legacy `rich_text` path this test exists to cover from ever running.
+        msg.rich_text_content = None
         msg.rich_text = [{"text": "part1"}, {"text": "part2"}, {"image": "url"}]
         assert DingTalkAdapter._extract_text(msg) == "part1 part2"
 
@@ -180,6 +184,7 @@ class TestExtractText:
         from plugins.platforms.dingtalk.adapter import DingTalkAdapter
         msg = MagicMock()
         msg.text = ""
+        msg.rich_text_content = None
         msg.rich_text = None
         assert DingTalkAdapter._extract_text(msg) == ""
 

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -375,7 +375,7 @@ class TestMattermostSend:
         assert payload["root_id"] == "root_post_123"
 
     @pytest.mark.asyncio
-    async def test_progress_send_with_invalid_thread_root_never_falls_back_flat(self):
+    async def test_progress_send_with_invalid_thread_root_never_falls_back_flat_after_api_error(self):
         """Tool/status/progress bubbles must stay quiet when the thread is broken."""
         self.adapter._reply_mode = "thread"
         self.adapter._api_get = AsyncMock(return_value={"id": "bad_root", "root_id": ""})

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3015,8 +3015,7 @@ class TestReactions:
         assert "1234567890.000001" in adapter._reacting_message_ids
 
         # Simulate the base class calling on_processing_start
-        from gateway.platforms.base import MessageEvent, MessageType, SessionSource
-        from gateway.config import Platform
+        from gateway.platforms.base import MessageType, SessionSource
 
         source = SessionSource(
             platform=Platform.SLACK,
@@ -3058,12 +3057,10 @@ class TestReactions:
         adapter._app.client.reactions_remove = AsyncMock()
 
         from gateway.platforms.base import (
-            MessageEvent,
             MessageType,
             SessionSource,
             ProcessingOutcome,
         )
-        from gateway.config import Platform
 
         source = SessionSource(
             platform=Platform.SLACK,
@@ -3134,12 +3131,10 @@ class TestReactions:
 
         # Hooks should also be no-ops when disabled
         from gateway.platforms.base import (
-            MessageEvent,
             MessageType,
             SessionSource,
             ProcessingOutcome,
         )
-        from gateway.config import Platform
 
         source = SessionSource(
             platform=Platform.SLACK,

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -566,7 +566,7 @@ def test_toolset_has_keys_for_vision_accepts_codex_auth(tmp_path, monkeypatch):
     assert _toolset_has_keys("vision") is True
 
 
-def test_save_platform_tools_preserves_mcp_server_names():
+def test_save_platform_tools_preserves_mcp_server_names_and_unselected_builtins():
     """Ensure MCP server names are preserved when saving platform tools.
 
     Regression test for https://github.com/NousResearch/hermes-agent/issues/1247

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -7073,8 +7073,6 @@ class TestDashboardPluginManifestExtensions:
 # monkeypatch that hook.
 # ---------------------------------------------------------------------------
 
-import sys
-
 
 skip_on_windows = pytest.mark.skipif(
     sys.platform.startswith("win"), reason="PTY bridge is POSIX-only"

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -1081,7 +1081,6 @@ class TestSafeStderr:
 
     def test_returns_stderr_on_utf8_system(self, monkeypatch):
         """On UTF-8 systems, _safe_stderr() returns sys.stderr unchanged."""
-        import io
         fake_stderr = io.StringIO()
         monkeypatch.setattr(sys, "stderr", fake_stderr)
         # On Linux/macOS, encoding is typically utf-8
@@ -1091,7 +1090,6 @@ class TestSafeStderr:
 
     def test_wraps_non_utf8_stderr(self, monkeypatch):
         """On non-UTF-8 systems (e.g. Windows cp949), wraps stderr with UTF-8."""
-        import io
 
         class FakeStderr:
             """Simulates a Windows stderr with legacy encoding."""
@@ -1114,7 +1112,6 @@ class TestSafeStderr:
 
     def test_handler_emits_unicode_without_crash(self, tmp_path):
         """StreamHandler with _safe_stderr can emit Unicode messages."""
-        import io
 
         # Create a stderr-like stream with ASCII encoding
         class AsciiStream:

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -368,7 +368,6 @@ def test_manager_fails_fast_noninteractive_without_cached_tokens(tmp_path, monke
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
 
 def _fake_response(status, url, body):

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -1258,7 +1258,6 @@ class TestVisionCpuBurstCap:
         encodes ever run at once — even though all N calls are in flight
         simultaneously (proving the analyses themselves are NOT serialized).
         """
-        import asyncio
         import importlib
         from concurrent.futures import ThreadPoolExecutor
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5359,36 +5359,6 @@ def _coerce_seed_history(value: Any) -> list[dict]:
     return history
 
 
-def _content_display_text(content: Any) -> str:
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, (int, float)):
-        return str(content)
-    if isinstance(content, list):
-        parts = []
-        for part in content:
-            text = _content_display_text(part).strip()
-            if text:
-                parts.append(text)
-        return "\n".join(parts)
-    if isinstance(content, dict):
-        kind = content.get("type")
-        if kind in {"text", "input_text", "output_text"}:
-            return str(content.get("text") or content.get("content") or "")
-        if kind in {"image_url", "input_image", "image"}:
-            return "[image]"
-        if kind in {"input_audio", "audio"}:
-            return "[audio]"
-        if kind:
-            return f"[{kind}]"
-        if "text" in content:
-            return str(content.get("text") or "")
-        return "[structured content]"
-    return str(content)
-
-
 def _inflight_text(value: Any) -> str:
     return _content_display_text(value).strip()
 


### PR DESCRIPTION
Enables ruff's `F811` (redefinition-of-unused-name) and clears the pre-existing hits, as the `NOTE` in `pyproject.toml` asked for.

## Why

`.github/workflows/lint.yml` runs a blocking `ruff check .`, but `select` was `["PLW1514"]` only — so nothing in CI could see a duplicate definition. The 2026-08-12 ancestry merge produced two from "keep both sides" conflict resolution, and the green suite could not catch either: **identical duplicates simply shadow each other, so every test still passes.** Every future upstream merge has the same failure mode.

## Two findings that changed the shape of this PR

### 1. `F811` alone does not work

Ruff skips `F811` for any name matching `dummy-variable-rgx`, and the default value matches **every** underscore-prefixed name, not just throwaways. With the default, the rule stays silent on a duplicated `_truncate_discord_component_text` — precisely the production duplicate that motivated turning it on. It would have caught only the duplicated test class.

Narrowing to `dummy-variable-rgx = "^_+$"` (bare underscores, which is what "dummy" is meant to mean) is what actually makes the guard work. Only `PLW1514` and `F811` are selected, so this setting changes nothing else today.

Narrowing it also surfaced three more real duplicates that were otherwise invisible, including one in production code.

### 2. The duplicates were not all dead code

Seven definitions shared a name but had **different bodies**, meaning the earlier copy had silently stopped running — lost coverage, not just clutter:

| Location | What was wrong |
|---|---|
| `tui_gateway/server.py` `_content_display_text` | Byte-identical 28-line duplicate in production code — removed |
| `test_auxiliary_client.py` `_clean_env` | Two `autouse` fixtures. The live one cleared fewer env vars and had dropped the module-level unhealthy-cache reset, so that test-isolation fix was **not in effect**. Merged — note this fixture is consumed by **8** call sites in the file, not 2; a reviewer should look at all of them. |
| `test_credential_pool.py` `_codex_auth_store` | Shadowing copy dropped `auth_mode`/`id_token`/`last_refresh`. Removed so the realistic store is used everywhere. |
| 4 test defs in `auxiliary_client`, `dingtalk`, `mattermost`, `tools_config` | Earlier, generally stricter versions never executed. Renamed so both run — **recovers 8 tests**. |

One recovered test needed a real fix. The dingtalk legacy rich-text case set `msg.rich_text` on a `MagicMock` without setting `rich_text_content` — and an unset `MagicMock` attribute auto-creates a *truthy* Mock, which satisfies the newer branch first and prevents the legacy path from ever running. Production code is correct; a real legacy object (no `rich_text_content` attribute) returns the right text. The test now sets it explicitly, with a comment.

The remaining hits were redundant function-local re-imports of names already bound at module scope. None were lazy imports guarding a cycle or a slow module, so all were deleted rather than `noqa`'d.

`F811` is deliberately **not** added to `per-file-ignores` — tests and plugins are exactly where shadowed definitions hide, since a shadowed test is invisible by construction.

## Verification

- `ruff check .` → clean.
- **Guard proven**: reintroduced the byte-identical `_truncate_discord_component_text` duplicate in `plugins/platforms/discord/adapter.py`; `ruff check .` failed on it; removed it again. (This is the step that caught finding #1 — with the default regex, this test passed silently.)
- Affected slices: 1500 tests pass across the 10 touched files, up 8 from the revived tests.
- Full suite run and diffed against pristine `main`: the 34 pre-existing env-dependent failures are identical. One extra file appeared, `tests/tools/test_base_environment.py` — a shell-concurrency race that fails **2 of 6 runs on unmodified `main`**, so it is flaky, not a regression.

## Note

`ruff` emits a pre-existing warning about an invalid `# noqa` on `run_agent.py:107`. It is a prose comment mentioning `# noqa: F401` inside a sentence, is identical on `main`, and is not masking anything. Left alone to keep this PR scoped.

