### PR TITLE
feat(routing): extra_body passthrough + per-turn decision metrics

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1243,9 +1243,26 @@ def restore_primary_runtime(agent) -> bool:
         _saved = getattr(agent, "_routing_override_saved_primary", None)
         if isinstance(_saved, dict):
             agent._primary_runtime = _saved
+        # Revert any turn-scoped request-body params (e.g. {"think": false}
+        # applied for a local cheap tier). _NOT_SET means the key did not exist
+        # before the routed turn, so we remove it rather than leaving {} behind.
+        try:
+            from agent.routing_override import _NOT_SET
+
+            _saved_eb = getattr(agent, "_routing_override_saved_extra_body", _NOT_SET)
+            _overrides = getattr(agent, "request_overrides", None)
+            if isinstance(_overrides, dict):
+                if _saved_eb is _NOT_SET:
+                    _overrides.pop("extra_body", None)
+                else:
+                    _overrides["extra_body"] = _saved_eb
+        except Exception:  # noqa: BLE001 — restore is best-effort, never fatal
+            pass
+
         # Clear the scoping state so this runs exactly once.
         agent._routing_override_active = False
         agent._routing_override_saved_primary = None
+        agent._routing_override_saved_extra_body = None
         # Do NOT return here — proceed to rebuild the runtime from the restored
         # (premium) _primary_runtime via the shared body below.
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1244,14 +1244,25 @@ def restore_primary_runtime(agent) -> bool:
         if isinstance(_saved, dict):
             agent._primary_runtime = _saved
         # Revert any turn-scoped request-body params (e.g. {"think": false}
-        # applied for a local cheap tier). _NOT_SET means the key did not exist
-        # before the routed turn, so we remove it rather than leaving {} behind.
+        # applied for a local cheap tier). Three states, not two: _UNTOUCHED
+        # means the routed turn never wrote extra_body (the default, since
+        # routing.cheap_extra_body is empty unless configured) and must be left
+        # strictly alone — popping there destroyed the primary provider's own
+        # body params for the rest of the session. _NOT_SET means the key did
+        # not exist before the routed turn, so we remove it rather than leaving
+        # {} behind. Anything else is the pre-turn value to reinstate.
+        #
+        # Act on the dict apply_routing_override actually mutated, NOT on a
+        # fresh read of agent.request_overrides: the gateway assigns a new
+        # per-turn overrides dict onto the cached agent before this revert runs.
         try:
-            from agent.routing_override import _NOT_SET
+            from agent.routing_override import _NOT_SET, _UNTOUCHED
 
-            _saved_eb = getattr(agent, "_routing_override_saved_extra_body", _NOT_SET)
-            _overrides = getattr(agent, "request_overrides", None)
-            if isinstance(_overrides, dict):
+            _saved_eb = getattr(
+                agent, "_routing_override_saved_extra_body", _UNTOUCHED
+            )
+            _overrides = getattr(agent, "_routing_override_overrides_ref", None)
+            if _saved_eb is not _UNTOUCHED and isinstance(_overrides, dict):
                 if _saved_eb is _NOT_SET:
                     _overrides.pop("extra_body", None)
                 else:
@@ -1263,6 +1274,7 @@ def restore_primary_runtime(agent) -> bool:
         agent._routing_override_active = False
         agent._routing_override_saved_primary = None
         agent._routing_override_saved_extra_body = None
+        agent._routing_override_overrides_ref = None
         # Do NOT return here — proceed to rebuild the runtime from the restored
         # (premium) _primary_runtime via the shared body below.
 

--- a/agent/routing_override.py
+++ b/agent/routing_override.py
@@ -77,6 +77,15 @@ _PASSTHROUGH_FIELDS = ("base_url", "api_key", "api_mode")
 # so restore removes the key entirely rather than leaving an empty dict behind.
 _NOT_SET = object()
 
