### PR TITLE
docs(ghcr): correct image paths and rename prose for cyborg-garden

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -5,12 +5,21 @@ name: Publish Docker Image (Fork)
 # publishing to GHCR for this fork.
 #
 # The image namespace is derived from github.repository_owner (lowercased by
-# docker/metadata-action), NOT hardcoded — so a repo TRANSFER auto-repoints the
-# publish target with no coordinated code change. Today (owner NimbleCoAI) it
-# publishes ghcr.io/nimblecoai/hermes-agent-mt exactly as before; after a
-# transfer to NimbleCoOrg it publishes ghcr.io/nimblecoorg/hermes-agent-mt.
-# The GHCR package under the OLD owner is retained (frozen) as a pull grace
-# window — never delete it.
+# docker/metadata-action), NOT hardcoded — so a repo TRANSFER or an org RENAME
+# auto-repoints the publish target with no coordinated code change. Today the
+# owner is the cyborg-garden org, so this publishes
+# ghcr.io/cyborg-garden/hermes-agent-mt.
+#
+# History: the repo was transferred NimbleCoAI → NimbleCoOrg, and the org was
+# later renamed NimbleCoOrg → cyborg-garden. These two events behave DIFFERENTLY
+# downstream, and the difference is the thing to remember:
+#   - A repo TRANSFER leaves the old owner's GHCR package behind, public and
+#     frozen. ghcr.io/nimblecoai/hermes-agent-mt still pulls SUCCESSFULLY and
+#     silently serves stale pre-move code. Never delete it; it is the grace
+#     window — but consumers must be repointed or they rot in silence.
+#   - An org RENAME carries the package namespace with it and leaves NO
+#     redirect. ghcr.io/nimblecoorg/hermes-agent-mt no longer resolves; pulls
+#     against it fail outright rather than going stale.
 
 on:
   push:
@@ -42,7 +51,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           # Owner-derived (see header): metadata-action lowercases the owner, so
-          # NimbleCoAI→nimblecoai, NimbleCoOrg→nimblecoorg, transfer-safe. The
+          # NimbleCoAI→nimblecoai, NimbleCoOrg→nimblecoorg,
+          # cyborg-garden→cyborg-garden — transfer- and rename-safe. The
           # deprecated `…/hermes-agent` dual-publish alias (removal date
           # 2026-07-15, now passed) is dropped — only the canonical
           # hermes-agent-mt path is published.

--- a/FORK-NOTICE.md
+++ b/FORK-NOTICE.md
@@ -1,11 +1,12 @@
 # Multi-Tenant Fork Notice
 
-> **⚠️ This repository moved orgs: `NimbleCoAI/hermes-agent-mt` → `NimbleCoOrg/hermes-agent-mt`.**
-> (Earlier history: it was also renamed from `hermes-agent` to `hermes-agent-mt`.)
+> **⚠️ The owning org was renamed: `NimbleCoOrg` → `cyborg-garden`.**
+> (Earlier history: this repo moved from `NimbleCoAI/hermes-agent-mt` to `NimbleCoOrg/hermes-agent-mt`, and before that was renamed from `hermes-agent` to `hermes-agent-mt`.)
 > - **Git URLs:** clone/remote URLs **auto-redirect** — existing checkouts keep working, no action needed.
-> - **Container image — action required.** CI now publishes to **`ghcr.io/nimblecoorg/hermes-agent-mt`** (the workflow derives the namespace from the repo owner, so it repointed itself on transfer). The old **`ghcr.io/nimblecoai/hermes-agent-mt`** package is **retained read-only and frozen at 2026-07-21**. It is still public and `docker pull` against it still **succeeds** — it just returns code from before the move, with no error. Repoint any compose file, deploy script, or pinned digest to the `nimblecoorg` path. The pre-rename **`ghcr.io/nimblecoai/hermes-agent`** package is likewise public and frozen (last build 2026-07-21), and it too still returns a *successful* pull — if anything is still pinned to that older path, repoint it as well. Neither old package is being deleted; both are the intended read-only grace window.
+> - **Container image — action required.** CI now publishes to **`ghcr.io/cyborg-garden/hermes-agent-mt`** (the workflow derives the namespace from the repo owner, so it repointed itself on the rename). **GHCR does not redirect the way Git does.** The org rename carried the package namespace with it, so **`ghcr.io/nimblecoorg/hermes-agent-mt` no longer resolves at all** — a pull against it now fails outright. Repoint any compose file, deploy script, or pinned digest to the `cyborg-garden` path.
+> - **The older `NimbleCoAI` packages still pull — and that is the dangerous case.** `NimbleCoAI` is a separate user account and was *not* renamed. **`ghcr.io/nimblecoai/hermes-agent-mt`** remains public and is **frozen at its last build, 2026-08-06**; `docker pull` against it still **succeeds** and simply returns pre-move code, with no error. The pre-rename **`ghcr.io/nimblecoai/hermes-agent`** package is likewise public and frozen (last build 2026-07-21), and it too still returns a *successful* pull. Neither is being deleted; both are the intended read-only grace window. If anything is pinned to either, repoint it.
 
