### PR TITLE
fix(memory): scope DMs and stop persisting the merged view into scoped files

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1436,11 +1436,26 @@ def init_agent(
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
             if agent._memory_enabled or agent._user_profile_enabled:
-                from tools.memory_tool import MemoryStore
+                from tools.memory_tool import MemoryStore, derive_context_id
+                # Per-context scoping (gateway/messaging only). Off by default;
+                # when enabled we partition memory by platform:chat_type:chat_id
+                # so a fact learned in one DM/group is isolated from others. The
+                # interactive CLI has no chat_id, so derive_context_id → None
+                # and the store stays unscoped regardless of the flag.
+                _context_id = None
+                _include_global = False
+                if mem_config.get("context_scoping_enabled", False):
+                    _context_id = derive_context_id(
+                        getattr(agent, "platform", None),
+                        getattr(agent, "_chat_type", None),
+                        getattr(agent, "_chat_id", None),
+                    )
+                    _include_global = bool(mem_config.get("include_global_in_scoped", False))
                 agent._memory_store = MemoryStore(
                     memory_char_limit=mem_config.get("memory_char_limit", 2200),
                     user_char_limit=mem_config.get("user_char_limit", 1375),
-                    context_id=context_id,
+                    context_id=_context_id,
+                    include_global=_include_global,
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2572,6 +2572,26 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
+def _context_id_for_source(source) -> Optional[str]:
+    """Derive the per-context memory id for a ``SessionSource``, or None.
+
+    Scopes EVERY chat type (DMs included) and platform-qualifies the id so the
+    same chat_id can't leak memory across platforms or between a DM and a
+    group. Returns None when there is no chat_id (routes to unscoped/global
+    memory). Delegates to the single-sourced ``derive_context_id`` so the
+    gateway and ``agent_init`` compute identical ids.
+    """
+    from tools.memory_tool import derive_context_id
+
+    platform = getattr(source, "platform", None)
+    platform_str = getattr(platform, "value", None) or (str(platform) if platform else None)
+    return derive_context_id(
+        platform_str,
+        getattr(source, "chat_type", None),
+        getattr(source, "chat_id", None),
+    )
+
+
 def _channel_override_lookup_keys(
     chat_id: str,
     *,
@@ -3328,12 +3348,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _context_id_for_source(source) -> Optional[str]:
         """Derive memory context_id from message source.
 
-        Group/forum/channel chats get per-chat scoped memory; DMs get global
-        memory (None).  MemoryStore sanitizes the returned value before use.
+        Delegates to the module-level ``_context_id_for_source`` so the gateway
+        and ``agent_init`` compute identical ids.
+
+        This previously scoped only group/forum/channel and returned None for
+        everything else — which filed DM (and thread, and unknown-chat_type)
+        memory into the GLOBAL layer, where it was merged into every scoped
+        read. Every chat type with a chat_id is now scoped and
+        platform-qualified.
         """
-        if source.chat_type in ("group", "forum", "channel") and source.chat_id:
-            return str(source.chat_id)
-        return None
+        return _context_id_for_source(source)
 
     def _wire_teams_pipeline_runtime(self) -> None:
         """Bind the Teams meeting pipeline runtime to Graph webhook ingress.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2283,6 +2283,26 @@ DEFAULT_CONFIG = {
         "write_approval": False,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        # Per-context memory scoping (gateway only). When True, memory in a
+        # messaging chat is partitioned to contexts/{platform:chat_type:chat_id}/
+        # so a fact learned in one DM or group is not readable in another.
+        # Default False = today's behavior (single shared memory). No effect on
+        # the interactive CLI, which is always unscoped.
+        # mt DIVERGES FROM UPSTREAM (which defaults this False): scoping is
+        # already unconditional on this fork, so defaulting to False would
+        # silently collapse every agent back to one shared memory. Keep it on.
+        "context_scoping_enabled": True,
+        # When scoping is on, whether a scoped context ALSO reads the shared
+        # global MEMORY.md/USER.md as a read-only layer. Default False keeps
+        # scoped contexts fully isolated; True lets them see (but never edit)
+        # global facts.
+        #
+        # mt DIVERGES FROM UPSTREAM (False) and sets this True: mt's global
+        # layer is what holds the agent's name, personality and skills, and
+        # those must stay visible inside a group. That is only safe now that
+        # DMs are scoped too — under the old code global also collected DM
+        # content, which is precisely what made the merged read a leak.
+        "include_global_in_scoped": True,
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".

--- a/scripts/migrate_memory_contexts.py
+++ b/scripts/migrate_memory_contexts.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Migrate memory context directories onto the platform-qualified id format.
+
+Background
+----------
+Before the partitioned MemoryStore landed, the gateway scoped memory by the
+raw ``chat_id`` (e.g. ``group:<signal-id>``) and, on every ordinary scoped
+write, persisted the MERGED global+scoped view into the scoped file. Two
+consequences survive the code fix and need a data pass:
+
+1. The context id format changed to ``{platform}:{chat_type}:{chat_id}``.
+   Directories under the old name are never loaded again, so their genuinely
+   scoped entries drop out of the agent's read view.
+2. Those directories still contain copies of global entries. The store's
+   self-heal only runs for a context it actually loads, so an orphaned
+   directory keeps its copied global content on disk indefinitely.
+
+This script renames each old-format directory to its new id and strips any
+entry that is also present in the global file for that target.
+
+Safety
+------
+Dry-run by default: prints the plan and changes nothing. Pass ``--apply`` to
+write. ``--apply`` takes a timestamped backup of each memories directory it
+touches before modifying it.
+
+Platform cannot be recovered from the directory name alone, so it must be
+supplied per run with ``--platform``. Ids that do not look like they belong to
+that platform are reported and skipped rather than guessed at.
+
+Usage
+-----
+    # inspect every agent on this host
+    python3 scripts/migrate_memory_contexts.py ~/.hermes-*/memories --platform signal
+
+    # commit the change
+    python3 scripts/migrate_memory_contexts.py ~/.hermes-*/memories --platform signal --apply
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+ENTRY_DELIMITER = "\n§\n"
+TARGETS = (("memory", "MEMORY.md"), ("user", "USER.md"))
+
+# A directory name already in {platform}:{chat_type}:{chat_id} form. The chat
+# id itself may contain ':' (Signal's "group:<id>"), so only the first two
+# segments are structural.
+_NEW_FORMAT = re.compile(r"^[a-z0-9_]+:[a-z0-9_]+:.+$", re.IGNORECASE)
+
+# Chat types the old gateway could produce a scoped directory for. It only
+# ever scoped group/forum/channel; everything else went to global.
+_OLD_SCOPED_CHAT_TYPES = ("group", "forum", "channel")
+
+
+def read_entries(path: Path) -> List[str]:
+    if not path.exists():
+        return []
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    if not raw.strip():
+        return []
+    return [e for e in (x.strip() for x in raw.split(ENTRY_DELIMITER)) if e]
+
+
+def write_entries(path: Path, entries: List[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(ENTRY_DELIMITER.join(entries), encoding="utf-8")
+
+
+def infer_chat_type(old_id: str, platform: str) -> Optional[str]:
+    """Infer the chat_type the old id was scoped under, or None if unclear.
+
+    The old gateway only created scoped directories for group/forum/channel,
+    so a directory that exists at all was one of those. Signal encodes it in
+    the id itself; for other platforms we cannot distinguish group from
+    channel and say so rather than guessing.
+    """
+    if old_id.startswith("group:"):
+        return "group"
+    if platform == "signal":
+        # Signal DMs were never scoped, so a non-"group:" Signal directory is
+        # not something this script knows how to name.
+        return None
+    return None
+
+
+def plan_for_memories_dir(
+    mem_dir: Path, platform: str
+) -> Tuple[List[Dict], List[Dict]]:
+    """Return (actions, skipped) for one memories/ directory."""
+    actions: List[Dict] = []
+    skipped: List[Dict] = []
+    contexts = mem_dir / "contexts"
+    if not contexts.is_dir():
+        return actions, skipped
+
+    globals_by_target = {
+        target: set(read_entries(mem_dir / fname)) for target, fname in TARGETS
+    }
+
+    for entry in sorted(contexts.iterdir()):
+        if not entry.is_dir():
+            continue
+        old_id = entry.name
+
+        if _NEW_FORMAT.match(old_id) and not old_id.startswith("group:"):
+            skipped.append({"dir": old_id, "reason": "already new format"})
+            continue
+
+        chat_type = infer_chat_type(old_id, platform)
+        if chat_type is None:
+            skipped.append({
+                "dir": old_id,
+                "reason": f"cannot infer chat_type for platform '{platform}' "
+                          f"— rename by hand or rerun with the right --platform",
+            })
+            continue
+
+        new_id = f"{platform}:{chat_type}:{old_id}"
+        safe_new_id = new_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+
+        strip: Dict[str, int] = {}
+        keep: Dict[str, List[str]] = {}
+        for target, fname in TARGETS:
+            entries = read_entries(entry / fname)
+            if not entries:
+                continue
+            gset = globals_by_target[target]
+            kept = [e for e in entries if e not in gset]
+            strip[fname] = len(entries) - len(kept)
+            keep[fname] = kept
+
+        actions.append({
+            "mem_dir": mem_dir,
+            "old_dir": entry,
+            "old_id": old_id,
+            "new_id": safe_new_id,
+            "new_dir": contexts / safe_new_id,
+            "strip": strip,
+            "keep": keep,
+        })
+
+    return actions, skipped
+
+
+def apply_action(action: Dict) -> None:
+    new_dir: Path = action["new_dir"]
+    old_dir: Path = action["old_dir"]
+
+    # Rewrite the files with global-copied entries removed, then move the dir.
+    for fname, kept in action["keep"].items():
+        write_entries(old_dir / fname, kept)
+
+    if new_dir.exists():
+        # Merge into an existing new-format dir rather than clobbering it.
+        for fname, kept in action["keep"].items():
+            existing = read_entries(new_dir / fname)
+            merged = list(dict.fromkeys(existing + kept))
+            write_entries(new_dir / fname, merged)
+        shutil.rmtree(old_dir)
+    else:
+        old_dir.rename(new_dir)
+
+
+def backup(mem_dir: Path, stamp: str) -> Path:
+    dest = mem_dir.parent / f"{mem_dir.name}.pre-migration-{stamp}"
+    shutil.copytree(mem_dir, dest)
+    return dest
+
+
+def main(argv: List[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("memories_dirs", nargs="+", type=Path,
+                    help="one or more agent memories/ directories")
+    ap.add_argument("--platform", required=True,
+                    help="platform these agents run on (e.g. signal, telegram)")
+    ap.add_argument("--apply", action="store_true",
+                    help="write the changes (default is a dry run)")
+    args = ap.parse_args(argv)
+
+    stamp = time.strftime("%Y%m%dT%H%M%S")
+    total_actions = 0
+    total_stripped = 0
+
+    for mem_dir in args.memories_dirs:
+        if not mem_dir.is_dir():
+            print(f"!! {mem_dir}: not a directory, skipping")
+            continue
+
+        actions, skipped = plan_for_memories_dir(mem_dir, args.platform)
+        if not actions and not skipped:
+            continue
+
+        print(f"\n=== {mem_dir}")
+        for s in skipped:
+            print(f"  -- skip {s['dir']}\n       {s['reason']}")
+        for a in actions:
+            stripped = sum(a["strip"].values())
+            total_stripped += stripped
+            print(f"  -> {a['old_id']}")
+            print(f"     rename to {a['new_id']}")
+            for fname, n in sorted(a["strip"].items()):
+                kept = len(a["keep"].get(fname, []))
+                print(f"     {fname}: drop {n} global-copied, keep {kept} scoped")
+        total_actions += len(actions)
+
+        if args.apply and actions:
+            dest = backup(mem_dir, stamp)
+            print(f"  backup: {dest}")
+            for a in actions:
+                apply_action(a)
+            print(f"  applied {len(actions)} migration(s)")
+
+    verb = "applied" if args.apply else "planned (dry run — pass --apply to write)"
+    print(f"\n{total_actions} directory migration(s) {verb}; "
+          f"{total_stripped} global-copied entries removed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/gateway/test_context_id_derivation.py
+++ b/tests/gateway/test_context_id_derivation.py
@@ -1,0 +1,137 @@
+"""Tests for gateway per-context memory id derivation.
+
+`_context_id_for_source` turns a messaging SessionSource into the context id
+used to partition memory. The guarantees under test:
+
+  - Every chat type is scoped, DMs included (fixes the leak where DMs were
+    left unscoped and shared one global memory).
+  - Ids are platform-qualified, so the same raw chat_id on two platforms — or
+    the same id used for a DM and a group — never collide.
+  - No chat_id ⇒ None ⇒ unscoped/global memory (interactive CLI, no-chat).
+  - Path-unsafe chat_ids are sanitized by MemoryStore and stay under contexts/.
+
+Uses the real Platform enum plus a lightweight fake source; no real chat ids.
+"""
+
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from gateway.run import _context_id_for_source
+from gateway.config import Platform
+from tools.memory_tool import MemoryStore, derive_context_id
+
+# Patch get_memory_dir on the exact module object MemoryStore came from, not by
+# dotted string: tests/tools/test_memory_tool_import_fallback.py reimports
+# tools.memory_tool, so a later sys.modules entry can be a different object.
+_MEM_MOD = sys.modules[MemoryStore.__module__]
+
+
+@dataclass
+class FakeSource:
+    """Minimal stand-in for gateway SessionSource: only the attributes the
+    derivation reads."""
+    platform: object
+    chat_type: str
+    chat_id: Optional[str]
+
+
+def test_dm_is_scoped():
+    """A DM is scoped (non-None) — the leak this fixes was DMs going unscoped."""
+    cid = _context_id_for_source(FakeSource(Platform.TELEGRAM, "dm", "u1"))
+    assert cid is not None
+    assert cid == "telegram:dm:u1"
+
+
+def test_group_is_scoped():
+    cid = _context_id_for_source(FakeSource(Platform.TELEGRAM, "group", "123"))
+    assert cid == "telegram:group:123"
+
+
+def test_no_chat_id_is_unscoped():
+    """Missing chat_id ⇒ None ⇒ global/unscoped memory."""
+    assert _context_id_for_source(FakeSource(Platform.LOCAL, "dm", None)) is None
+    assert _context_id_for_source(FakeSource(Platform.LOCAL, "dm", "")) is None
+
+
+def test_platform_qualified_ids_dont_collide():
+    """Same chat_id '123' as a group on TELEGRAM vs SLACK → distinct ids."""
+    tg = _context_id_for_source(FakeSource(Platform.TELEGRAM, "group", "123"))
+    sl = _context_id_for_source(FakeSource(Platform.SLACK, "group", "123"))
+    assert tg != sl
+    assert tg == "telegram:group:123"
+    assert sl == "slack:group:123"
+
+
+def test_dm_and_group_same_chat_id_distinct():
+    """Same chat_id '123' as a DM vs a group → distinct ids (no cross-type leak)."""
+    dm = _context_id_for_source(FakeSource(Platform.TELEGRAM, "dm", "123"))
+    grp = _context_id_for_source(FakeSource(Platform.TELEGRAM, "group", "123"))
+    assert dm != grp
+
+
+def test_string_platform_supported():
+    """A plugin platform passed as a bare string (no .value) still derives."""
+    cid = _context_id_for_source(FakeSource("irc", "group", "42"))
+    assert cid == "irc:group:42"
+
+
+def test_context_id_path_safe(tmp_path, monkeypatch):
+    """A chat_id containing path-traversal sequences is sanitized by the store
+    and stays under contexts/ — never escapes the memories dir."""
+    monkeypatch.setattr(_MEM_MOD, "get_memory_dir", lambda: tmp_path)
+
+    cid = _context_id_for_source(FakeSource(Platform.SLACK, "group", "../../etc/x"))
+    assert cid is not None
+
+    store = MemoryStore(context_id=cid)
+    store.load_from_disk()
+    store.add("memory", "trapped")
+
+    # No escape outside the memories tree.
+    assert not (tmp_path.parent.parent / "etc" / "x" / "MEMORY.md").exists()
+    # The scoped file lives under contexts/.
+    contexts = tmp_path / "contexts"
+    assert contexts.exists()
+    written = list(contexts.rglob("MEMORY.md"))
+    assert written, "expected a scoped MEMORY.md under contexts/"
+    for p in written:
+        assert contexts in p.parents
+
+
+class TestLiveDerivationPath:
+    """agent/agent_init.py is the LIVE construction site: it calls
+    tools.memory_tool.derive_context_id directly with the agent's stored
+    platform string / chat_type / chat_id (the gateway threads these onto the
+    agent). These tests exercise that shared core so the wired path — not only
+    the gateway-typed _context_id_for_source adapter — is covered, and assert
+    the two entry points agree."""
+
+    def test_derive_context_id_matches_source_helper(self):
+        """The bare-string core and the SessionSource adapter agree, so the
+        gateway and agent_init compute identical ids."""
+        via_core = derive_context_id("telegram", "dm", "u1")
+        via_source = _context_id_for_source(FakeSource(Platform.TELEGRAM, "dm", "u1"))
+        assert via_core == via_source == "telegram:dm:u1"
+
+    def test_cli_like_source_is_unscoped(self):
+        """The interactive CLI passes platform='cli' with no chat_id → None,
+        so a scoped store is never built even if scoping is enabled."""
+        assert derive_context_id("cli", None, None) is None
+        assert derive_context_id("cli", "dm", "") is None
+
+    def test_dm_scoped_via_core(self):
+        assert derive_context_id("slack", "dm", "u9") == "slack:dm:u9"
+
+
+def test_derivation_matches_stored_context_id(tmp_path, monkeypatch):
+    """The colon-delimited id resolves to a single directory under contexts/
+    (the ':' separators are kept verbatim, not treated as path boundaries)."""
+    monkeypatch.setattr(_MEM_MOD, "get_memory_dir", lambda: tmp_path)
+    cid = _context_id_for_source(FakeSource(Platform.TELEGRAM, "dm", "u1"))
+    store = MemoryStore(context_id=cid)
+    store.load_from_disk()
+    store.add("memory", "hi")
+    assert (tmp_path / "contexts" / "telegram:dm:u1" / "MEMORY.md").exists()

--- a/tests/tools/test_memory_scoping.py
+++ b/tests/tools/test_memory_scoping.py
@@ -1,355 +1,361 @@
-"""Tests for context_id-based memory scoping in MemoryStore.
+"""Tests for opt-in context_id memory partitioning in MemoryStore.
 
-Validates that:
-- No context_id → global path (backward compatible)
-- context_id → writes to contexts/{id}/, reads merge global + scoped
-- Different contexts are isolated from each other
-- Concurrent writes to different contexts don't block each other
+Partition model (per target ∈ {memory, user}):
+  - Global files:  <memories>/MEMORY.md, USER.md  (unchanged, backward compatible)
+  - Scoped files:  <memories>/contexts/{context_id}/MEMORY.md, USER.md
+
+Guarantees under test:
+  - A scoped file on disk contains ONLY scoped entries — global facts are
+    never copied into it (the core isolation bug this partition model fixes).
+  - Global is an OPT-IN, READ-ONLY layer: include_global defaults False. The
+    default scoped read view is scoped-only.
+  - Every mutation path (add / replace / remove / apply_batch) refuses to
+    mutate a global entry from a scoped context, for BOTH targets.
+  - Global membership is decided by set-membership against the global
+    partition, per target (index-free) — different global counts in MEMORY vs
+    USER never cross-guard.
+  - Migration: a scoped file that wrongly contains a global entry (old buggy
+    write-back) is healed on load.
+  - Feature disabled (context_id=None) ⇒ behavior identical to flat upstream.
+
+No real PII: fixtures use "u1", "123", and synthetic facts only.
 """
 
-import os
-import tempfile
-import threading
-from pathlib import Path
-from unittest.mock import patch
+import sys
 
 import pytest
 
 from tools.memory_tool import MemoryStore, ENTRY_DELIMITER
 
+# Patch get_memory_dir on the exact module object MemoryStore was defined in,
+# not by dotted string. tests/tools/test_memory_tool_import_fallback.py deletes
+# and re-imports tools.memory_tool, so a later ``sys.modules["tools.memory_tool"]``
+# can be a different module object than the one holding this class's methods.
+# Resolving via the class keeps the patch pointed at the right globals.
+_MEM_MOD = sys.modules[MemoryStore.__module__]
+
 
 @pytest.fixture
-def mem_dir(tmp_path):
-    """Create a temporary memory directory and patch get_memory_dir to use it."""
-    with patch("tools.memory_tool.get_memory_dir", return_value=tmp_path):
-        yield tmp_path
+def mem_dir(tmp_path, monkeypatch):
+    """Patch get_memory_dir to a temp dir; return the dir."""
+    monkeypatch.setattr(_MEM_MOD, "get_memory_dir", lambda: tmp_path)
+    return tmp_path
 
 
-class TestNoContextId:
-    """Backward compatibility: context_id=None uses global paths."""
+def _parse(path):
+    """Parse a memory file on disk into its list of entries."""
+    if not path.exists():
+        return []
+    raw = path.read_text(encoding="utf-8")
+    if not raw.strip():
+        return []
+    return [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
 
-    def test_no_context_id_uses_global_path(self, mem_dir):
-        store = MemoryStore()
-        path = store._path_for("memory")
-        assert path == mem_dir / "MEMORY.md"
 
-        path_user = store._path_for("user")
-        assert path_user == mem_dir / "USER.md"
+def _global_path(mem_dir, target):
+    return mem_dir / ("USER.md" if target == "user" else "MEMORY.md")
 
-    def test_no_context_id_backward_compatible(self, mem_dir):
-        """Full round-trip: add, save, reload — same as upstream behavior."""
-        store = MemoryStore()
+
+def _scoped_path(mem_dir, context_id, target):
+    return mem_dir / "contexts" / context_id / ("USER.md" if target == "user" else "MEMORY.md")
+
+
+# =========================================================================
+# Scoped writes never leak global entries into the scoped file
+# =========================================================================
+
+class TestScopedWriteDoesNotCopyGlobal:
+    def test_scoped_add_does_not_copy_global_into_scoped_file(self, mem_dir):
+        """Global MEMORY.md has 'global fact'; a scoped add writes ONLY the
+        scoped fact into the scoped file — never the global one."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+
+        store = MemoryStore(context_id="grp-1")
         store.load_from_disk()
-
-        result = store.add("memory", "global note")
+        result = store.add("memory", "scoped fact")
         assert result["success"] is True
 
-        # Verify file was written to global path
-        assert (mem_dir / "MEMORY.md").exists()
-        assert "global note" in (mem_dir / "MEMORY.md").read_text()
+        scoped_file = _scoped_path(mem_dir, "grp-1", "memory")
+        assert _parse(scoped_file) == ["scoped fact"]
+        # Global file untouched.
+        assert _parse(_global_path(mem_dir, "memory")) == ["global fact"]
 
-        # No context directory created
-        assert not (mem_dir / "contexts").exists()
+    def test_scoped_add_of_global_fact_is_noop_not_copy(self, mem_dir):
+        """Adding text that already exists globally is a no-op — it is NOT
+        copied into the scoped partition (which load-time healing would strip
+        anyway), even with include_global=False."""
+        _global_path(mem_dir, "memory").write_text("global fact")
 
-    def test_no_context_id_read_write_cycle(self, mem_dir):
-        """Write with no context, read back — identical to upstream."""
-        store = MemoryStore()
+        store = MemoryStore(context_id="grp-1")  # include_global=False
         store.load_from_disk()
-        store.add("memory", "fact one")
-        store.add("user", "user pref")
+        result = store.add("memory", "global fact")
+        assert result["success"] is True  # idempotent no-op
 
-        # Fresh store, same dir
-        store2 = MemoryStore()
-        store2.load_from_disk()
-        assert "fact one" in store2.memory_entries
-        assert "user pref" in store2.user_entries
+        # Scoped file must not have been created with the global entry in it.
+        scoped_file = _scoped_path(mem_dir, "grp-1", "memory")
+        assert _parse(scoped_file) == []
+        assert _parse(_global_path(mem_dir, "memory")) == ["global fact"]
 
+    def test_scoped_add_user_does_not_copy_global_user(self, mem_dir):
+        """Same guarantee for the USER.md target."""
+        _global_path(mem_dir, "user").write_text("global user pref")
 
-class TestContextId:
-    """context_id routes writes to per-context subdirectory."""
-
-    def test_context_id_creates_scoped_directory(self, mem_dir):
-        store = MemoryStore(context_id="group-123")
+        store = MemoryStore(context_id="grp-1")
         store.load_from_disk()
-
-        result = store.add("memory", "scoped note")
+        result = store.add("user", "scoped user pref")
         assert result["success"] is True
 
-        scoped_path = mem_dir / "contexts" / "group-123" / "MEMORY.md"
-        assert scoped_path.exists()
-        assert "scoped note" in scoped_path.read_text()
+        scoped_file = _scoped_path(mem_dir, "grp-1", "user")
+        assert _parse(scoped_file) == ["scoped user pref"]
+        assert _parse(_global_path(mem_dir, "user")) == ["global user pref"]
 
-    def test_context_id_path_for_returns_scoped(self, mem_dir):
-        store = MemoryStore(context_id="chan-456")
-        assert store._path_for("memory") == mem_dir / "contexts" / "chan-456" / "MEMORY.md"
-        assert store._path_for("user") == mem_dir / "contexts" / "chan-456" / "USER.md"
 
-    def test_context_id_merges_global_and_scoped(self, mem_dir):
-        """Reads should include both global and context-scoped entries."""
-        # Write a global entry directly
-        (mem_dir / "MEMORY.md").write_text("global fact")
+# =========================================================================
+# Read view: global is opt-in
+# =========================================================================
 
-        # Create scoped store and add a scoped entry
+class TestReadViewOptInGlobal:
+    def test_scoped_read_excludes_global_by_default(self, mem_dir):
+        """include_global=False (default): read view is scoped-only."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+        _scoped_path(mem_dir, "grp-1", "memory").parent.mkdir(parents=True, exist_ok=True)
+        _scoped_path(mem_dir, "grp-1", "memory").write_text("scoped fact")
+
         store = MemoryStore(context_id="grp-1")
         store.load_from_disk()
 
-        # Should have loaded the global entry
+        assert "scoped fact" in store.memory_entries
+        assert "global fact" not in store.memory_entries
+
+    def test_scoped_read_includes_global_when_opted_in(self, mem_dir):
+        """include_global=True: read view = global + scoped (global first)."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+        _scoped_path(mem_dir, "grp-1", "memory").parent.mkdir(parents=True, exist_ok=True)
+        _scoped_path(mem_dir, "grp-1", "memory").write_text("scoped fact")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+
         assert "global fact" in store.memory_entries
+        assert "scoped fact" in store.memory_entries
+        # Global first.
+        assert store.memory_entries.index("global fact") < store.memory_entries.index("scoped fact")
 
-        # Add a scoped entry
-        store.add("memory", "scoped fact")
+    def test_unscoped_read_is_global_only(self, mem_dir):
+        """context_id=None: read view = global only (today's behavior)."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+        store = MemoryStore()
+        store.load_from_disk()
+        assert store.memory_entries == ["global fact"]
 
-        # Reload to verify merge
-        store2 = MemoryStore(context_id="grp-1")
+
+# =========================================================================
+# Mutation guards: global is read-only from a scoped context
+# =========================================================================
+
+class TestGlobalReadOnlyFromScope:
+    def test_replace_global_entry_from_scope_refused(self, mem_dir):
+        """Scoped store, include_global=True: replacing a global entry is
+        refused (global is read-only from a scoped context)."""
+        _global_path(mem_dir, "memory").write_text("the sky is blue")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        result = store.replace("memory", "sky is blue", "sky is green")
+
+        assert result["success"] is False
+        err = result["error"].lower()
+        assert "global" in err
+        # Nothing written to the scoped file; global unchanged.
+        assert not _scoped_path(mem_dir, "grp-1", "memory").exists() or \
+            "sky is green" not in _parse(_scoped_path(mem_dir, "grp-1", "memory"))
+        assert _parse(_global_path(mem_dir, "memory")) == ["the sky is blue"]
+
+    def test_remove_global_entry_from_scope_refused(self, mem_dir):
+        """Removing a global entry from a scoped context is refused."""
+        _global_path(mem_dir, "memory").write_text("the sky is blue")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        result = store.remove("memory", "sky is blue")
+
+        assert result["success"] is False
+        assert "global" in result["error"].lower()
+        assert _parse(_global_path(mem_dir, "memory")) == ["the sky is blue"]
+
+    def test_replace_global_user_entry_from_scope_refused(self, mem_dir):
+        """Per-target: the same refusal holds for the USER.md target."""
+        _global_path(mem_dir, "user").write_text("user likes tea")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        result = store.replace("user", "likes tea", "likes coffee")
+
+        assert result["success"] is False
+        assert "global" in result["error"].lower()
+        assert _parse(_global_path(mem_dir, "user")) == ["user likes tea"]
+
+    def test_replace_scoped_entry_from_scope_allowed(self, mem_dir):
+        """Positive control: a scoped entry CAN be replaced from its scope."""
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        store.add("memory", "scoped original")
+        result = store.replace("memory", "scoped original", "scoped updated")
+
+        assert result["success"] is True
+        assert _parse(_scoped_path(mem_dir, "grp-1", "memory")) == ["scoped updated"]
+
+
+# =========================================================================
+# apply_batch is partition-aware
+# =========================================================================
+
+class TestApplyBatchPartitioning:
+    def test_apply_batch_scoped_does_not_copy_global(self, mem_dir):
+        """A batch of scoped ops leaves the global file untouched and writes
+        no global entries into the scoped file."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        result = store.apply_batch("memory", [
+            {"action": "add", "content": "scoped a"},
+            {"action": "add", "content": "scoped b"},
+        ])
+        assert result["success"] is True
+
+        assert _parse(_scoped_path(mem_dir, "grp-1", "memory")) == ["scoped a", "scoped b"]
+        assert _parse(_global_path(mem_dir, "memory")) == ["global fact"]
+
+    def test_apply_batch_refuses_global_mutation_from_scope(self, mem_dir):
+        """A batch containing a replace/remove that targets a global entry is
+        refused whole — nothing is written (all-or-nothing)."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        result = store.apply_batch("memory", [
+            {"action": "add", "content": "scoped a"},
+            {"action": "replace", "old_text": "global fact", "content": "hacked"},
+        ])
+        assert result["success"] is False
+        assert "global" in result["error"].lower()
+
+        # All-or-nothing: neither op committed.
+        assert not _scoped_path(mem_dir, "grp-1", "memory").exists() or \
+            _parse(_scoped_path(mem_dir, "grp-1", "memory")) == []
+        assert _parse(_global_path(mem_dir, "memory")) == ["global fact"]
+
+    def test_apply_batch_refuses_global_remove_from_scope(self, mem_dir):
+        """Batch remove of a global entry from a scoped context is refused."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+        result = store.apply_batch("memory", [
+            {"action": "remove", "old_text": "global fact"},
+        ])
+        assert result["success"] is False
+        assert "global" in result["error"].lower()
+        assert _parse(_global_path(mem_dir, "memory")) == ["global fact"]
+
+
+# =========================================================================
+# Global membership is per-target (no cross-guard)
+# =========================================================================
+
+class TestGlobalMembershipPerTarget:
+    def test_global_membership_is_per_target(self, mem_dir):
+        """Different global contents in MEMORY vs USER don't cross-guard:
+        a scoped entry in one target must remain mutable even when the OTHER
+        target's global partition is larger."""
+        # MEMORY global has two entries; USER global has none.
+        _global_path(mem_dir, "memory").write_text(
+            "mem global 1" + ENTRY_DELIMITER + "mem global 2"
+        )
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+
+        # A scoped USER add + replace must succeed — USER has no global entries,
+        # so an index-based guard borrowing MEMORY's count would wrongly block.
+        store.add("user", "scoped user entry")
+        result = store.replace("user", "scoped user entry", "scoped user updated")
+        assert result["success"] is True
+        assert _parse(_scoped_path(mem_dir, "grp-1", "user")) == ["scoped user updated"]
+
+        # And a scoped MEMORY entry (positioned AFTER the 2 globals in the read
+        # view) is still mutable.
+        store.add("memory", "scoped mem entry")
+        result2 = store.replace("memory", "scoped mem entry", "scoped mem updated")
+        assert result2["success"] is True
+        assert "scoped mem updated" in _parse(_scoped_path(mem_dir, "grp-1", "memory"))
+
+
+# =========================================================================
+# Migration / self-healing of old buggy scoped files
+# =========================================================================
+
+class TestMigrationDedup:
+    def test_migration_dedups_preexisting_global_in_scoped_file(self, mem_dir):
+        """A scoped file that wrongly contains a global entry (from the old
+        buggy write-back) is healed on load: the read view doesn't double-show
+        it, and after any scoped write the scoped partition no longer holds
+        the global entry."""
+        _global_path(mem_dir, "memory").write_text("global fact")
+        # Old bug: scoped file has BOTH the global fact and a real scoped fact.
+        scoped_file = _scoped_path(mem_dir, "grp-1", "memory")
+        scoped_file.parent.mkdir(parents=True, exist_ok=True)
+        scoped_file.write_text("global fact" + ENTRY_DELIMITER + "real scoped fact")
+
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+
+        # Read view shows the global fact exactly once, plus the scoped fact.
+        assert store.memory_entries.count("global fact") == 1
+        assert "real scoped fact" in store.memory_entries
+
+        # The scoped partition no longer holds the global entry.
+        store.add("memory", "another scoped fact")
+        on_disk = _parse(scoped_file)
+        assert "global fact" not in on_disk
+        assert "real scoped fact" in on_disk
+        assert "another scoped fact" in on_disk
+
+
+# =========================================================================
+# Feature disabled == flat upstream behavior
+# =========================================================================
+
+class TestFeatureDisabledMatchesFlat:
+    def test_feature_disabled_matches_flat_behavior(self, mem_dir):
+        """context_id=None behaves exactly like flat upstream: writes land in
+        the global file, no contexts/ directory is ever created."""
+        store = MemoryStore()
+        store.load_from_disk()
+        store.add("memory", "flat fact")
+        store.add("user", "flat pref")
+
+        assert _parse(_global_path(mem_dir, "memory")) == ["flat fact"]
+        assert _parse(_global_path(mem_dir, "user")) == ["flat pref"]
+        assert not (mem_dir / "contexts").exists()
+
+        # Fresh store reads it straight back.
+        store2 = MemoryStore()
         store2.load_from_disk()
-        assert "global fact" in store2.memory_entries
-        assert "scoped fact" in store2.memory_entries
+        assert store2.memory_entries == ["flat fact"]
+        assert store2.user_entries == ["flat pref"]
 
-    def test_scoped_write_does_not_modify_global(self, mem_dir):
-        """Writing with context_id should not touch global MEMORY.md."""
-        (mem_dir / "MEMORY.md").write_text("original global")
-
-        store = MemoryStore(context_id="grp-2")
-        store.load_from_disk()
-        store.add("memory", "scoped only")
-
-        # Global file unchanged
-        assert (mem_dir / "MEMORY.md").read_text() == "original global"
-
-    def test_global_path_for_helper(self, mem_dir):
-        store = MemoryStore(context_id="ctx-1")
-        assert store._global_path_for("memory") == mem_dir / "MEMORY.md"
-        assert store._global_path_for("user") == mem_dir / "USER.md"
-
-
-class TestContextIsolation:
-    """Different context_ids are isolated from each other."""
-
-    def test_different_contexts_are_isolated(self, mem_dir):
-        store_a = MemoryStore(context_id="group-A")
-        store_a.load_from_disk()
-        store_a.add("memory", "only for A")
-
-        store_b = MemoryStore(context_id="group-B")
-        store_b.load_from_disk()
-        store_b.add("memory", "only for B")
-
-        # Reload A — should not see B's entry
-        store_a2 = MemoryStore(context_id="group-A")
-        store_a2.load_from_disk()
-        assert "only for A" in store_a2.memory_entries
-        assert "only for B" not in store_a2.memory_entries
-
-        # Reload B — should not see A's entry
-        store_b2 = MemoryStore(context_id="group-B")
-        store_b2.load_from_disk()
-        assert "only for B" in store_b2.memory_entries
-        assert "only for A" not in store_b2.memory_entries
-
-    def test_both_see_global(self, mem_dir):
-        """Both contexts should see global entries."""
-        (mem_dir / "MEMORY.md").write_text("shared global")
-
-        store_a = MemoryStore(context_id="group-A")
-        store_a.load_from_disk()
-        assert "shared global" in store_a.memory_entries
-
-        store_b = MemoryStore(context_id="group-B")
-        store_b.load_from_disk()
-        assert "shared global" in store_b.memory_entries
-
-
-class TestReplaceAndRemove:
-    """Replace and remove operate on scoped files, not global."""
-
-    def test_replace_in_scoped_context(self, mem_dir):
-        store = MemoryStore(context_id="ctx-r")
-        store.load_from_disk()
-        store.add("memory", "old entry")
-        store.replace("memory", "old entry", "new entry")
-
-        store2 = MemoryStore(context_id="ctx-r")
-        store2.load_from_disk()
-        assert "new entry" in store2.memory_entries
-        assert "old entry" not in store2.memory_entries
-
-    def test_remove_from_scoped_context(self, mem_dir):
-        store = MemoryStore(context_id="ctx-rm")
-        store.load_from_disk()
-        store.add("memory", "to remove")
-        store.remove("memory", "to remove")
-
-        store2 = MemoryStore(context_id="ctx-rm")
-        store2.load_from_disk()
-        assert "to remove" not in store2.memory_entries
-
-
-class TestSystemPromptSnapshot:
-    """System prompt snapshot merges global + scoped at load time."""
-
-    def test_snapshot_includes_both(self, mem_dir):
-        (mem_dir / "MEMORY.md").write_text("global info")
-
-        # Write scoped entry
-        scoped_dir = mem_dir / "contexts" / "snap-ctx"
-        scoped_dir.mkdir(parents=True)
-        (scoped_dir / "MEMORY.md").write_text("scoped info")
-
-        store = MemoryStore(context_id="snap-ctx")
-        store.load_from_disk()
-
-        snapshot = store.format_for_system_prompt("memory")
-        assert snapshot is not None
-        assert "global info" in snapshot
-        assert "scoped info" in snapshot
-
-
-class TestPathTraversalAndEdgeCases:
-    """Security and edge-case tests for context_id handling."""
-
-    def test_context_id_path_traversal_sanitized(self, mem_dir):
-        """Path traversal in context_id is sanitized."""
-        store = MemoryStore(context_id="../../etc/passwd")
-        store.load_from_disk()
-        store.add("memory", "test entry")
-
-        # Should NOT escape the contexts directory
-        assert not (mem_dir.parent.parent / "etc" / "passwd" / "MEMORY.md").exists()
-        # Should be sanitized to a safe path under contexts/
-        contexts_dir = mem_dir / "contexts"
-        assert contexts_dir.exists()
-
-    def test_empty_context_id_treated_as_none(self, mem_dir):
-        """Empty string context_id behaves like None (global)."""
+    def test_empty_context_id_is_none(self, mem_dir):
+        """Empty-string context_id sanitizes to None (unscoped)."""
         store = MemoryStore(context_id="")
         assert store.context_id is None
 
-    def test_replace_global_entry_from_scoped_context_fails(self, mem_dir):
-        """Replacing a global entry from a scoped context returns error."""
-        # Write a global entry directly
-        (mem_dir / "MEMORY.md").write_text("The sky is blue")
-
-        store = MemoryStore(context_id="group-123")
+    def test_context_id_path_traversal_sanitized(self, mem_dir):
+        """Path traversal in context_id can't escape contexts/."""
+        store = MemoryStore(context_id="../../etc/passwd")
         store.load_from_disk()
-        # Try to replace a global entry
-        result = store.replace("memory", "sky is blue", "sky is green")
-        assert result["success"] is False
-        assert "global" in result["error"].lower()
-
-    def test_remove_global_entry_from_scoped_context_fails(self, mem_dir):
-        """Removing a global entry from a scoped context returns error."""
-        # Write a global entry directly
-        (mem_dir / "MEMORY.md").write_text("The sky is blue")
-
-        store = MemoryStore(context_id="group-123")
-        store.load_from_disk()
-        result = store.remove("memory", "sky is blue")
-        assert result["success"] is False
-        assert "global" in result["error"].lower()
-
-
-class TestGlobalEntryGuardLoopBreak:
-    """Modifying a global entry from a scoped context must fail without coaching
-    the model toward an impossible action, and must degrade to a terminal result
-    so the turn can proceed instead of looping (issue #39)."""
-
-    def test_guard_message_has_no_phantom_scope_param(self, mem_dir):
-        """The old guard said 'use scope=global' — a parameter that does not
-        exist on the memory tool — so the model could never comply and looped."""
-        (mem_dir / "MEMORY.md").write_text("The sky is blue")
-        store = MemoryStore(context_id="group-x")
-        store.load_from_disk()
-
-        result = store.replace("memory", "sky is blue", "sky is green")
-        assert result["success"] is False
-        # still explains it's a global-entry problem
-        assert "global" in result["error"].lower()
-        # but must NOT reference a nonexistent parameter
-        assert "scope=" not in result["error"]
-        assert "scope='global'" not in result["error"]
-
-    def test_guard_terminates_after_cap_on_replace(self, mem_dir):
-        (mem_dir / "MEMORY.md").write_text("The sky is blue")
-        store = MemoryStore(context_id="group-y")
-        store.load_from_disk()
-
-        n = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
-        results = [store.replace("memory", "sky is blue", "sky is green")
-                   for _ in range(n + 1)]
-
-        assert all(r["success"] is False for r in results)
-        # early attempts are recoverable (model may still self-correct)
-        assert not results[0].get("done")
-        # once the per-turn cap is exceeded the result is terminal, so the
-        # model stops retrying and answers the user
-        assert results[-1].get("done") is True
-
-    def test_guard_terminates_after_cap_on_remove(self, mem_dir):
-        (mem_dir / "MEMORY.md").write_text("global truth")
-        store = MemoryStore(context_id="group-z")
-        store.load_from_disk()
-
-        n = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
-        results = [store.remove("memory", "global truth") for _ in range(n + 1)]
-        assert results[-1].get("done") is True
-
-    def test_turn_reset_clears_guard_failures(self, mem_dir):
-        """A new turn resets the per-turn counter so guidance is offered afresh."""
-        (mem_dir / "MEMORY.md").write_text("The sky is blue")
-        store = MemoryStore(context_id="group-reset")
-        store.load_from_disk()
-
-        n = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
-        for _ in range(n + 1):
-            store.replace("memory", "sky is blue", "sky is green")
-
-        store.reset_consolidation_failures()
-        result = store.replace("memory", "sky is blue", "sky is green")
-        # first attempt of the new turn is recoverable again, not terminal
-        assert result["success"] is False
-        assert not result.get("done")
-
-    def test_scoped_add_overflow_flags_global_readonly(self, mem_dir):
-        """When a scoped add overflows because global entries fill the budget,
-        the coaching should tell the model global entries are read-only here so
-        it doesn't reach for an entry it can't edit."""
-        (mem_dir / "MEMORY.md").write_text("x" * 2100)  # near the 2200 cap
-        store = MemoryStore(context_id="ctx-hint")
-        store.load_from_disk()
-
-        result = store.add("memory", "y" * 300)
-        assert result["success"] is False
-        assert "global memory" in result["error"].lower()
-
-
-class TestConcurrentContextWrites:
-    """Different contexts use different lock files, so they don't block each other."""
-
-    def test_concurrent_context_writes_dont_block(self, mem_dir):
-        results = {}
-        errors = {}
-
-        def write_to_context(ctx_id, entry):
-            try:
-                store = MemoryStore(context_id=ctx_id)
-                store.load_from_disk()
-                result = store.add("memory", entry)
-                results[ctx_id] = result
-            except Exception as e:
-                errors[ctx_id] = e
-
-        t1 = threading.Thread(target=write_to_context, args=("ctx-1", "entry from 1"))
-        t2 = threading.Thread(target=write_to_context, args=("ctx-2", "entry from 2"))
-
-        t1.start()
-        t2.start()
-        t1.join(timeout=5)
-        t2.join(timeout=5)
-
-        assert not errors, f"Errors: {errors}"
-        assert results["ctx-1"]["success"] is True
-        assert results["ctx-2"]["success"] is True
-
-        # Verify isolation
-        assert (mem_dir / "contexts" / "ctx-1" / "MEMORY.md").exists()
-        assert (mem_dir / "contexts" / "ctx-2" / "MEMORY.md").exists()
+        store.add("memory", "trapped")
+        # Nothing written outside the temp memory dir tree.
+        assert not (mem_dir.parent.parent / "etc" / "passwd" / "MEMORY.md").exists()
+        assert (mem_dir / "contexts").exists()

--- a/tests/tools/test_memory_scoping_legacy.py
+++ b/tests/tools/test_memory_scoping_legacy.py
@@ -1,0 +1,357 @@
+"""Tests for context_id-based memory scoping in MemoryStore.
+
+Validates that:
+- No context_id → global path (backward compatible)
+- context_id → writes to contexts/{id}/, reads merge global + scoped
+- Different contexts are isolated from each other
+- Concurrent writes to different contexts don't block each other
+"""
+
+import os
+import tempfile
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.memory_tool import MemoryStore, ENTRY_DELIMITER
+
+
+@pytest.fixture
+def mem_dir(tmp_path):
+    """Create a temporary memory directory and patch get_memory_dir to use it."""
+    with patch("tools.memory_tool.get_memory_dir", return_value=tmp_path):
+        yield tmp_path
+
+
+class TestNoContextId:
+    """Backward compatibility: context_id=None uses global paths."""
+
+    def test_no_context_id_uses_global_path(self, mem_dir):
+        store = MemoryStore()
+        path = store._path_for("memory")
+        assert path == mem_dir / "MEMORY.md"
+
+        path_user = store._path_for("user")
+        assert path_user == mem_dir / "USER.md"
+
+    def test_no_context_id_backward_compatible(self, mem_dir):
+        """Full round-trip: add, save, reload — same as upstream behavior."""
+        store = MemoryStore()
+        store.load_from_disk()
+
+        result = store.add("memory", "global note")
+        assert result["success"] is True
+
+        # Verify file was written to global path
+        assert (mem_dir / "MEMORY.md").exists()
+        assert "global note" in (mem_dir / "MEMORY.md").read_text()
+
+        # No context directory created
+        assert not (mem_dir / "contexts").exists()
+
+    def test_no_context_id_read_write_cycle(self, mem_dir):
+        """Write with no context, read back — identical to upstream."""
+        store = MemoryStore()
+        store.load_from_disk()
+        store.add("memory", "fact one")
+        store.add("user", "user pref")
+
+        # Fresh store, same dir
+        store2 = MemoryStore()
+        store2.load_from_disk()
+        assert "fact one" in store2.memory_entries
+        assert "user pref" in store2.user_entries
+
+
+class TestContextId:
+    """context_id routes writes to per-context subdirectory."""
+
+    def test_context_id_creates_scoped_directory(self, mem_dir):
+        store = MemoryStore(context_id="group-123")
+        store.load_from_disk()
+
+        result = store.add("memory", "scoped note")
+        assert result["success"] is True
+
+        scoped_path = mem_dir / "contexts" / "group-123" / "MEMORY.md"
+        assert scoped_path.exists()
+        assert "scoped note" in scoped_path.read_text()
+
+    def test_context_id_path_for_returns_scoped(self, mem_dir):
+        store = MemoryStore(context_id="chan-456")
+        assert store._path_for("memory") == mem_dir / "contexts" / "chan-456" / "MEMORY.md"
+        assert store._path_for("user") == mem_dir / "contexts" / "chan-456" / "USER.md"
+
+    def test_context_id_merges_global_and_scoped(self, mem_dir):
+        """Reads should include both global and context-scoped entries."""
+        # Write a global entry directly
+        (mem_dir / "MEMORY.md").write_text("global fact")
+
+        # Create scoped store and add a scoped entry. The merged read view is
+        # now opt-in (include_global) rather than automatic — mt turns it on by
+        # default in config, so this is the shipped behavior.
+        store = MemoryStore(context_id="grp-1", include_global=True)
+        store.load_from_disk()
+
+        # Should have loaded the global entry
+        assert "global fact" in store.memory_entries
+
+        # Add a scoped entry
+        store.add("memory", "scoped fact")
+
+        # Reload to verify merge
+        store2 = MemoryStore(context_id="grp-1", include_global=True)
+        store2.load_from_disk()
+        assert "global fact" in store2.memory_entries
+        assert "scoped fact" in store2.memory_entries
+
+    def test_scoped_write_does_not_modify_global(self, mem_dir):
+        """Writing with context_id should not touch global MEMORY.md."""
+        (mem_dir / "MEMORY.md").write_text("original global")
+
+        store = MemoryStore(context_id="grp-2")
+        store.load_from_disk()
+        store.add("memory", "scoped only")
+
+        # Global file unchanged
+        assert (mem_dir / "MEMORY.md").read_text() == "original global"
+
+    def test_global_path_for_helper(self, mem_dir):
+        store = MemoryStore(context_id="ctx-1")
+        assert store._global_path_for("memory") == mem_dir / "MEMORY.md"
+        assert store._global_path_for("user") == mem_dir / "USER.md"
+
+
+class TestContextIsolation:
+    """Different context_ids are isolated from each other."""
+
+    def test_different_contexts_are_isolated(self, mem_dir):
+        store_a = MemoryStore(context_id="group-A")
+        store_a.load_from_disk()
+        store_a.add("memory", "only for A")
+
+        store_b = MemoryStore(context_id="group-B")
+        store_b.load_from_disk()
+        store_b.add("memory", "only for B")
+
+        # Reload A — should not see B's entry
+        store_a2 = MemoryStore(context_id="group-A")
+        store_a2.load_from_disk()
+        assert "only for A" in store_a2.memory_entries
+        assert "only for B" not in store_a2.memory_entries
+
+        # Reload B — should not see A's entry
+        store_b2 = MemoryStore(context_id="group-B")
+        store_b2.load_from_disk()
+        assert "only for B" in store_b2.memory_entries
+        assert "only for A" not in store_b2.memory_entries
+
+    def test_both_see_global(self, mem_dir):
+        """Both contexts should see global entries."""
+        (mem_dir / "MEMORY.md").write_text("shared global")
+
+        store_a = MemoryStore(context_id="group-A", include_global=True)
+        store_a.load_from_disk()
+        assert "shared global" in store_a.memory_entries
+
+        store_b = MemoryStore(context_id="group-B", include_global=True)
+        store_b.load_from_disk()
+        assert "shared global" in store_b.memory_entries
+
+
+class TestReplaceAndRemove:
+    """Replace and remove operate on scoped files, not global."""
+
+    def test_replace_in_scoped_context(self, mem_dir):
+        store = MemoryStore(context_id="ctx-r")
+        store.load_from_disk()
+        store.add("memory", "old entry")
+        store.replace("memory", "old entry", "new entry")
+
+        store2 = MemoryStore(context_id="ctx-r")
+        store2.load_from_disk()
+        assert "new entry" in store2.memory_entries
+        assert "old entry" not in store2.memory_entries
+
+    def test_remove_from_scoped_context(self, mem_dir):
+        store = MemoryStore(context_id="ctx-rm")
+        store.load_from_disk()
+        store.add("memory", "to remove")
+        store.remove("memory", "to remove")
+
+        store2 = MemoryStore(context_id="ctx-rm")
+        store2.load_from_disk()
+        assert "to remove" not in store2.memory_entries
+
+
+class TestSystemPromptSnapshot:
+    """System prompt snapshot merges global + scoped at load time."""
+
+    def test_snapshot_includes_both(self, mem_dir):
+        (mem_dir / "MEMORY.md").write_text("global info")
+
+        # Write scoped entry
+        scoped_dir = mem_dir / "contexts" / "snap-ctx"
+        scoped_dir.mkdir(parents=True)
+        (scoped_dir / "MEMORY.md").write_text("scoped info")
+
+        store = MemoryStore(context_id="snap-ctx", include_global=True)
+        store.load_from_disk()
+
+        snapshot = store.format_for_system_prompt("memory")
+        assert snapshot is not None
+        assert "global info" in snapshot
+        assert "scoped info" in snapshot
+
+
+class TestPathTraversalAndEdgeCases:
+    """Security and edge-case tests for context_id handling."""
+
+    def test_context_id_path_traversal_sanitized(self, mem_dir):
+        """Path traversal in context_id is sanitized."""
+        store = MemoryStore(context_id="../../etc/passwd")
+        store.load_from_disk()
+        store.add("memory", "test entry")
+
+        # Should NOT escape the contexts directory
+        assert not (mem_dir.parent.parent / "etc" / "passwd" / "MEMORY.md").exists()
+        # Should be sanitized to a safe path under contexts/
+        contexts_dir = mem_dir / "contexts"
+        assert contexts_dir.exists()
+
+    def test_empty_context_id_treated_as_none(self, mem_dir):
+        """Empty string context_id behaves like None (global)."""
+        store = MemoryStore(context_id="")
+        assert store.context_id is None
+
+    def test_replace_global_entry_from_scoped_context_fails(self, mem_dir):
+        """Replacing a global entry from a scoped context returns error."""
+        # Write a global entry directly
+        (mem_dir / "MEMORY.md").write_text("The sky is blue")
+
+        store = MemoryStore(context_id="group-123", include_global=True)
+        store.load_from_disk()
+        # Try to replace a global entry
+        result = store.replace("memory", "sky is blue", "sky is green")
+        assert result["success"] is False
+        assert "global" in result["error"].lower()
+
+    def test_remove_global_entry_from_scoped_context_fails(self, mem_dir):
+        """Removing a global entry from a scoped context returns error."""
+        # Write a global entry directly
+        (mem_dir / "MEMORY.md").write_text("The sky is blue")
+
+        store = MemoryStore(context_id="group-123", include_global=True)
+        store.load_from_disk()
+        result = store.remove("memory", "sky is blue")
+        assert result["success"] is False
+        assert "global" in result["error"].lower()
+
+
+class TestGlobalEntryGuardLoopBreak:
+    """Modifying a global entry from a scoped context must fail without coaching
+    the model toward an impossible action, and must degrade to a terminal result
+    so the turn can proceed instead of looping (issue #39)."""
+
+    def test_guard_message_has_no_phantom_scope_param(self, mem_dir):
+        """The old guard said 'use scope=global' — a parameter that does not
+        exist on the memory tool — so the model could never comply and looped."""
+        (mem_dir / "MEMORY.md").write_text("The sky is blue")
+        store = MemoryStore(context_id="group-x", include_global=True)
+        store.load_from_disk()
+
+        result = store.replace("memory", "sky is blue", "sky is green")
+        assert result["success"] is False
+        # still explains it's a global-entry problem
+        assert "global" in result["error"].lower()
+        # but must NOT reference a nonexistent parameter
+        assert "scope=" not in result["error"]
+        assert "scope='global'" not in result["error"]
+
+    def test_guard_terminates_after_cap_on_replace(self, mem_dir):
+        (mem_dir / "MEMORY.md").write_text("The sky is blue")
+        store = MemoryStore(context_id="group-y", include_global=True)
+        store.load_from_disk()
+
+        n = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
+        results = [store.replace("memory", "sky is blue", "sky is green")
+                   for _ in range(n + 1)]
+
+        assert all(r["success"] is False for r in results)
+        # early attempts are recoverable (model may still self-correct)
+        assert not results[0].get("done")
+        # once the per-turn cap is exceeded the result is terminal, so the
+        # model stops retrying and answers the user
+        assert results[-1].get("done") is True
+
+    def test_guard_terminates_after_cap_on_remove(self, mem_dir):
+        (mem_dir / "MEMORY.md").write_text("global truth")
+        store = MemoryStore(context_id="group-z", include_global=True)
+        store.load_from_disk()
+
+        n = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
+        results = [store.remove("memory", "global truth") for _ in range(n + 1)]
+        assert results[-1].get("done") is True
+
+    def test_turn_reset_clears_guard_failures(self, mem_dir):
+        """A new turn resets the per-turn counter so guidance is offered afresh."""
+        (mem_dir / "MEMORY.md").write_text("The sky is blue")
+        store = MemoryStore(context_id="group-reset")
+        store.load_from_disk()
+
+        n = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
+        for _ in range(n + 1):
+            store.replace("memory", "sky is blue", "sky is green")
+
+        store.reset_consolidation_failures()
+        result = store.replace("memory", "sky is blue", "sky is green")
+        # first attempt of the new turn is recoverable again, not terminal
+        assert result["success"] is False
+        assert not result.get("done")
+
+    def test_scoped_add_overflow_flags_global_readonly(self, mem_dir):
+        """When a scoped add overflows because global entries fill the budget,
+        the coaching should tell the model global entries are read-only here so
+        it doesn't reach for an entry it can't edit."""
+        (mem_dir / "MEMORY.md").write_text("x" * 2100)  # near the 2200 cap
+        store = MemoryStore(context_id="ctx-hint", include_global=True)
+        store.load_from_disk()
+
+        result = store.add("memory", "y" * 300)
+        assert result["success"] is False
+        assert "global memory" in result["error"].lower()
+
+
+class TestConcurrentContextWrites:
+    """Different contexts use different lock files, so they don't block each other."""
+
+    def test_concurrent_context_writes_dont_block(self, mem_dir):
+        results = {}
+        errors = {}
+
+        def write_to_context(ctx_id, entry):
+            try:
+                store = MemoryStore(context_id=ctx_id)
+                store.load_from_disk()
+                result = store.add("memory", entry)
+                results[ctx_id] = result
+            except Exception as e:
+                errors[ctx_id] = e
+
+        t1 = threading.Thread(target=write_to_context, args=("ctx-1", "entry from 1"))
+        t2 = threading.Thread(target=write_to_context, args=("ctx-2", "entry from 2"))
+
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        assert not errors, f"Errors: {errors}"
+        assert results["ctx-1"]["success"] is True
+        assert results["ctx-2"]["success"] is True
+
+        # Verify isolation
+        assert (mem_dir / "contexts" / "ctx-1" / "MEMORY.md").exists()
+        assert (mem_dir / "contexts" / "ctx-2" / "MEMORY.md").exists()

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -80,6 +80,28 @@ def _scan_memory_content(content: str) -> Optional[str]:
     return _first_threat_message(content, scope="strict")
 
 
+def derive_context_id(platform: Optional[str], chat_type: Optional[str],
+                      chat_id: Optional[str]) -> Optional[str]:
+    """Build a memory context id from a messaging source, or None if unscopable.
+
+    Scopes EVERY chat type (including DMs) and qualifies by platform so the
+    same raw chat_id on two platforms — or the same id used for a DM and a
+    group — never collide:
+
+        f"{platform}:{chat_type}:{chat_id}"
+
+    Returns None when ``chat_id`` is empty/None, which routes memory to the
+    unscoped global store (the interactive-CLI and no-chat case). The
+    ``MemoryStore`` sanitizer maps any residual path-unsafe characters to ``_``
+    so the derived id always stays under contexts/.
+    """
+    if not chat_id:
+        return None
+    plat = platform if platform else "unknown"
+    ctype = chat_type if chat_type else "chat"
+    return f"{plat}:{ctype}:{chat_id}"
+
+
 def _drift_error(path: "Path", bak_path: str) -> Dict[str, Any]:
     """Build the error dict returned when external drift is detected.
 
@@ -128,20 +150,36 @@ class MemoryStore:
     _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
     def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375,
-                 context_id: Optional[str] = None):
+                 context_id: Optional[str] = None, include_global: bool = False):
+        # ``memory_entries`` / ``user_entries`` are the DERIVED read view (what
+        # the system prompt, ``read``, and success responses show). They are
+        # never persisted as one blob. The two partitions below are the source
+        # of truth and are written to their own files independently.
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
-        # Sanitize context_id: treat empty/falsy as None; replace path separators
-        # and parent-ref sequences so chat IDs from any platform can't escape
-        # the contexts/ directory via path traversal.
+        # Partition state (per target). Global is the shared, backward-compatible
+        # layer; scoped is per-context and isolated. Keeping them separate is
+        # what guarantees a scoped file only ever holds scoped entries.
+        self._global_entries: Dict[str, List[str]] = {"memory": [], "user": []}
+        self._scoped_entries: Dict[str, List[str]] = {"memory": [], "user": []}
+        # Sanitize context_id: treat empty/falsy as None; replace path
+        # separators and parent-ref sequences so chat IDs from any platform
+        # can't escape the contexts/ directory via path traversal. The gateway
+        # emits ``{platform}:{chat_type}:{chat_id}`` — ``:`` is kept verbatim
+        # (safe on every supported filesystem and used only as a within-name
+        # separator, not a directory boundary).
         if context_id:
             safe_id = str(context_id).replace("/", "_").replace("\\", "_").replace("..", "_")
-            self.context_id: Optional[str] = safe_id
+            self.context_id: Optional[str] = safe_id or None
         else:
             self.context_id = None
-        self._global_entry_count: int = 0  # tracks how many entries came from global files
+        # Opt-in, read-only global layer for scoped stores. Default OFF: a
+        # scoped store's read view is scoped-only unless the operator turns
+        # this on. Ignored (no effect) for unscoped stores, which are always
+        # global-only.
+        self.include_global = bool(include_global)
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
         # Per-turn counter of failed at-capacity consolidation attempts; reset
@@ -227,32 +265,14 @@ class MemoryStore:
         mem_dir = get_memory_dir()
         mem_dir.mkdir(parents=True, exist_ok=True)
 
-        # Always start with global entries
-        self.memory_entries = self._read_file(self._global_path_for("memory"))
-        self.user_entries = self._read_file(self._global_path_for("user"))
-
-        # Merge context-scoped entries when context_id is set
-        if self.context_id is not None:
-            scoped_dir = mem_dir / "contexts" / self.context_id
-            scoped_dir.mkdir(parents=True, exist_ok=True)
-            scoped_memory = self._read_file(scoped_dir / "MEMORY.md")
-            scoped_user = self._read_file(scoped_dir / "USER.md")
-            self.memory_entries.extend(scoped_memory)
-            self.user_entries.extend(scoped_user)
-
-        # Deduplicate entries (preserves order, keeps first occurrence)
-        self.memory_entries = list(dict.fromkeys(self.memory_entries))
-        self.user_entries = list(dict.fromkeys(self.user_entries))
-
-        # Track how many of the merged memory entries came from global files.
-        # Used by replace/remove to reject mutations targeting global entries
-        # when operating from a scoped context.
-        if self.context_id is not None:
-            global_raw = self._read_file(self._global_path_for("memory"))
-            global_set = set(global_raw)
-            self._global_entry_count = sum(1 for e in self.memory_entries if e in global_set)
-        else:
-            self._global_entry_count = 0
+        # Load each target's partitions from disk and derive the read view.
+        # ``_load_partitions`` also self-heals a scoped file that a previous
+        # (buggy) build copied global entries into — global membership, not the
+        # merged blob, is what a scoped write may ever persist.
+        for target in ("memory", "user"):
+            self._load_partitions(target)
+        self.memory_entries = self._derive_view("memory")
+        self.user_entries = self._derive_view("user")
 
         # Sanitize entries for the system-prompt snapshot only.  Live state
         # (memory_entries / user_entries) keeps the raw text so the user
@@ -341,67 +361,156 @@ class MemoryStore:
 
     @staticmethod
     def _global_path_for(target: str) -> Path:
-        """Return the global (unscoped) path for a memory target."""
+        """Return the global (unscoped) file for a target — always at the
+        memories-dir root, backward compatible."""
         mem_dir = get_memory_dir()
         if target == "user":
             return mem_dir / "USER.md"
         return mem_dir / "MEMORY.md"
 
-    def _path_for(self, target: str) -> Path:
-        """Return the write path for a memory target.
+    def _scoped_path_for(self, target: str) -> Path:
+        """Return the scoped file for a target under contexts/{context_id}/.
 
-        When context_id is set, routes to contexts/{context_id}/ subdirectory.
-        When context_id is None, returns the global path (backward compatible).
+        Only meaningful when ``context_id`` is set.
+        """
+        mem_dir = get_memory_dir()
+        base = mem_dir / "contexts" / str(self.context_id)
+        if target == "user":
+            return base / "USER.md"
+        return base / "MEMORY.md"
+
+    def _path_for(self, target: str) -> Path:
+        """Return the file this store MUTATES for a target.
+
+        Unscoped (context_id=None) → the global file (backward compatible).
+        Scoped → the scoped file. Global files are never mutated from a scoped
+        store, so a scoped store's write path is always the scoped file.
         """
         if self.context_id is None:
             return self._global_path_for(target)
-        mem_dir = get_memory_dir()
-        if target == "user":
-            return mem_dir / "contexts" / self.context_id / "USER.md"
-        return mem_dir / "contexts" / self.context_id / "MEMORY.md"
+        return self._scoped_path_for(target)
+
+    # -- Partition load / derive --
+
+    def _load_partitions(self, target: str) -> None:
+        """Load the global and scoped partitions for ``target`` from disk into
+        ``_global_entries`` / ``_scoped_entries`` (deduplicated within each).
+
+        Migration / self-healing: when a scoped file wrongly contains an entry
+        that also exists in the global partition (from the old buggy write-back
+        that copied the merged list into the scoped file), that entry is
+        dropped from the scoped partition here. The scoped partition holds ONLY
+        genuinely-scoped entries; global stays the single source of truth for
+        shared facts.
+        """
+        global_entries = list(dict.fromkeys(self._read_file(self._global_path_for(target))))
+        self._global_entries[target] = global_entries
+
+        if self.context_id is None:
+            self._scoped_entries[target] = []
+            return
+
+        scoped_raw = list(dict.fromkeys(self._read_file(self._scoped_path_for(target))))
+        global_set = set(global_entries)
+        # Heal old data: never keep a global entry inside the scoped partition.
+        self._scoped_entries[target] = [e for e in scoped_raw if e not in global_set]
+
+    def _derive_view(self, target: str) -> List[str]:
+        """Return the merged READ view for ``target`` from the partitions.
+
+        - Unscoped store: global only (today's behavior).
+        - Scoped, include_global=False (default): scoped only.
+        - Scoped, include_global=True: global first, then scoped, deduped.
+        """
+        scoped = self._scoped_entries.get(target, [])
+        if self.context_id is None:
+            return list(self._global_entries.get(target, []))
+        if not self.include_global:
+            return list(scoped)
+        merged = list(self._global_entries.get(target, [])) + list(scoped)
+        return list(dict.fromkeys(merged))
+
+    def _project_view(self, target: str, writable: List[str]) -> List[str]:
+        """Derive the read view that WOULD result from a candidate writable
+        partition, without committing it. Used for budget checks.
+
+        Mirrors ``_derive_view`` but substitutes ``writable`` for the stored
+        partition this store mutates.
+        """
+        if self.context_id is None:
+            return list(writable)
+        if not self.include_global:
+            return list(writable)
+        merged = list(self._global_entries.get(target, [])) + list(writable)
+        return list(dict.fromkeys(merged))
+
+    def _is_global_entry(self, target: str, entry: str) -> bool:
+        """True if ``entry`` belongs to the global partition for ``target``.
+
+        Set-membership against the global partition — per-target and
+        index-free, so a scoped mutation is judged only against that target's
+        own global entries (no cross-target guarding).
+        """
+        return entry in set(self._global_entries.get(target, []))
+
+    # Plain-string form of the guard, for the apply_batch paths — a batch
+    # returns one aggregate error, so it can't carry the richer interactive
+    # guard response below.
+    _GLOBAL_READONLY_MSG = (
+        "Cannot modify a global entry from a scoped context — global memory is "
+        "read-only here. Edit it from an unscoped (global) session instead."
+    )
+
+    def _reject_global_mutation(self, target: str, entry: str) -> Optional[Dict[str, Any]]:
+        """Return a refusal dict if ``entry`` is a global entry and this store
+        is scoped; otherwise None (mutation may proceed).
+
+        The predicate is upstream's per-target set membership (index-free, so
+        it can't be fooled by dedup reordering). The response body stays mt's
+        ``_global_entry_guard_response``: it gives the model scope-honest,
+        actionable guidance and routes through the per-turn consolidation
+        cap, so repeated attempts degrade to a terminal result instead of
+        looping the turn to budget exhaustion (mt #39 / #42405). Upstream's
+        plain error string has neither property.
+        """
+        if self.context_id is not None and self._is_global_entry(target, entry):
+            return self._global_entry_guard_response(target)
+        return None
 
     def _reload_target(self, target: str, *, skip_drift: bool = False) -> Optional[str]:
-        """Re-read entries from disk into in-memory state.
+        """Re-read the target's partitions from disk into in-memory state.
 
         Called under file lock to get the latest state before mutating.
-        Returns the backup path if external drift was detected (the on-disk
-        file contains content that wouldn't round-trip through our
-        parser/serializer, OR an entry larger than the store's char limit).
-        When drift is detected the caller must abort the mutation —
-        flushing would discard the un-roundtrippable content.
-        Returns None on clean reload.
+        Returns the backup path if external drift was detected on the SCOPED
+        file (the file this store writes), or None on clean reload. The global
+        file is read-only from every store, so drift detection only applies to
+        the write path.
 
         When *skip_drift* is True the round-trip / entry-size check is
         bypassed.  Used by the ``add`` action which appends without
         rewriting, so existing content is never clobbered.
 
-        When context_id is set, merges global + scoped entries and updates
-        _global_entry_count for the memory target (used by replace/remove
-        to block mutations on global entries from a scoped context).
+        Rebuilds both partitions and the derived read view so the mutation
+        methods below see a fresh, healed picture.
         """
-        path = self._path_for(target)
         bak = None if skip_drift else self._detect_external_drift(target)
-        if self.context_id is not None:
-            # Merge global + scoped
-            global_entries = self._read_file(self._global_path_for(target))
-            scoped_entries = self._read_file(path)
-            fresh = global_entries + scoped_entries
-            fresh = list(dict.fromkeys(fresh))  # deduplicate
-            if target == "memory":
-                # Recount global entries after dedup
-                global_set = set(global_entries)
-                self._global_entry_count = sum(1 for e in fresh if e in global_set)
-        else:
-            fresh = self._read_file(path)
-            fresh = list(dict.fromkeys(fresh))  # deduplicate
-        self._set_entries(target, fresh)
+        self._load_partitions(target)
+        self._set_entries(target, self._derive_view(target))
         return bak
 
     def save_to_disk(self, target: str):
-        """Persist entries to the appropriate file. Called after every mutation."""
+        """Persist the mutated partition to its own file.
+
+        Scoped store → writes ONLY the scoped file, and ONLY the scoped
+        partition (never the merged read view — that would leak global entries
+        into the scoped file). Unscoped store → writes the global file.
+        """
         path = self._path_for(target)
         path.parent.mkdir(parents=True, exist_ok=True)
-        self._write_file(path, self._entries_for(target))
+        if self.context_id is None:
+            self._write_file(path, self._global_entries[target])
+        else:
+            self._write_file(path, self._scoped_entries[target])
 
     def _entries_for(self, target: str) -> List[str]:
         if target == "user":
@@ -413,6 +522,26 @@ class MemoryStore:
             self.user_entries = entries
         else:
             self.memory_entries = entries
+
+    def _writable_entries(self, target: str) -> List[str]:
+        """Return a COPY of the partition this store may mutate for ``target``.
+
+        Scoped store → the scoped partition; unscoped store → the global
+        partition. Mutations operate on this copy and commit via
+        ``_commit_writable`` so the merged read view is never written back to
+        a partition file.
+        """
+        if self.context_id is None:
+            return list(self._global_entries[target])
+        return list(self._scoped_entries[target])
+
+    def _commit_writable(self, target: str, entries: List[str]) -> None:
+        """Store the mutated partition and re-derive the read view."""
+        if self.context_id is None:
+            self._global_entries[target] = entries
+        else:
+            self._scoped_entries[target] = entries
+        self._set_entries(target, self._derive_view(target))
 
     def _char_count(self, target: str) -> int:
         entries = self._entries_for(target)
@@ -445,16 +574,25 @@ class MemoryStore:
             # would discard un-roundtrippable content (issue #26045).
             self._reload_target(target, skip_drift=True)
 
-            entries = self._entries_for(target)
+            # Duplicate check is against the READ view AND the global partition.
+            # Consulting the global partition even when include_global is False
+            # keeps a scoped store from shadowing a global fact with a
+            # redundant scoped copy — such a copy would be silently stripped by
+            # the load-time healing (_load_partitions), so the "add" would not
+            # survive a reload. Treating it as an existing entry is correct and
+            # never copies a global entry into the scoped file.
+            view = self._entries_for(target)
             limit = self._char_limit(target)
-
-            # Reject exact duplicates
-            if content in entries:
+            if content in view or self._is_global_entry(target, content):
                 return self._success_response(target, "Entry already exists (no duplicate added).")
 
-            # Calculate what the new total would be
-            new_entries = entries + [content]
-            new_total = len(ENTRY_DELIMITER.join(new_entries))
+            # Append to the WRITABLE partition (scoped for a scoped store).
+            writable = self._writable_entries(target)
+            new_writable = writable + [content]
+
+            # Budget is measured against the resulting READ view.
+            projected = self._project_view(target, new_writable)
+            new_total = len(ENTRY_DELIMITER.join(projected))
 
             if new_total > limit:
                 current = self._char_count(target)
@@ -463,7 +601,7 @@ class MemoryStore:
                 # of reaching for a global one and looping on the guard (#39).
                 scope_hint = ""
                 if (self.context_id is not None and target == "memory"
-                        and self._global_entry_count):
+                        and self._global_entries.get("memory")):
                     scope_hint = (
                         " Note: entries from global memory can't be edited from "
                         "this context — consolidate only your context-scoped "
@@ -479,12 +617,11 @@ class MemoryStore:
                         f"current_entries below), then retry this add — all in this turn."
                         f"{scope_hint}"
                     ),
-                    "current_entries": entries,
+                    "current_entries": view,
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            entries.append(content)
-            self._set_entries(target, entries)
+            self._commit_writable(target, new_writable)
             self.save_to_disk(target)
 
         return self._success_response(target, "Entry added.")
@@ -530,21 +667,26 @@ class MemoryStore:
                     }
                 # All identical -- safe to replace just the first
 
-            idx = matches[0][0]
+            matched_text = matches[0][1]
 
-            # Guard: refuse to mutate a global entry from a scoped context.
-            # Global entries occupy the first _global_entry_count positions in
-            # the merged list. Saving goes to the scoped file only, so any
-            # modification would be lost on the next reload.
-            if self.context_id is not None and idx < self._global_entry_count:
-                return self._global_entry_guard_response(target)
+            # Guard: a global entry is read-only from a scoped context. The
+            # scoped store only writes the scoped file, so mutating a global
+            # entry here would silently be lost on the next reload — refuse.
+            guard = self._reject_global_mutation(target, matched_text)
+            if guard is not None:
+                return guard
 
             limit = self._char_limit(target)
 
-            # Check that replacement doesn't blow the budget
-            test_entries = entries.copy()
-            test_entries[idx] = new_content
-            new_total = len(ENTRY_DELIMITER.join(test_entries))
+            # Locate the entry in the WRITABLE partition (it is scoped, since
+            # the guard above ruled out a global match for a scoped store).
+            writable = self._writable_entries(target)
+            w_idx = writable.index(matched_text)
+            writable[w_idx] = new_content
+
+            # Budget against the resulting READ view.
+            projected = self._project_view(target, writable)
+            new_total = len(ENTRY_DELIMITER.join(projected))
 
             if new_total > limit:
                 current = self._char_count(target)
@@ -560,8 +702,7 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            entries[idx] = new_content
-            self._set_entries(target, entries)
+            self._commit_writable(target, writable)
             self.save_to_disk(target)
 
         return self._success_response(target, "Entry replaced.")
@@ -599,14 +740,16 @@ class MemoryStore:
                     }
                 # All identical -- safe to remove just the first
 
-            idx = matches[0][0]
+            matched_text = matches[0][1]
 
             # Guard: refuse to remove a global entry from a scoped context.
-            if self.context_id is not None and idx < self._global_entry_count:
-                return self._global_entry_guard_response(target)
+            guard = self._reject_global_mutation(target, matched_text)
+            if guard is not None:
+                return guard
 
-            entries.pop(idx)
-            self._set_entries(target, entries)
+            writable = self._writable_entries(target)
+            writable.pop(writable.index(matched_text))
+            self._commit_writable(target, writable)
             self.save_to_disk(target)
 
         return self._success_response(target, "Entry removed.")
@@ -642,8 +785,15 @@ class MemoryStore:
             if bak:
                 return _drift_error(self._path_for(target), bak)
 
-            # Work on a copy; only commit if the whole batch validates.
-            working: List[str] = list(self._entries_for(target))
+            # Work on a copy of the WRITABLE partition (scoped for a scoped
+            # store); only commit if the whole batch validates. Global entries
+            # are read-only here, so ``working`` never contains them and
+            # replace/remove that resolve to a global entry are refused before
+            # any change is applied.
+            working: List[str] = self._writable_entries(target)
+            # The set the model "sees" for match/idempotency, including the
+            # read-only global layer when opted in.
+            view = self._entries_for(target)
             limit = self._char_limit(target)
 
             for i, op in enumerate(operations):
@@ -656,8 +806,12 @@ class MemoryStore:
                 if act == "add":
                     if not content:
                         return self._batch_error(target, f"{pos}: content is required.")
-                    if content in working:
-                        continue  # idempotent -- skip duplicate, don't fail the batch
+                    # Idempotent against the working set, the read view, AND the
+                    # global partition (even when include_global is off) — a
+                    # scoped store never shadows a global fact with a redundant
+                    # scoped copy that load-time healing would later strip.
+                    if content in working or content in view or self._is_global_entry(target, content):
+                        continue
                     working.append(content)
 
                 elif act == "replace":
@@ -668,6 +822,14 @@ class MemoryStore:
                             target,
                             f"{pos}: content is required (use action='remove' to delete).",
                         )
+                    # Refuse a batch that targets a global entry from a scope,
+                    # even if that entry isn't in the writable partition — the
+                    # guard is against the read view (issue: apply_batch arrived
+                    # unguarded from upstream).
+                    if self.context_id is not None and any(
+                        self._is_global_entry(target, e) for e in view if old_text in e
+                    ):
+                        return self._batch_error(target, f"{pos}: {self._GLOBAL_READONLY_MSG}")
                     matches = [j for j, e in enumerate(working) if old_text in e]
                     if not matches:
                         return self._batch_error(target, f"{pos}: no entry matched '{old_text}'.")
@@ -681,6 +843,10 @@ class MemoryStore:
                 elif act == "remove":
                     if not old_text:
                         return self._batch_error(target, f"{pos}: old_text is required.")
+                    if self.context_id is not None and any(
+                        self._is_global_entry(target, e) for e in view if old_text in e
+                    ):
+                        return self._batch_error(target, f"{pos}: {self._GLOBAL_READONLY_MSG}")
                     matches = [j for j, e in enumerate(working) if old_text in e]
                     if not matches:
                         return self._batch_error(target, f"{pos}: no entry matched '{old_text}'.")
@@ -697,8 +863,9 @@ class MemoryStore:
                         f"{pos}: unknown action. Use add, replace, or remove.",
                     )
 
-            # Budget check against the FINAL state only.
-            new_total = len(ENTRY_DELIMITER.join(working)) if working else 0
+            # Budget check against the FINAL read view only.
+            projected = self._project_view(target, working)
+            new_total = len(ENTRY_DELIMITER.join(projected)) if projected else 0
             if new_total > limit:
                 current = self._char_count(target)
                 return self._consolidation_failure({
@@ -712,8 +879,8 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            # Commit.
-            self._set_entries(target, working)
+            # Commit the scoped partition only.
+            self._commit_writable(target, working)
             self.save_to_disk(target)
 
         return self._success_response(target, f"Applied {len(operations)} operation(s).")


### PR DESCRIPTION
## What

- Scope **every** chat type, not just group/forum/channel. `_context_id_for_source` returned `None` for DMs (and threads, and unknown `chat_type`), filing that memory into the **global** layer — which is merged into every scoped read. The gateway's static method now delegates to the module-level `derive_context_id`, which also platform-qualifies the id so the same `chat_id` can't collide across platforms.
- Stop persisting the merged view into the scoped file. `save_to_disk` wrote `_entries_for(target)` (global + scoped, merged) to the **scoped** path, so one ordinary group write copied all of global into that group's own file — and retracting a fact from global then removed it nowhere. `MemoryStore` now holds `_global_entries` / `_scoped_entries` as separate partitions and persists only the partition it may mutate. `_load_partitions` self-heals scoped files an earlier build polluted.
- Add `scripts/migrate_memory_contexts.py` — dry-run-by-default data pass for existing on-disk contexts (see Risk).
- Add upstream's 29 partition/derivation tests; preserve mt's prior scoping suite as `test_memory_scoping_legacy.py`.

## Why

A fact learned in a DM was readable in every group the agent is in, and after one ordinary group write it became permanently resident in that group's own file — un-retractable from global. Ported from upstream PR #47552, whose `MemoryStore` rewrite already fixes both and is clean (verified against its own commit-message claims with controls).

The reason this survived a green test suite: group→group isolation genuinely worked and the `context_id=None` round-trip was unchanged, so every read-side assertion passed on a store that was mishandling the persist path. `test_memory_scoping_legacy.py` is kept rather than deleted precisely because it is that suite.

## Verification

- New suites: 29 passed (`tests/tools/test_memory_scoping.py`, `tests/gateway/test_context_id_derivation.py`).
- Legacy suite: 23 passed, after updating its merged-view cases to opt in via `include_global=True`.
- `tests/tools -k memory`: 148 passed, 1 skipped.
- Full `tests/gateway`: **16 failed / 9886 passed** on this branch against **16 failed / 9875 passed** on `origin/main` — the same 16 pre-existing failures (telegram markdown escaping, feishu websocket, shutdown forensics), +11 from the new tests. No regressions introduced.
- Migration script exercised against a fixture with a polluted scoped file: global left untouched, scoped file reduced to genuinely-scoped entries, directory renamed.

## Risk

- **Two deliberate divergences from upstream defaults.** Upstream ships `context_scoping_enabled` and `include_global_in_scoped` as `False` because scoping is opt-in there. On mt scoping is already unconditional, so inheriting `False` would silently collapse every agent to one shared memory. Both default `True` here. `include_global_in_scoped` stays on because mt's global layer holds the agent's name, personality and skills — only safe now that DMs no longer land in global.
- **Existing on-disk contexts need the migration before this helps the running fleet.** The id format changes from the raw `chat_id` (`group:<signal-id>`) to `{platform}:{chat_type}:{chat_id}`, so current directories are orphaned — their genuinely-scoped entries drop out of the read view, and because the store's self-heal only runs for a context it actually loads, their copied global entries stay on disk indefinitely. `scripts/migrate_memory_contexts.py` handles both, backs up before writing, and cannot infer `platform` from a directory name (pass `--platform`). **Not yet run against any live agent.**
- The global-entry guard keeps mt's `_global_entry_guard_response` (scope-honest coaching through the per-turn consolidation cap, mt #39 / #42405) rather than upstream's plain error string, but adopts upstream's index-free set-membership predicate. `_GLOBAL_READONLY_MSG` is retained for the `apply_batch` paths, which return one aggregate error.

## Links

- Upstream: NousResearch/hermes-agent PR #47552 (`3a4f9217b`), cherry-picked with per-hunk conflict resolution.
- Context: NousResearch/hermes-agent#34352, where DanceNitra's persist-path question surfaced this.