+# THIRD state, and the one a single sentinel got wrong: "this routed turn never
+# wrote extra_body at all". routing.cheap_extra_body is empty by default, so
+# that is the COMMON case — and conflating it with _NOT_SET made the revert pop
+# an extra_body the override never set. request_overrides["extra_body"] is built
+# once at agent construction for custom providers and for fast/priority mode, so
+# that pop silently destroyed the primary provider's own body params for the
+# rest of the session. Revert must be a no-op on this value.
+_UNTOUCHED = object()
+
 
 def extract_routing_override(results: Iterable[Any]) -> Optional[dict]:
     """Return the first well-formed ``route`` override from hook results, or None.
@@ -176,7 +185,8 @@ def apply_routing_override(agent: Any, override: Optional[dict]) -> bool:
     # Merged over any existing extra_body so custom-provider params survive; the
     # prior value is stashed for restore_primary_runtime to revert next turn.
     # Best-effort: a malformed extra_body must not undo an applied swap.
-    saved_extra_body = _NOT_SET
+    saved_extra_body = _UNTOUCHED
+    overrides_ref = None
     try:
         routed_extra_body = override.get("extra_body")
         if isinstance(routed_extra_body, dict) and routed_extra_body:
@@ -184,9 +194,20 @@ def apply_routing_override(agent: Any, override: Optional[dict]) -> bool:
             if isinstance(overrides, dict):
                 saved_extra_body = overrides.get("extra_body", _NOT_SET)
                 base = saved_extra_body if isinstance(saved_extra_body, dict) else {}
+                # Shallow copy: saved and live are always DISTINCT dicts (so the
+                # merge can't corrupt the snapshot at the top level), but they
+                # share nested values. Never mutate a nested value in place here
+                # or in flight — that would reach through into the snapshot and
+                # into the loaded config that cheap_extra_body() copied from.
                 merged = dict(base)
                 merged.update(routed_extra_body)
                 overrides["extra_body"] = merged
+                # Remember WHICH dict we dirtied. The gateway assigns a freshly
+                # built per-turn request_overrides onto the cached agent before
+                # the next turn's revert runs, so re-reading the attribute there
+                # would clean the wrong object: leaving cheap params on the dict
+                # we actually mutated and stomping the new turn's own extra_body.
+                overrides_ref = overrides
         elif routed_extra_body not in (None, {}):
             logger.debug(
                 "intelligent_routing: ignoring non-dict extra_body (%s)",
@@ -196,8 +217,26 @@ def apply_routing_override(agent: Any, override: Optional[dict]) -> bool:
         logger.debug("intelligent_routing: could not apply extra_body", exc_info=True)
 
     try:
-        agent._routing_override_saved_primary = primary_snapshot
-        agent._routing_override_saved_extra_body = saved_extra_body
+        # Only the FIRST apply of a turn snapshots. A second apply without an
+        # intervening restore would otherwise stash the first route's own
+        # runtime and merged extra_body as the "pristine" pre-turn state, so the
+        # cheap params would survive the revert. The single in-tree call site
+        # applies once per turn, but the snapshot is the whole safety property.
+        # `is not True` deliberately, not falsiness: the flag is set to exactly
+        # True here and cleared to False by the revert, so anything else means
+        # "no snapshot has been taken" rather than "a routed turn is live".
+        if getattr(agent, "_routing_override_active", False) is not True:
+            agent._routing_override_saved_primary = primary_snapshot
+            agent._routing_override_saved_extra_body = saved_extra_body
+            agent._routing_override_overrides_ref = overrides_ref
+        elif overrides_ref is not None and getattr(
+            agent, "_routing_override_saved_extra_body", _UNTOUCHED
+        ) is _UNTOUCHED:
+            # First apply wrote no extra_body, this one did: the snapshot is
+            # still pristine, but the revert now needs the dirtied dict + the
+            # value that was there before this apply touched it.
+            agent._routing_override_saved_extra_body = saved_extra_body
+            agent._routing_override_overrides_ref = overrides_ref
         agent._routing_override_active = True
     except Exception:  # noqa: BLE001 — best-effort scoping; swap already applied
         logger.debug("intelligent_routing: could not scope override to turn",

--- a/agent/routing_override.py
+++ b/agent/routing_override.py
@@ -14,7 +14,13 @@ A ``pre_llm_call`` hook result may be a dict carrying a ``route`` key::
      "route": {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}}
 
 ``model`` is required; ``provider`` (and optional ``base_url`` / ``api_key`` /
-``api_mode``) are passed through to ``switch_model``. ``turn_context`` extracts
+``api_mode``) are passed through to ``switch_model``. An optional ``extra_body``
+dict is NOT passed to ``switch_model`` (its signature has no such parameter) —
+it is merged into ``agent.request_overrides["extra_body"]`` for the turn and
+reverted with the rest of the override. That is what lets a routed turn carry a
+provider-specific body param such as ``{"think": false}`` for a local ollama
+cheap tier; without it a thinking model returns an empty completion under a
+modest ``max_tokens``. ``turn_context`` extracts
 the first well-formed override and applies it right after the hook fires, before
 the turn's first API call assembles.
 
@@ -66,6 +72,10 @@ logger = logging.getLogger(__name__)
 # Fields we forward from an override into switch_model (model/provider plus the
 # optional endpoint/credential fields switch_model already accepts).
 _PASSTHROUGH_FIELDS = ("base_url", "api_key", "api_mode")
+
+# Distinguishes "there was no extra_body before" from "it was explicitly {}",
+# so restore removes the key entirely rather than leaving an empty dict behind.
+_NOT_SET = object()
 
 
 def extract_routing_override(results: Iterable[Any]) -> Optional[dict]:
@@ -162,8 +172,32 @@ def apply_routing_override(agent: Any, override: Optional[dict]) -> bool:
     # Mark the override turn-scoped with a DEDICATED flag. Do NOT restore the
     # premium snapshot into _primary_runtime (keep it == cheap) and do NOT arm
     # _fallback_activated (that would corrupt reactive cooldown accounting).
+    # Turn-scoped request-body params (e.g. {"think": false} for a local tier).
+    # Merged over any existing extra_body so custom-provider params survive; the
+    # prior value is stashed for restore_primary_runtime to revert next turn.
+    # Best-effort: a malformed extra_body must not undo an applied swap.
+    saved_extra_body = _NOT_SET
+    try:
+        routed_extra_body = override.get("extra_body")
+        if isinstance(routed_extra_body, dict) and routed_extra_body:
+            overrides = getattr(agent, "request_overrides", None)
+            if isinstance(overrides, dict):
+                saved_extra_body = overrides.get("extra_body", _NOT_SET)
+                base = saved_extra_body if isinstance(saved_extra_body, dict) else {}
+                merged = dict(base)
+                merged.update(routed_extra_body)
+                overrides["extra_body"] = merged
+        elif routed_extra_body not in (None, {}):
+            logger.debug(
+                "intelligent_routing: ignoring non-dict extra_body (%s)",
+                type(routed_extra_body).__name__,
+            )
+    except Exception:  # noqa: BLE001 — never break the turn over extra_body
+        logger.debug("intelligent_routing: could not apply extra_body", exc_info=True)
+
     try:
         agent._routing_override_saved_primary = primary_snapshot
+        agent._routing_override_saved_extra_body = saved_extra_body
         agent._routing_override_active = True
     except Exception:  # noqa: BLE001 — best-effort scoping; swap already applied
         logger.debug("intelligent_routing: could not scope override to turn",

--- a/plugins/intelligent_routing/config.py
+++ b/plugins/intelligent_routing/config.py
@@ -34,6 +34,14 @@ _DEFAULT_MODE = "heuristic"
 _DEFAULT_CHEAP_MODEL = "deepseek/deepseek-v3.2"
 _DEFAULT_CHEAP_PROVIDER = "openrouter"
 
+# Provider-specific request-body params to send WITH a cheap-routed turn, e.g.
+# ``{"think": false}`` for a local ollama tier. Without this a thinking model on
+# an OpenAI-compatible endpoint burns its whole token budget on reasoning and
+# returns an EMPTY completion under any modest max_tokens — measured on
+# qwen3.5:9b: 8 tokens with think=false vs 1807 with it on, same answer, and
+# empty output at max_tokens=200. Empty by default: changes nothing unless set.
+_DEFAULT_CHEAP_EXTRA_BODY: Dict[str, Any] = {}
+
 
 def _load_config() -> Dict[str, Any]:
     """Load the full config dict (``{}`` on any failure). Patched in tests."""
@@ -79,3 +87,19 @@ def cheap_tier_target() -> tuple[str, str]:
     model = str(section.get("cheap_model") or _DEFAULT_CHEAP_MODEL).strip() or _DEFAULT_CHEAP_MODEL
     provider = str(section.get("cheap_provider") or _DEFAULT_CHEAP_PROVIDER).strip() or _DEFAULT_CHEAP_PROVIDER
     return model, provider
+
+
+def cheap_extra_body() -> Dict[str, Any]:
+    """Return ``routing.cheap_extra_body`` as a dict (``{}`` when unset/malformed).
+
+    Returns a shallow copy so callers cannot mutate the loaded config.
+    """
+    value = _routing_section().get("cheap_extra_body", _DEFAULT_CHEAP_EXTRA_BODY)
+    if not isinstance(value, dict):
+        if value not in (None, "", {}):
+            logger.debug(
+                "intelligent_routing: routing.cheap_extra_body is %s, expected a "
+                "mapping — ignoring", type(value).__name__,
+            )
+        return {}
+    return dict(value)

--- a/plugins/intelligent_routing/registration.py
+++ b/plugins/intelligent_routing/registration.py
@@ -29,6 +29,7 @@ different axis; reactive escalation still applies underneath the chosen tier.
 """
 from __future__ import annotations
 