-This is **hermes-agent-mt** — a thin fork of [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) patched for multi-tenant deployments managed by [Swarm Map](https://github.com/NimbleCoOrg/swarm-map).
+This is **hermes-agent-mt** — a thin fork of [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) patched for multi-tenant deployments managed by [Swarm Map](https://github.com/cyborg-garden/swarm-map).
 
 ## What's Different
 
@@ -36,15 +37,15 @@ This fork adds **2 core patches** and **~8 adapter improvements** on top of upst
 
 ```bash
 # Docker (recommended)
-docker pull ghcr.io/nimblecoorg/hermes-agent-mt:latest
+docker pull ghcr.io/cyborg-garden/hermes-agent-mt:latest
 
 # Or build from source
-git clone https://github.com/NimbleCoOrg/hermes-agent-mt.git
+git clone https://github.com/cyborg-garden/hermes-agent-mt.git
 cd hermes-agent-mt
 pip install -e ".[all]"
 ```
 
-For multi-tenant management, use [Swarm Map](https://github.com/NimbleCoOrg/swarm-map).
+For multi-tenant management, use [Swarm Map](https://github.com/cyborg-garden/swarm-map).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 # Hermes Agent ☤
 
-> **🔀 Multi-Tenant Fork** — This is `hermes-agent-mt`, patched for multi-tenant deployments with per-context memory isolation, group policy enforcement, and [Swarm Map](https://github.com/NimbleCoOrg/swarm-map) integration. See [FORK-NOTICE.md](FORK-NOTICE.md) for details.
+> **🔀 Multi-Tenant Fork** — This is `hermes-agent-mt`, patched for multi-tenant deployments with per-context memory isolation, group policy enforcement, and [Swarm Map](https://github.com/cyborg-garden/swarm-map) integration. See [FORK-NOTICE.md](FORK-NOTICE.md) for details.
 >
-> **⚠️ Repo moved orgs:** `NimbleCoAI/hermes-agent-mt` → `NimbleCoOrg/hermes-agent-mt` (and earlier, `hermes-agent` → `hermes-agent-mt`). Git clone/remote URLs auto-redirect — no action needed. **The image path did change:** CI now publishes to **`ghcr.io/nimblecoorg/hermes-agent-mt`**. The old `ghcr.io/nimblecoai/hermes-agent-mt` package is kept read-only, **frozen at 2026-07-21** — pulls against it still succeed and silently return pre-move code, so repoint anything pinned to it. The pre-rename `ghcr.io/nimblecoai/hermes-agent` package is frozen the same way and also still pulls successfully — repoint anything pinned to it too.
+> **⚠️ Org renamed:** `NimbleCoOrg` → `cyborg-garden` (earlier history: `NimbleCoAI/hermes-agent-mt` → `NimbleCoOrg/hermes-agent-mt`, and before that `hermes-agent` → `hermes-agent-mt`). Git clone/remote URLs auto-redirect — no action needed. **The image path did change:** CI now publishes to **`ghcr.io/cyborg-garden/hermes-agent-mt`**. Unlike Git, **GHCR does not redirect across an org rename** — `ghcr.io/nimblecoorg/hermes-agent-mt` no longer resolves at all, and anything still pinned to it now **fails to pull**. The older `ghcr.io/nimblecoai/hermes-agent-mt` package (separate `NimbleCoAI` user account, not renamed) is still public and **frozen at its last build, 2026-08-06** — pulls against it still *succeed* and silently return pre-move code, which is the more dangerous failure. Repoint anything on either old path. The pre-rename `ghcr.io/nimblecoai/hermes-agent` package is frozen the same way (last build 2026-07-21) and also still pulls successfully — repoint anything pinned to it too.
 >
-> Upstream: [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) · Image: `ghcr.io/nimblecoorg/hermes-agent-mt:latest`
+> Upstream: [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) · Image: `ghcr.io/cyborg-garden/hermes-agent-mt:latest`
 
 <p align="center">
   <a href="https://hermes-agent.nousresearch.com/">Hermes Agent</a> | <a href="https://hermes-agent.nousresearch.com/">Hermes Desktop</a>


### PR DESCRIPTION
## What

- `README.md` and `FORK-NOTICE.md`: correct `ghcr.io/nimblecoorg/hermes-agent-mt` pull instructions and the clone snippet
- `.github/workflows/ghcr-publish.yml` (header prose only): rewrite the stale note describing the old `NimbleCoAI → NimbleCoOrg` transfer

## Why

The org was renamed on 2026-08-13 and `ghcr.io/nimblecoorg/hermes-agent-mt` is now **fully dead** (token `DENIED`, manifest 401). The README was telling people to pull a path that no longer exists — this repo is public with 11 stars, so that is externally visible.

The prose rewrite draws the distinction that caused the confusion: an org **rename** takes the GHCR namespace with it and leaves no redirect, whereas a repo **transfer** leaves a frozen-but-still-pullable package behind. Both break; only one breaks loudly.

## Verification

Docs and YAML comments only — no build or runtime change. Workflow YAML re-parsed clean. **Line 50 (`${{ github.repository_owner }}`) deliberately untouched**: it is owner-derived and already publishes to the correct new path.

## Risk

`patches/*.patch` untouched by design — frozen fork-layer artifacts.

⚠️ Note for whoever owns this tree: creating the branch cleared a stale `CHERRY_PICK_HEAD` marker. No content was lost — the WIP files are byte-identical and this commit contains only the 3 doc files — but if you were mid-`cherry-pick`, finish with a normal commit rather than `--continue`.