+import json
 import logging
 import re
 from typing import Any, Optional
@@ -39,7 +40,11 @@ from .classifier import (
     classify_turn,
     decide_tier,
 )
-from .config import cheap_tier_target, is_intelligent_routing_enabled
+from .config import (
+    cheap_extra_body,
+    cheap_tier_target,
+    is_intelligent_routing_enabled,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -210,14 +215,63 @@ def on_pre_llm_call(**kwargs: Any) -> Optional[dict]:
         # runtime's routing-override extension (agent/routing_override.py)
         # actuates. Premium / fail-open turns emit no override and stay on the
         # configured primary.
+        routed_model, routed_provider = kwargs.get("model"), kwargs.get("provider")
         if tier == TIER_CHEAP:
             cheap_model, cheap_provider = cheap_tier_target()
             if cheap_model:
-                result["route"] = {"model": cheap_model, "provider": cheap_provider}
+                route = {"model": cheap_model, "provider": cheap_provider}
+                # Provider-specific body params for the cheap tier (e.g.
+                # {"think": false} on a local ollama model). Omitted entirely
+                # when unset, so nothing changes for existing cloud tiers.
+                extra_body = cheap_extra_body()
+                if extra_body:
+                    route["extra_body"] = extra_body
+                result["route"] = route
+                routed_model, routed_provider = cheap_model, cheap_provider
+
+        log_routing_decision(
+            tier=tier,
+            model=routed_model,
+            provider=routed_provider,
+            reason=reason,
+            primary_model=kwargs.get("model"),
+        )
         return result
     except Exception as exc:  # noqa: BLE001 — must never break the turn
         logger.warning("intelligent_routing: pre_llm_call failed (inert): %s", exc)
         return None
+
+
+def log_routing_decision(*, tier, model, provider, reason, primary_model) -> None:
+    """Emit ONE machine-parseable decision record per classified turn.
+
+    Format: ``routing_decision {json}`` at INFO on this module's logger, so a
+    window of fleet data can be harvested with a grep + ``json.loads`` on the
+    suffix. This is the instrumentation the upstream-PR spec
+    (2026-07-23, "numbers needed for the Nous upstream PR") names as its first
+    prerequisite: *"Routing decisions must be countable: parseable per-turn log
+    line of tier, model, reason."* Absent it, coverage/cost/fail-open rates
+    cannot be computed, which is why Stage 2 never had numbers to attach.
+
+    Never raises — metrics must not be able to break a turn.
+    """
+    try:
+        logger.info(
+            "routing_decision %s",
+            json.dumps(
+                {
+                    "tier": tier,
+                    "model": model,
+                    "provider": provider,
+                    "reason": reason,
+                    "primary_model": primary_model,
+                },
+                default=str,
+                ensure_ascii=False,
+            ),
+        )
+    except Exception:  # noqa: BLE001 — instrumentation must never break the turn
+        logger.debug("intelligent_routing: metric emit failed", exc_info=True)
 
 
 def register(ctx) -> None:

--- a/plugins/intelligent_routing/registration.py
+++ b/plugins/intelligent_routing/registration.py
@@ -99,6 +99,12 @@ def _parse_model_directive(message: str) -> object:
 # non-mechanical), so an over-peel can never wrongly cheap-route real work.
 _SENDER_PREFIX_RE = re.compile(r"^\[[^\]\n]{1,64}\]\s+")
 
+# Metrics-only tier label. NOT a classifier tier (the classifier never sees a
+# directive turn — the intercept runs before it), so it does not belong beside
+# TIER_CHEAP/TIER_PREMIUM in classifier.py. It keeps user-directed turns
+# countable and separable from classified ones in the same log stream.
+TIER_DIRECTIVE = "directive"
+
 
 def _strip_sender_prefix(message: str) -> str:
     """Peel one leading ``[sender] `` group-attribution prefix, if present."""
@@ -178,6 +184,18 @@ def on_pre_llm_call(**kwargs: Any) -> Optional[dict]:
         if not isinstance(raw_message, str):
             raw_message = str(raw_message)
         stripped = _strip_sender_prefix(raw_message)
+        # Whether a "[sender] " attribution was peeled IS the group signal — a
+        # Discord DM and a Discord group turn share platform="discord", so
+        # platform cannot separate them. The group/DM split is the dimension the
+        # harvest needs most: a past bug made group chat inert (what
+        # _SENDER_PREFIX_RE fixes), and without this flag a recurrence is
+        # invisible in the log.
+        metric_dims = {
+            "session_id": kwargs.get("session_id"),
+            "turn_id": kwargs.get("turn_id"),
+            "platform": kwargs.get("platform") or "",
+            "is_group": stripped != raw_message,
+        }
 
         # ── User model directive ("use fable for this") ───────────────────────
         # Check BEFORE the classifier. "use" is in _IMPERATIVE_VERBS so without
@@ -188,10 +206,24 @@ def on_pre_llm_call(**kwargs: Any) -> Optional[dict]:
                 # "use claude" — stay on configured primary; inject a context note.
                 reason = "user-requested → primary"
                 line = _reason_line(kwargs.get("model"), kwargs.get("provider"), reason)
+                # A directive is the pushback signal — "the user rejected the
+                # cheap answer" is exactly what the upstream numbers need, and
+                # it is also a real turn. Returning here without a row both lost
+                # that signal and left the log with no total-turn denominator,
+                # so any cheap-share read off it described classified turns only.
+                log_routing_decision(
+                    tier=TIER_DIRECTIVE, model=kwargs.get("model"),
+                    provider=kwargs.get("provider"), reason=reason,
+                    primary_model=kwargs.get("model"), **metric_dims,
+                )
                 return {"context": line}
             model, provider = directive
             reason = f"user-requested → {model.split('/')[0] if '/' in model else model}"
             line = _reason_line(kwargs.get("model"), kwargs.get("provider"), reason)
+            log_routing_decision(
+                tier=TIER_DIRECTIVE, model=model, provider=provider, reason=reason,
+                primary_model=kwargs.get("model"), **metric_dims,
+            )
             return {"route": {"model": model, "provider": provider}, "context": line}
 
         # ── Heuristic classifier (no explicit directive) ───────────────────────
@@ -235,6 +267,7 @@ def on_pre_llm_call(**kwargs: Any) -> Optional[dict]:
             provider=routed_provider,
             reason=reason,
             primary_model=kwargs.get("model"),
+            **metric_dims,
         )
         return result
     except Exception as exc:  # noqa: BLE001 — must never break the turn
@@ -242,7 +275,10 @@ def on_pre_llm_call(**kwargs: Any) -> Optional[dict]:
         return None
 
 
-def log_routing_decision(*, tier, model, provider, reason, primary_model) -> None:
+def log_routing_decision(
+    *, tier, model, provider, reason, primary_model,
+    session_id=None, turn_id=None, platform=None, is_group=None,
+) -> None:
     """Emit ONE machine-parseable decision record per classified turn.
 
     Format: ``routing_decision {json}`` at INFO on this module's logger, so a
@@ -265,6 +301,16 @@ def log_routing_decision(*, tier, model, provider, reason, primary_model) -> Non
                     "provider": provider,
                     "reason": reason,
                     "primary_model": primary_model,
+                    # Join keys. Cost / latency / 429-rate live on the POST-call
+                    # side (usage, api_duration, finish_reason), which this
+                    # pre-call hook structurally cannot see; carrying turn_id +
+                    # session_id lets those rows be joined against an already
+                    # deployed observability plugin instead of blocking on a
+                    # post_llm_call hook here.
+                    "session_id": session_id,
+                    "turn_id": turn_id,
+                    "platform": platform,
+                    "is_group": is_group,
                 },
                 default=str,
                 ensure_ascii=False,

--- a/tests/plugins/intelligent_routing/test_extra_body_and_metrics.py
+++ b/tests/plugins/intelligent_routing/test_extra_body_and_metrics.py
@@ -1,0 +1,216 @@
+"""Cheap-tier `extra_body` passthrough + per-turn routing metrics.
+
+Two gaps this closes:
+
+1. **extra_body** — `routing_override` forwarded only base_url/api_key/api_mode,
+   so there was no way to send a provider-specific body param with a routed
+   turn. That blocks a LOCAL cheap tier: ollama's OpenAI-compatible endpoint
+   leaves thinking ON by default, so a mechanical turn on qwen3.5:9b burns
+   ~1800 reasoning tokens for an 8-token answer, and returns an EMPTY string
+   under any modest max_tokens. Measured on the Mini 2026-08-26.
+
+2. **metrics** — the plugin emitted no per-turn decision record, which is the
+   stated blocker on the upstream PR (spec 2026-07-23: "Routing decisions must
+   be countable: parseable per-turn log line of tier, model, reason").
+"""
+import json
+import logging
+from unittest.mock import patch
+
+from plugins.intelligent_routing import config as cfgmod
+
+
+# ── 1. config: routing.cheap_extra_body ──────────────────────────────────────
+
+def test_cheap_extra_body_defaults_empty():
+    with patch.object(cfgmod, "_load_config", return_value={}):
+        assert cfgmod.cheap_extra_body() == {}
+
+
+def test_cheap_extra_body_read_from_config():
+    with patch.object(cfgmod, "_load_config", return_value={
+            "routing": {"cheap_extra_body": {"think": False}}}):
+        assert cfgmod.cheap_extra_body() == {"think": False}
+
+
+def test_cheap_extra_body_non_dict_is_ignored():
+    """A malformed value must not break the turn — fail to {}."""
+    for bad in ("think=false", 42, [1, 2], None):
+        with patch.object(cfgmod, "_load_config",
+                          return_value={"routing": {"cheap_extra_body": bad}}):
+            assert cfgmod.cheap_extra_body() == {}, bad
+
+
+def test_cheap_extra_body_returns_a_copy():
+    """Callers must not be able to mutate the cached config section."""
+    section = {"routing": {"cheap_extra_body": {"think": False}}}
+    with patch.object(cfgmod, "_load_config", return_value=section):
+        got = cfgmod.cheap_extra_body()
+        got["think"] = True
+        assert section["routing"]["cheap_extra_body"] == {"think": False}
+
+
+# ── 2. routing_override: apply / scope / restore extra_body ──────────────────
+
+class _FakeAgent:
+    def __init__(self):
+        self.model = "z-ai/glm-5.3"
+        self.provider = "openrouter"
+        self.request_overrides = {}
+        self._primary_runtime = {"model": "z-ai/glm-5.3", "provider": "openrouter"}
+        self.switched = None
+
+    def switch_model(self, model, provider, **kw):
+        self.switched = (model, provider, kw)
+        self.model, self.provider = model, provider
+
+
+def test_extra_body_applied_to_request_overrides():
+    from agent import routing_override as ro
+    a = _FakeAgent()
+    ok = ro.apply_routing_override(a, {
+        "model": "qwen3.5:9b", "provider": "ollama",
+        "extra_body": {"think": False},
+    })
+    assert ok is True
+    assert a.request_overrides.get("extra_body") == {"think": False}
+
+
+def test_extra_body_not_passed_to_switch_model():
+    """switch_model()'s signature has no extra_body — passing it would TypeError."""
+    from agent import routing_override as ro
+    a = _FakeAgent()
+    ro.apply_routing_override(a, {
+        "model": "qwen3.5:9b", "provider": "ollama",
+        "extra_body": {"think": False},
+    })
+    assert "extra_body" not in (a.switched[2] or {})
+
+
+def test_extra_body_merges_over_existing_without_destroying_it():
+    from agent import routing_override as ro
+    a = _FakeAgent()
+    a.request_overrides["extra_body"] = {"tags": ["x"], "think": True}
+    ro.apply_routing_override(a, {
+        "model": "qwen3.5:9b", "provider": "ollama",
+        "extra_body": {"think": False},
+    })
+    eb = a.request_overrides["extra_body"]
+    assert eb["think"] is False      # routed value wins
+    assert eb["tags"] == ["x"]       # pre-existing survives
+
+
+def test_extra_body_stashed_for_restore():
+    from agent import routing_override as ro
+    a = _FakeAgent()
+    a.request_overrides["extra_body"] = {"tags": ["x"]}
+    ro.apply_routing_override(a, {
+        "model": "qwen3.5:9b", "provider": "ollama",
+        "extra_body": {"think": False},
+    })
+    assert a._routing_override_saved_extra_body == {"tags": ["x"]}
+    assert a._routing_override_active is True
+
+
+def test_no_extra_body_leaves_request_overrides_untouched():
+    from agent import routing_override as ro
+    a = _FakeAgent()
+    ro.apply_routing_override(a, {"model": "deepseek/x", "provider": "openrouter"})
+    assert "extra_body" not in a.request_overrides
+
+
+def test_malformed_extra_body_does_not_break_the_turn():
+    from agent import routing_override as ro
+    a = _FakeAgent()
+    ok = ro.apply_routing_override(a, {
+        "model": "qwen3.5:9b", "provider": "ollama", "extra_body": "think=false",
+    })
+    assert ok is True                       # swap still happened
+    assert "extra_body" not in a.request_overrides
+
+
+# ── 3. registration: per-turn metrics line ───────────────────────────────────
+
+def test_routing_decision_emits_parseable_metric(caplog):
+    """One machine-parseable line per turn carrying tier, model, reason."""
+    from plugins.intelligent_routing import registration as reg
+    with caplog.at_level(logging.INFO, logger=reg.logger.name):
+        reg.log_routing_decision(
+            tier="cheap", model="qwen3.5:9b", provider="ollama",
+            reason="mechanical → cheap", primary_model="z-ai/glm-5.3",
+        )
+    recs = [r for r in caplog.records if "routing_decision" in r.getMessage()]
+    assert len(recs) == 1
+    payload = json.loads(recs[0].getMessage().split("routing_decision ", 1)[1])
+    assert payload["tier"] == "cheap"
+    assert payload["model"] == "qwen3.5:9b"
+    assert payload["provider"] == "ollama"
+    assert payload["reason"] == "mechanical → cheap"
+    assert payload["primary_model"] == "z-ai/glm-5.3"
+
+
+def test_metric_emission_never_raises():
+    from plugins.intelligent_routing import registration as reg
+    reg.log_routing_decision(tier=None, model=None, provider=None,
+                             reason=None, primary_model=None)
+
+
+# ── 4. hook path + restore (regression guards) ───────────────────────────────
+
+def test_hook_emits_extra_body_on_cheap_route():
+    """Exercises the real hook body — guards the import of cheap_extra_body."""
+    from plugins.intelligent_routing import registration as reg
+    with patch.object(reg, "is_intelligent_routing_enabled", return_value=True), \
+         patch.object(reg, "decide_tier", return_value=reg.TIER_CHEAP), \
+         patch.object(reg, "classify_turn", return_value="mechanical"), \
+         patch.object(reg, "cheap_tier_target", return_value=("qwen3.5:9b", "ollama")), \
+         patch.object(reg, "cheap_extra_body", return_value={"think": False}):
+        out = reg.on_pre_llm_call(messages=[{"role": "user", "content": "list the files"}],
+                                  model="z-ai/glm-5.3", provider="openrouter")
+    assert out["route"]["model"] == "qwen3.5:9b"
+    assert out["route"]["extra_body"] == {"think": False}
+
+
+def test_hook_omits_extra_body_when_unset():
+    from plugins.intelligent_routing import registration as reg
+    with patch.object(reg, "is_intelligent_routing_enabled", return_value=True), \
+         patch.object(reg, "decide_tier", return_value=reg.TIER_CHEAP), \
+         patch.object(reg, "classify_turn", return_value="mechanical"), \
+         patch.object(reg, "cheap_tier_target", return_value=("deepseek/x", "openrouter")), \
+         patch.object(reg, "cheap_extra_body", return_value={}):
+        out = reg.on_pre_llm_call(messages=[{"role": "user", "content": "list the files"}],
+                                  model="z-ai/glm-5.3", provider="openrouter")
+    assert "extra_body" not in out["route"]
+
+
+def test_restore_removes_extra_body_that_did_not_exist_before():
+    from agent import routing_override as ro
+    a = _FakeAgent()
+    ro.apply_routing_override(a, {"model": "qwen3.5:9b", "provider": "ollama",
+                                  "extra_body": {"think": False}})
+    assert a.request_overrides["extra_body"] == {"think": False}
+    _simulate_restore(a)
+    assert "extra_body" not in a.request_overrides
+
+
+def test_restore_reinstates_prior_extra_body():
+    from agent import routing_override as ro
+    a = _FakeAgent()
+    a.request_overrides["extra_body"] = {"tags": ["x"]}
+    ro.apply_routing_override(a, {"model": "qwen3.5:9b", "provider": "ollama",
+                                  "extra_body": {"think": False}})
+    _simulate_restore(a)
+    assert a.request_overrides["extra_body"] == {"tags": ["x"]}
+
+
+def _simulate_restore(agent):
+    """Mirror of the revert block in agent_runtime_helpers.restore_primary_runtime."""
+    from agent.routing_override import _NOT_SET
+    saved = getattr(agent, "_routing_override_saved_extra_body", _NOT_SET)
+    if isinstance(agent.request_overrides, dict):
+        if saved is _NOT_SET:
+            agent.request_overrides.pop("extra_body", None)
+        else:
+            agent.request_overrides["extra_body"] = saved
+    agent._routing_override_active = False
+    agent._routing_override_saved_extra_body = None

--- a/tests/plugins/intelligent_routing/test_extra_body_and_metrics.py
+++ b/tests/plugins/intelligent_routing/test_extra_body_and_metrics.py
@@ -183,34 +183,81 @@ def test_hook_omits_extra_body_when_unset():
     assert "extra_body" not in out["route"]
 
 
-def test_restore_removes_extra_body_that_did_not_exist_before():
-    from agent import routing_override as ro
-    a = _FakeAgent()
-    ro.apply_routing_override(a, {"model": "qwen3.5:9b", "provider": "ollama",
-                                  "extra_body": {"think": False}})
-    assert a.request_overrides["extra_body"] == {"think": False}
-    _simulate_restore(a)
-    assert "extra_body" not in a.request_overrides
+# Restore coverage lives in test_extra_body_revert_real_path.py, which drives the
+# REAL restore_primary_runtime. This file used to mirror its revert block in a
+# local _simulate_restore() helper; the mirror reproduced the implementation's
+# own assumptions, so it could not fail on either revert bug the audit found —
+# and it had already drifted (no _routing_override_active gate).
 
 
-def test_restore_reinstates_prior_extra_body():
-    from agent import routing_override as ro
-    a = _FakeAgent()
-    a.request_overrides["extra_body"] = {"tags": ["x"]}
-    ro.apply_routing_override(a, {"model": "qwen3.5:9b", "provider": "ollama",
-                                  "extra_body": {"think": False}})
-    _simulate_restore(a)
-    assert a.request_overrides["extra_body"] == {"tags": ["x"]}
+# ── 5. metrics: the dimensions a harvest actually has to slice by ────────────
+
+def _decision_rows(caplog):
+    return [json.loads(r.getMessage().split("routing_decision ", 1)[1])
+            for r in caplog.records if "routing_decision " in r.getMessage()]
 
 
-def _simulate_restore(agent):
-    """Mirror of the revert block in agent_runtime_helpers.restore_primary_runtime."""
-    from agent.routing_override import _NOT_SET
-    saved = getattr(agent, "_routing_override_saved_extra_body", _NOT_SET)
-    if isinstance(agent.request_overrides, dict):
-        if saved is _NOT_SET:
-            agent.request_overrides.pop("extra_body", None)
-        else:
-            agent.request_overrides["extra_body"] = saved
-    agent._routing_override_active = False
-    agent._routing_override_saved_extra_body = None
+def _routing_on(reg, tier=None):
+    """Force the plugin on with a deterministic classification."""
+    tier = tier or reg.TIER_CHEAP
+    return (patch.object(reg, "is_intelligent_routing_enabled", return_value=True),
+            patch.object(reg, "decide_tier", return_value=tier),
+            patch.object(reg, "classify_turn", return_value="mechanical"),
+            patch.object(reg, "cheap_tier_target", return_value=("deepseek/x", "openrouter")),
+            patch.object(reg, "cheap_extra_body", return_value={}))
+
+
+def test_decision_row_carries_join_keys_and_group_flag(caplog):
+    """A row with no session_id/turn_id cannot be joined to post-call usage, and
+    without a group flag the group-chat regression _SENDER_PREFIX_RE exists to
+    catch stays invisible in the harvest."""
+    from plugins.intelligent_routing import registration as reg
+    ctxs = _routing_on(reg)
+    with ctxs[0], ctxs[1], ctxs[2], ctxs[3], ctxs[4], \
+            caplog.at_level(logging.INFO, logger=reg.logger.name):
+        reg.on_pre_llm_call(user_message="[alice] list the files",
+                            model="z-ai/glm-5.3", platform="discord",
+                            session_id="S1", turn_id="T7")
+    row = _decision_rows(caplog)[0]
+    assert row["session_id"] == "S1"
+    assert row["turn_id"] == "T7"
+    assert row["platform"] == "discord"
+    assert row["is_group"] is True
+
+
+def test_dm_turn_is_not_flagged_as_group(caplog):
+    from plugins.intelligent_routing import registration as reg
+    ctxs = _routing_on(reg)
+    with ctxs[0], ctxs[1], ctxs[2], ctxs[3], ctxs[4], \
+            caplog.at_level(logging.INFO, logger=reg.logger.name):
+        reg.on_pre_llm_call(user_message="list the files", model="z-ai/glm-5.3",
+                            platform="discord", session_id="S1", turn_id="T7")
+    assert _decision_rows(caplog)[0]["is_group"] is False
+
+
+def test_user_directive_to_primary_emits_a_row(caplog):
+    """"use claude" is the pushback signal — it must not be a silent turn."""
+    from plugins.intelligent_routing import registration as reg
+    ctxs = _routing_on(reg)
+    with ctxs[0], ctxs[1], ctxs[2], ctxs[3], ctxs[4], \
+            caplog.at_level(logging.INFO, logger=reg.logger.name):
+        out = reg.on_pre_llm_call(user_message="use claude please",
+                                  model="z-ai/glm-5.3", session_id="S1", turn_id="T8")
+    assert "route" not in out
+    rows = _decision_rows(caplog)
+    assert len(rows) == 1
+    assert rows[0]["tier"] == "directive"
+    assert rows[0]["turn_id"] == "T8"
+
+
+def test_user_directive_to_another_model_emits_a_row(caplog):
+    from plugins.intelligent_routing import registration as reg
+    ctxs = _routing_on(reg)
+    with ctxs[0], ctxs[1], ctxs[2], ctxs[3], ctxs[4], \
+            caplog.at_level(logging.INFO, logger=reg.logger.name):
+        out = reg.on_pre_llm_call(user_message="use fable for this",
+                                  model="z-ai/glm-5.3", session_id="S1", turn_id="T9")
+    rows = _decision_rows(caplog)
+    assert len(rows) == 1
+    assert rows[0]["tier"] == "directive"
+    assert rows[0]["model"] == out["route"]["model"]

--- a/tests/plugins/intelligent_routing/test_extra_body_revert_real_path.py
+++ b/tests/plugins/intelligent_routing/test_extra_body_revert_real_path.py
@@ -1,0 +1,99 @@
+"""Revert of the turn-scoped ``extra_body`` driven through the REAL
+``restore_primary_runtime`` — not a hand-copied mirror of its revert block.
+
+The PR that introduced ``extra_body`` passthrough tested restore with a local
+``_simulate_restore()`` mirror. A mirror reproduces whatever assumption the
+implementation makes, so it structurally cannot fail on the two bugs the
+independent audit found, and it drifted immediately: the mirror had no
+``_routing_override_active`` gate while the real block does.
+
+These drive ``restore_primary_runtime`` itself, reusing the fake-agent harness
+from ``tests/agent/test_routing_override_revert.py`` (the suite that surfaced
+the original three blockers) so the covered code is the shipped code.
+"""
+import pytest
+
+from agent.agent_runtime_helpers import restore_primary_runtime
+from agent.routing_override import apply_routing_override
+from tests.agent.test_routing_override_revert import _make_agent
+
+
+def _agent_with_overrides(overrides=None):
+    a = _make_agent()
+    a.request_overrides = {} if overrides is None else overrides
+    return a
+
+
+def test_restore_removes_extra_body_that_did_not_exist_before():
+    a = _agent_with_overrides()
+    apply_routing_override(a, {"model": "qwen3.5:9b", "provider": "ollama",
+                               "extra_body": {"think": False}})
+    assert a.request_overrides["extra_body"] == {"think": False}
+    restore_primary_runtime(a)
+    assert "extra_body" not in a.request_overrides
+
+
+def test_restore_reinstates_prior_extra_body():
+    a = _agent_with_overrides({"extra_body": {"tags": ["x"]}})
+    apply_routing_override(a, {"model": "qwen3.5:9b", "provider": "ollama",
+                               "extra_body": {"think": False}})
+    restore_primary_runtime(a)
+    assert a.request_overrides["extra_body"] == {"tags": ["x"]}
+
+
+def test_routed_turn_without_extra_body_preserves_a_pre_existing_one():
+    """BLOCKER (audit finding 3): the DEFAULT path must not destroy extra_body.
+
+    ``routing.cheap_extra_body`` is empty by default, so almost every routed
+    turn carries no ``extra_body``. Conflating "this turn wrote nothing" with
+    "the key was absent before the turn" made the revert pop a primary
+    provider's own body params — set once at agent construction
+    (``_custom_provider_request_overrides``, and fast/priority mode), so the
+    loss is session-persistent and silent.
+    """
+    a = _agent_with_overrides({"extra_body": {"think": True, "top_k": 40}})
+    apply_routing_override(a, {"model": "deepseek/x", "provider": "openrouter"})
+    restore_primary_runtime(a)
+    assert a.request_overrides["extra_body"] == {"think": True, "top_k": 40}
+
+
+def test_revert_cleans_the_dict_it_actually_mutated_not_the_live_one():
+    """Audit finding 1: the gateway swaps in a fresh per-turn overrides dict.
+
+    ``gateway/run.py`` assigns a newly built ``request_overrides`` onto the
+    CACHED agent before ``run_conversation`` fires the revert, so re-reading
+    ``agent.request_overrides`` at revert time reaches a different object than
+    the one the routed turn dirtied: the dirty dict keeps the cheap params and
+    the next turn's dict gets stomped.
+    """
+    routed = {"speed": "fast"}
+    a = _agent_with_overrides(routed)
+    apply_routing_override(a, {"model": "qwen3.5:9b", "provider": "ollama",
+                               "extra_body": {"think": False}})
+    assert routed["extra_body"] == {"think": False}
+
+    # Gateway builds a brand-new dict for the next turn on the same agent.
+    next_turn = {"speed": "fast", "extra_body": {"think": True}}
+    a.request_overrides = next_turn
+    restore_primary_runtime(a)
+
+    assert "extra_body" not in routed, "the mutated dict was never cleaned"
+    assert next_turn["extra_body"] == {"think": True}, "next turn's dict was stomped"
+
+
+def test_double_apply_keeps_the_pristine_pre_turn_extra_body():
+    """Audit finding 4b: a re-apply must not overwrite the pristine snapshot."""
+    a = _agent_with_overrides({"extra_body": {"tags": ["x"]}})
+    apply_routing_override(a, {"model": "qwen3.5:9b", "provider": "ollama",
+                               "extra_body": {"think": False}})
+    apply_routing_override(a, {"model": "deepseek/x", "provider": "openrouter",
+                               "extra_body": {"reasoning": "none"}})
+    restore_primary_runtime(a)
+    assert a.request_overrides["extra_body"] == {"tags": ["x"]}
+
+
+def test_revert_is_gated_on_the_override_flag():
+    """No routed turn ⇒ the revert block must not touch request_overrides."""
+    a = _agent_with_overrides({"extra_body": {"think": True}})
+    restore_primary_runtime(a)
+    assert a.request_overrides["extra_body"] == {"think": True}


### PR DESCRIPTION
## What
- `route.extra_body` — a routed turn can now carry provider-specific request-body params (e.g. `{"think": false}`), merged into `request_overrides` for the turn and reverted with the rest of the override.
- `routing.cheap_extra_body` — per-agent config for the above. Empty by default, so nothing changes for existing cloud cheap tiers.
- `log_routing_decision()` — one parseable `routing_decision {json}` line per classified turn carrying `tier, model, provider, reason, primary_model`.

## Why
Two gaps blocked a **local** cheap tier and the upstream PR.

**1. No way to disable reasoning on a routed turn.** `routing_override` forwarded only `base_url`/`api_key`/`api_mode`. On ollama's OpenAI-compatible endpoint a thinking model reasons by default. Measured on the Mini, qwen3.5:9b, identical mechanical task and identical correct answer:

| route | thinking | completion tokens |
|---|---|---|
| `think: false` | off | **8** |
| OpenAI-compat, max_tokens 2000 | on | **1807** |
| OpenAI-compat, max_tokens 200 | on | 200 — **returns an empty string** |

A cost router that silently answers nothing on exactly the turns it targets is worse than no router.

**2. No per-turn record.** `specs/2026-07-23-intelligent-routing-upstream-pr-metrics.md` names this as its first prerequisite: *"Routing decisions must be countable: parseable per-turn log line of tier, model, reason."* Without it, coverage / cost / fail-open rates cannot be computed — which is why Stage 2 never had numbers to attach.

`extra_body` is applied to `request_overrides`, **not** passed to `switch_model` (its signature has no such parameter); a test guards that. A sentinel distinguishes "absent before the routed turn" from "explicitly `{}`" so restore removes the key rather than leaving an empty dict.

## Verification
- 118 tests in `tests/plugins/intelligent_routing/` pass, including 16 new ones covering config coercion, merge-over-existing, stash/restore, the hook path, and fail-open on malformed input.
- Full suite via `scripts/run_tests.sh`: 30 failures across 15 files. **All pre-existing.** The two files adjacent to this change (`test_model_switch_custom_providers.py`, `test_runtime_provider_resolution.py`) produce byte-identical failures at `HEAD~1` — they cover provider *listing* and Qwen OAuth. The other 13 reference none of the changed modules and are the known macOS/env set (systemd, WSL, feishu, live-system-guard, file perms).
- Changed files compile and import cleanly under Python 3.13 (the runtime the fleet actually runs).
- Both new paths fail open: a malformed `extra_body` still routes; a metrics failure never breaks a turn.

## Risk
Touches the model-selection path. Mitigated by: `cheap_extra_body` defaults to `{}` (no behavior change unless explicitly configured), the metrics line is additive, and the revert path is covered by tests. Not yet exercised in production — the local cheap tier should be enabled on one agent and watched before any fleet rollout.

## Links
- Spec: `specs/2026-07-23-intelligent-routing-upstream-pr-metrics.md`
- Upstream context: NousResearch/hermes-agent#43534 (teknium1: *"If you do want it, please create a plugin. Happy to support adding to the plugin interface to make this work as one."*)

---
Per org rule this needs an independent audit before merge.
