### PR TITLE
fix(agent): merge request_overrides extra_body on the legacy transport path; correct the cheap_extra_body justification

### DIFF
--- a/agent/routing_override.py
+++ b/agent/routing_override.py
@@ -17,12 +17,21 @@ A ``pre_llm_call`` hook result may be a dict carrying a ``route`` key::
 ``api_mode``) are passed through to ``switch_model``. An optional ``extra_body``
 dict is NOT passed to ``switch_model`` (its signature has no such parameter) —
 it is merged into ``agent.request_overrides["extra_body"]`` for the turn and
-reverted with the rest of the override. That is what lets a routed turn carry a
-provider-specific body param such as ``{"think": false}`` for a local ollama
-cheap tier; without it a thinking model returns an empty completion under a
-modest ``max_tokens``. ``turn_context`` extracts
-the first well-formed override and applies it right after the hook fires, before
-the turn's first API call assembles.
+reverted with the rest of the override. That is what lets a routed turn carry
+provider-specific BODY params for the cheap tier (e.g. ollama
+``{"options": {"num_ctx": N}}``, or an aggregator's ``provider`` preferences).
+
+⚠️ The OpenAI SDK merges ``extra_body`` into the JSON body LAST, so a key here
+silently OVERRIDES a same-named TYPED parameter the transport already emitted —
+measured, not assumed (see
+``tests/plugins/intelligent_routing/test_cheap_extra_body_wire_semantics.py``).
+Do NOT use it to disable thinking on a local tier: ``think: false`` is ignored
+by ollama's OpenAI-compat ``/v1`` endpoint (ollama#14820), and the switch that
+does work (``reasoning_effort``) is already resolved PER-MODEL by
+``switch_model`` from ``agent.reasoning_overrides``.
+
+``turn_context`` extracts the first well-formed override and applies it right
+after the hook fires, before the turn's first API call assembles.
 
 ── Turn-scoping (the load-bearing detail) ──
 Proactive routing is a PER-TURN decision, exactly like reactive fallback — it
@@ -181,7 +190,10 @@ def apply_routing_override(agent: Any, override: Optional[dict]) -> bool:
     # Mark the override turn-scoped with a DEDICATED flag. Do NOT restore the
     # premium snapshot into _primary_runtime (keep it == cheap) and do NOT arm
     # _fallback_activated (that would corrupt reactive cooldown accounting).
-    # Turn-scoped request-body params (e.g. {"think": false} for a local tier).
+    # Turn-scoped request-body params (e.g. {"options": {"num_ctx": N}} for a
+    # local tier). The SDK merges these into the JSON body LAST, so they
+    # override same-named typed params. Thinking control does NOT belong here —
+    # use agent.reasoning_overrides (see the module docstring).
     # Merged over any existing extra_body so custom-provider params survive; the
     # prior value is stashed for restore_primary_runtime to revert next turn.
     # Best-effort: a malformed extra_body must not undo an applied swap.

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -504,9 +504,20 @@ class ChatCompletionsTransport(ProviderTransport):
         # Request overrides last (service_tier etc.). extra_body is MERGED, not
         # replaced — same semantics as the provider-profile path below. A plain
         # update() here dropped everything assembled above (provider prefs,
-        # reasoning config) the moment a caller passed its own extra_body, e.g.
-        # a routed turn carrying routing.cheap_extra_body onto an unregistered
-        # provider. A non-dict value keeps the old last-write-wins behaviour.
+        # reasoning config) the moment a caller passed its own extra_body.
+        #
+        # Two callers reach this with request_overrides["extra_body"], and the
+        # second one is NOT routing-only:
+        #   1. a routed turn carrying routing.cheap_extra_body (agent/
+        #      routing_override.py) onto a provider with no registered profile;
+        #   2. agent_init._merge_custom_provider_extra_body, which writes
+        #      request_overrides["extra_body"] at AGENT INIT for any
+        #      `provider: custom:<key>` agent — so for those agents this merge
+        #      is on EVERY turn, routed or not.
+        #
+        # The merge is SHALLOW (one level): a colliding nested dict is replaced
+        # wholesale, not merged into. See TestNestedCollisionIsShallow.
+        # A non-dict value keeps the old last-write-wins behaviour.
         overrides = params.get("request_overrides")
         if overrides:
             for k, v in overrides.items():
@@ -628,7 +639,10 @@ class ChatCompletionsTransport(ProviderTransport):
         if additions:
             extra_body.update(additions)
 
-        # Request overrides (user config)
+        # Request overrides (user config). extra_body merges SHALLOW (one
+        # level), same as the legacy path above. A non-dict value lands
+        # top-level here and is then overwritten below whenever the profile
+        # assembled anything — the one place the two paths do NOT agree.
         overrides = params.get("request_overrides")
         if overrides:
             for k, v in overrides.items():

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -501,10 +501,23 @@ class ChatCompletionsTransport(ProviderTransport):
         if extra_body:
             api_kwargs["extra_body"] = extra_body
 
-        # Request overrides last (service_tier etc.)
+        # Request overrides last (service_tier etc.). extra_body is MERGED, not
+        # replaced — same semantics as the provider-profile path below. A plain
+        # update() here dropped everything assembled above (provider prefs,
+        # reasoning config) the moment a caller passed its own extra_body, e.g.
+        # a routed turn carrying routing.cheap_extra_body onto an unregistered
+        # provider. A non-dict value keeps the old last-write-wins behaviour.
         overrides = params.get("request_overrides")
         if overrides:
-            api_kwargs.update(overrides)
+            for k, v in overrides.items():
+                if k == "extra_body" and isinstance(v, dict):
+                    merged = api_kwargs.get("extra_body")
+                    if isinstance(merged, dict):
+                        merged.update(v)
+                    else:
+                        api_kwargs["extra_body"] = dict(v)
+                else:
+                    api_kwargs[k] = v
 
         return api_kwargs
 

--- a/plugins/intelligent_routing/README.md
+++ b/plugins/intelligent_routing/README.md
@@ -39,6 +39,40 @@ routing:
 
 Enabled but `routing.intelligent` OFF ⇒ the hook is inert (`None`, zero change).
 
+### Pointing the cheap tier at a LOCAL model
+
+A local cheap tier needs one extra thing: thinking OFF. A thinking-capable
+model on a modest `max_tokens` spends the whole budget reasoning and returns an
+**empty string** (measured, qwen3.5:9b at `max_tokens: 200` → 200 completion
+tokens, empty content, `finish_reason: length`).
+
+Do it with the per-model reasoning config, **not** with `cheap_extra_body`:
+
+```yaml
+routing:
+  intelligent: true
+  cheap_model: "qwen3.5:9b"
+  cheap_provider: custom            # aliases: ollama, local, vllm, llamacpp
+
+agent:
+  reasoning_overrides:
+    "qwen3.5:9b": none              # → reasoning_effort: "none" on the wire
+```
+
+`switch_model` re-resolves `reasoning_config` against the **routed** model, so
+the override applies to the cheap turn even though the primary is a different
+model. With it: 2 completion tokens and the right answer.
+
+⚠️ On ollama's OpenAI-compatible `/v1/chat/completions`, `think: false`,
+`chat_template_kwargs` and an in-prompt `/no_think` all do **nothing**
+(ollama#14820). `reasoning_effort: "none"` is the only switch that works.
+
+`routing.cheap_extra_body` is for genuinely provider-specific **body** params
+on a routed turn — ollama `{"options": {"num_ctx": 8192}}`, an aggregator's
+`provider` preferences. It is empty by default. Note the OpenAI SDK merges
+`extra_body` into the request body *last*, so anything set there **overrides** a
+same-named typed parameter the transport already emitted.
+
 ## How a turn flows
 
 ```

--- a/plugins/intelligent_routing/README.md
+++ b/plugins/intelligent_routing/README.md
@@ -73,6 +73,11 @@ on a routed turn — ollama `{"options": {"num_ctx": 8192}}`, an aggregator's
 `extra_body` into the request body *last*, so anything set there **overrides** a
 same-named typed parameter the transport already emitted.
 
+The transport merges your keys into the `extra_body` it assembled, but the
+merge is **shallow** (one level): a nested dict you set replaces the assembled
+one wholesale rather than merging into it. `{"reasoning": {"effort": "none"}}`
+therefore drops the assembled `enabled` key — write nested values out in full.
+
 ## How a turn flows
 
 ```

--- a/plugins/intelligent_routing/config.py
+++ b/plugins/intelligent_routing/config.py
@@ -34,12 +34,28 @@ _DEFAULT_MODE = "heuristic"
 _DEFAULT_CHEAP_MODEL = "deepseek/deepseek-v3.2"
 _DEFAULT_CHEAP_PROVIDER = "openrouter"
 
-# Provider-specific request-body params to send WITH a cheap-routed turn, e.g.
-# ``{"think": false}`` for a local ollama tier. Without this a thinking model on
-# an OpenAI-compatible endpoint burns its whole token budget on reasoning and
-# returns an EMPTY completion under any modest max_tokens — measured on
-# qwen3.5:9b: 8 tokens with think=false vs 1807 with it on, same answer, and
-# empty output at max_tokens=200. Empty by default: changes nothing unless set.
+# Provider-specific request-BODY params to send WITH a cheap-routed turn — e.g.
+# ollama ``{"options": {"num_ctx": 8192}}``, or an aggregator's ``provider``
+# preferences. Empty by default: changes nothing unless set.
+#
+# NOT the place to disable thinking. Measured against ollama's OpenAI-compat
+# /v1 endpoint (2026-08-26): ``think: false``, ``chat_template_kwargs`` and an
+# in-prompt ``/no_think`` all do NOTHING (ollama#14820). The only switch that
+# works is the first-class ``reasoning_effort: "none"``, and the supported way
+# to set it for a routed model is per-model config:
+#
+#     agent:
+#       reasoning_overrides:
+#         "qwen3.5:9b": none
+#
+# ``switch_model`` re-resolves reasoning_config against the ROUTED model, and
+# the custom/ollama provider profile then emits ``reasoning_effort: "none"``.
+# Without it a thinking model burns its whole budget and returns an EMPTY
+# completion — measured on qwen3.5:9b at max_tokens=200: 200 completion tokens,
+# empty content, finish_reason=length; with it, 2 tokens and the right answer.
+#
+# NOTE: anything set here is merged into the JSON body LAST by the OpenAI SDK,
+# so it OVERRIDES a same-named typed parameter the transport emitted.
 _DEFAULT_CHEAP_EXTRA_BODY: Dict[str, Any] = {}
 
 

--- a/plugins/intelligent_routing/registration.py
+++ b/plugins/intelligent_routing/registration.py
@@ -253,8 +253,10 @@ def on_pre_llm_call(**kwargs: Any) -> Optional[dict]:
             if cheap_model:
                 route = {"model": cheap_model, "provider": cheap_provider}
                 # Provider-specific body params for the cheap tier (e.g.
-                # {"think": false} on a local ollama model). Omitted entirely
-                # when unset, so nothing changes for existing cloud tiers.
+                # {"options": {"num_ctx": N}} on a local ollama model). Omitted
+                # entirely when unset, so nothing changes for existing cloud
+                # tiers. Thinking control is NOT set here — see
+                # config.cheap_extra_body for why and what to use instead.
                 extra_body = cheap_extra_body()
                 if extra_body:
                     route["extra_body"] = extra_body

--- a/tests/agent/transports/test_request_overrides_extra_body_merge.py
+++ b/tests/agent/transports/test_request_overrides_extra_body_merge.py
@@ -8,7 +8,14 @@ used ``api_kwargs.update(overrides)``, which REPLACED the assembled extra_body
 wholesale — so a cheap tier pointed at an unregistered provider silently lost
 its provider preferences and reasoning config.
 
-Both paths must agree: routed keys win on collision, everything else survives.
+Both paths agree for DICT values: overriding keys win on collision, everything
+else survives, and the merge is SHALLOW — a colliding nested dict is replaced
+wholesale, not merged into.
+
+They do NOT agree for non-dict values, and that divergence is pinned below
+rather than papered over: the legacy path forwards the raw value verbatim,
+while the profile path assigns it top-level and then discards it whenever the
+profile assembled an extra_body of its own.
 """
 
 import pytest
@@ -100,11 +107,55 @@ class TestLegacyPathMerges:
             request_overrides={"extra_body": ROUTED_EXTRA_BODY},
         )
         assert kw["extra_body"] == ROUTED_EXTRA_BODY
+        # Defensive copy, not the caller's dict. Callers pass
+        # agent.request_overrides BY REFERENCE (chat_completion_helpers.py),
+        # and downstream mutators recurse into api_kwargs in place
+        # (conversation_loop._sanitize_structure_non_ascii) — aliasing here
+        # would permanently corrupt the agent's persistent overrides.
+        assert kw["extra_body"] is not ROUTED_EXTRA_BODY
+
+    def test_returned_kwargs_mutation_cannot_reach_the_callers_overrides(
+        self, transport
+    ):
+        overrides = {"extra_body": {"tag": "cafe"}}
+        kw = transport.build_kwargs(
+            model="qwen3.5:9b", messages=MSGS, request_overrides=overrides
+        )
+        kw["extra_body"]["tag"] = "MUTATED"
+        assert overrides["extra_body"] == {"tag": "cafe"}
 
     def test_non_dict_extra_body_override_is_passed_through_verbatim(self, transport):
         """Malformed value: keep the old last-write-wins behaviour, don't crash."""
         kw = _legacy_kwargs(transport, request_overrides={"extra_body": "nope"})
         assert kw["extra_body"] == "nope"
+
+
+class TestNestedCollisionIsShallow:
+    """A colliding nested dict is REPLACED, not deep-merged. Pinned, not fixed.
+
+    ``reasoning`` is the live case: the transport assembles the two-key
+    ``{"enabled": True, "effort": ...}``, so an override of ``{"effort": "none"}``
+    drops ``enabled``. That is deliberate last-write-wins — an override the
+    caller wrote out in full should reach the wire in full, and a deep merge
+    would make removing an assembled sub-key impossible. Documented in the
+    README recipe and in the transport comment; asserted here so a change to
+    either semantics is a visible test failure, not a silent one.
+    """
+
+    def test_legacy_nested_dict_is_replaced_wholesale(self, transport):
+        eb = _legacy_kwargs(
+            transport,
+            request_overrides={"extra_body": {"reasoning": {"effort": "none"}}},
+        )["extra_body"]
+        assert eb["reasoning"] == {"effort": "none"}   # "enabled" is gone
+        assert eb["provider"] == PREFS                 # siblings survive
+
+    def test_profile_nested_dict_is_replaced_wholesale(self, transport):
+        eb = _profile_kwargs(
+            transport,
+            request_overrides={"extra_body": {"provider": {"order": ["x"]}}},
+        )["extra_body"]
+        assert eb["provider"] == {"order": ["x"]}      # "sort" is gone
 
 
 class TestProfilePathParity:
@@ -127,3 +178,40 @@ class TestProfilePathParity:
         for eb in (legacy, profile):
             assert eb["provider"] == PREFS
             assert eb["reasoning_effort"] == "none"
+
+    def test_non_dict_override_diverges_and_the_profile_path_discards_it(
+        self, transport
+    ):
+        """The one input where the two paths do NOT agree. Pinned, not fixed.
+
+        Neither behaviour is defensible for a malformed value, but the plugin
+        cannot emit one (config.py coerces non-dicts to {}; routing_override
+        ignores them), so only a hand-written agent.request_overrides reaches
+        here. Pin it so a future change to either path is visible.
+        """
+        legacy = _legacy_kwargs(
+            transport, request_overrides={"extra_body": "nope"}
+        )["extra_body"]
+        assert legacy == "nope"
+
+        profile = _profile_kwargs(
+            transport, request_overrides={"extra_body": "nope"}
+        )["extra_body"]
+        # Assigned top-level, then overwritten by the profile's assembled dict.
+        assert isinstance(profile, dict)
+        assert profile["provider"] == PREFS
+
+    def test_profile_path_keeps_a_non_dict_when_it_assembled_nothing(
+        self, transport
+    ):
+        """The overwrite is conditional: nothing assembled ⇒ the value survives."""
+        from providers import get_provider_profile
+
+        kw = transport.build_kwargs(
+            model="deepseek/deepseek-v3.2",
+            messages=MSGS,
+            provider_profile=get_provider_profile("openrouter"),
+            provider_name="openrouter",
+            request_overrides={"extra_body": "nope"},
+        )
+        assert kw["extra_body"] == "nope"

--- a/tests/agent/transports/test_request_overrides_extra_body_merge.py
+++ b/tests/agent/transports/test_request_overrides_extra_body_merge.py
@@ -1,0 +1,129 @@
+"""``request_overrides["extra_body"]`` must MERGE on both transport paths.
+
+The intelligent_routing plugin ships ``routing.cheap_extra_body`` into
+``agent.request_overrides["extra_body"]`` for a routed turn (see
+``agent/routing_override.py``). The provider-profile path merges that dict into
+the extra_body the transport already assembled; the legacy (no-profile) path
+used ``api_kwargs.update(overrides)``, which REPLACED the assembled extra_body
+wholesale — so a cheap tier pointed at an unregistered provider silently lost
+its provider preferences and reasoning config.
+
+Both paths must agree: routed keys win on collision, everything else survives.
+"""
+
+import pytest
+
+from agent.transports import get_transport
+
+
+@pytest.fixture
+def transport():
+    import agent.transports.chat_completions  # noqa: F401
+    return get_transport("chat_completions")
+
+
+MSGS = [{"role": "user", "content": "Hi"}]
+PREFS = {"sort": "throughput"}
+ROUTED_EXTRA_BODY = {"reasoning_effort": "none"}
+
+
+def _legacy_kwargs(transport, **extra):
+    """Legacy path: no provider_profile (custom / unregistered provider)."""
+    return transport.build_kwargs(
+        model="qwen3.5:9b",
+        messages=MSGS,
+        is_openrouter=True,
+        provider_preferences=PREFS,
+        supports_reasoning=True,
+        reasoning_config={"enabled": True, "effort": "medium"},
+        **extra,
+    )
+
+
+def _profile_kwargs(transport, **extra):
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("openrouter")
+    return transport.build_kwargs(
+        model="deepseek/deepseek-v3.2",
+        messages=MSGS,
+        provider_profile=profile,
+        provider_name="openrouter",
+        base_url=profile.base_url,
+        provider_preferences=PREFS,
+        supports_reasoning=True,
+        reasoning_config={"enabled": True, "effort": "medium"},
+        **extra,
+    )
+
+
+class TestLegacyPathMerges:
+
+    def test_baseline_assembles_provider_and_reasoning(self, transport):
+        eb = _legacy_kwargs(transport)["extra_body"]
+        assert eb["provider"] == PREFS
+        assert eb["reasoning"] == {"enabled": True, "effort": "medium"}
+
+    def test_routed_extra_body_does_not_destroy_assembled_keys(self, transport):
+        eb = _legacy_kwargs(
+            transport, request_overrides={"extra_body": ROUTED_EXTRA_BODY}
+        )["extra_body"]
+
+        # The regression: these two used to vanish entirely.
+        assert eb["provider"] == PREFS
+        assert eb["reasoning"] == {"enabled": True, "effort": "medium"}
+        assert eb["reasoning_effort"] == "none"
+
+    def test_routed_value_wins_on_collision(self, transport):
+        eb = _legacy_kwargs(
+            transport,
+            request_overrides={"extra_body": {"provider": {"sort": "price"}}},
+        )["extra_body"]
+        assert eb["provider"] == {"sort": "price"}
+        assert eb["reasoning"] == {"enabled": True, "effort": "medium"}
+
+    def test_non_extra_body_overrides_still_land_top_level(self, transport):
+        kw = _legacy_kwargs(
+            transport,
+            request_overrides={
+                "service_tier": "priority",
+                "extra_body": ROUTED_EXTRA_BODY,
+            },
+        )
+        assert kw["service_tier"] == "priority"
+        assert kw["extra_body"]["provider"] == PREFS
+
+    def test_extra_body_only_from_overrides_when_nothing_assembled(self, transport):
+        kw = transport.build_kwargs(
+            model="qwen3.5:9b",
+            messages=MSGS,
+            request_overrides={"extra_body": ROUTED_EXTRA_BODY},
+        )
+        assert kw["extra_body"] == ROUTED_EXTRA_BODY
+
+    def test_non_dict_extra_body_override_is_passed_through_verbatim(self, transport):
+        """Malformed value: keep the old last-write-wins behaviour, don't crash."""
+        kw = _legacy_kwargs(transport, request_overrides={"extra_body": "nope"})
+        assert kw["extra_body"] == "nope"
+
+
+class TestProfilePathParity:
+
+    def test_profile_path_merges_the_same_way(self, transport):
+        eb = _profile_kwargs(
+            transport, request_overrides={"extra_body": ROUTED_EXTRA_BODY}
+        )["extra_body"]
+        assert eb["provider"] == PREFS
+        assert eb["reasoning_effort"] == "none"
+        assert "reasoning" in eb
+
+    def test_both_paths_preserve_assembled_keys(self, transport):
+        legacy = _legacy_kwargs(
+            transport, request_overrides={"extra_body": ROUTED_EXTRA_BODY}
+        )["extra_body"]
+        profile = _profile_kwargs(
+            transport, request_overrides={"extra_body": ROUTED_EXTRA_BODY}
+        )["extra_body"]
+        for eb in (legacy, profile):
+            assert eb["provider"] == PREFS
+            assert eb["reasoning_effort"] == "none"

--- a/tests/plugins/intelligent_routing/test_cheap_extra_body_wire_semantics.py
+++ b/tests/plugins/intelligent_routing/test_cheap_extra_body_wire_semantics.py
@@ -1,0 +1,177 @@
+"""What ``routing.cheap_extra_body`` actually does on the wire.
+
+PR #163 shipped the passthrough justified by ``{"think": false}`` for a local
+ollama cheap tier. That justification is wrong: ollama's OpenAI-compatible
+``/v1/chat/completions`` ignores ``think``, ``chat_template_kwargs`` and an
+in-prompt ``/no_think`` (ollama#14820). The only switch that stops a thinking
+model is the first-class ``reasoning_effort: "none"``.
+
+The mechanism still works, for a reason nobody wrote down: the OpenAI SDK
+merges ``extra_body`` into the JSON body LAST, so a key there OVERRIDES a
+same-named TYPED parameter the transport already emitted — one key on the wire,
+the extra_body value winning. Every doc site now says so; these tests are what
+stops that from silently regressing.
+
+Measured against real ollama (qwen3.5:9b, max_tokens=200) on the Mini
+2026-08-26: thinking on → 200 completion tokens, EMPTY content,
+finish_reason=length. reasoning_effort="none" → 2 tokens, "OK", stop.
+The SDK-merge assertions below reproduce the same request hermetically.
+"""
+import json
+
+import httpx
+import pytest
+from openai import OpenAI
+
+from agent.routing_override import apply_routing_override
+from agent.transports import get_transport
+
+
+ROUTED_NONE = {"reasoning_effort": "none"}
+
+
+@pytest.fixture
+def transport():
+    import agent.transports.chat_completions  # noqa: F401
+    return get_transport("chat_completions")
+
+
+class _FakeAgent:
+    """Minimal stand-in for the runtime surface apply_routing_override touches."""
+
+    def __init__(self):
+        self.model = "z-ai/glm-5.3"
+        self.provider = "openrouter"
+        self.request_overrides = {}
+        self._primary_runtime = {"model": self.model, "provider": self.provider}
+
+    def switch_model(self, model, provider, **kw):
+        self.model, self.provider = model, provider
+
+
+def _capture_wire_body(**create_kwargs) -> dict:
+    """Fire one chat.completions.create through a mock transport, return the body."""
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["raw"] = request.content.decode()
+        return httpx.Response(200, json={
+            "id": "x", "object": "chat.completion", "created": 0, "model": "m",
+            "choices": [{"index": 0,
+                         "message": {"role": "assistant", "content": "OK"},
+                         "finish_reason": "stop"}],
+        })
+
+    client = OpenAI(
+        api_key="test",
+        base_url="http://local.test/v1",
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+    client.chat.completions.create(**create_kwargs)
+    seen["parsed"] = json.loads(seen["raw"])
+    return seen
+
+
+def test_extra_body_overrides_a_same_named_typed_param():
+    """The load-bearing fact: extra_body is merged LAST and wins."""
+    seen = _capture_wire_body(
+        model="qwen3.5:9b",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=200,
+        reasoning_effort="medium",          # typed SDK param
+        extra_body=dict(ROUTED_NONE),       # routed cheap-tier body params
+    )
+    assert seen["parsed"]["reasoning_effort"] == "none"
+    # Exactly ONE key on the wire — not a duplicate, not a dropped param.
+    assert seen["raw"].count('"reasoning_effort"') == 1
+
+
+def test_extra_body_key_without_a_typed_twin_is_simply_added():
+    seen = _capture_wire_body(
+        model="qwen3.5:9b",
+        messages=[{"role": "user", "content": "hi"}],
+        extra_body={"options": {"num_ctx": 8192}},
+    )
+    assert seen["parsed"]["options"] == {"num_ctx": 8192}
+
+
+def test_routed_turn_carries_reasoning_effort_none_end_to_end(transport):
+    """cheap_extra_body → request_overrides → transport kwargs → wire body."""
+    from providers import get_provider_profile
+
+    agent = _FakeAgent()
+    assert apply_routing_override(agent, {
+        "model": "qwen3.5:9b", "provider": "ollama", "extra_body": dict(ROUTED_NONE),
+    }) is True
+    assert agent.request_overrides["extra_body"] == ROUTED_NONE
+
+    profile = get_provider_profile("ollama")
+    kwargs = transport.build_kwargs(
+        model="qwen3.5:9b",
+        messages=[{"role": "user", "content": "hi"}],
+        provider_profile=profile,
+        provider_name="ollama",
+        base_url="http://local.test/v1",
+        supports_reasoning=True,
+        reasoning_config={"enabled": True, "effort": "medium"},
+        request_overrides=agent.request_overrides,
+        max_tokens=200,
+    )
+    # The transport still emits the profile's typed param; the routed value
+    # rides in extra_body and only wins at SDK body-assembly time.
+    assert kwargs["reasoning_effort"] == "medium"
+    assert kwargs["extra_body"]["reasoning_effort"] == "none"
+
+    kwargs.pop("timeout", None)
+    seen = _capture_wire_body(**kwargs)
+    assert seen["parsed"]["reasoning_effort"] == "none"
+    assert seen["raw"].count('"reasoning_effort"') == 1
+
+
+def test_reasoning_overrides_is_the_supported_route_to_the_same_wire_shape(transport):
+    """The first-class mechanism: per-model reasoning config, no extra_body hack.
+
+    ``switch_model`` re-resolves ``reasoning_config`` against the ROUTED model
+    (agent_runtime_helpers.resolve_reasoning_config), so
+    ``agent.reasoning_overrides: {"qwen3.5:9b": none}`` reaches the transport as
+    a disabled reasoning_config — and the custom/ollama profile emits both the
+    working switch and ollama's native flag.
+    """
+    from providers import get_provider_profile
+
+    kwargs = transport.build_kwargs(
+        model="qwen3.5:9b",
+        messages=[{"role": "user", "content": "hi"}],
+        provider_profile=get_provider_profile("ollama"),
+        provider_name="ollama",
+        base_url="http://local.test/v1",
+        supports_reasoning=True,
+        reasoning_config={"enabled": False},
+        max_tokens=200,
+    )
+    assert kwargs["reasoning_effort"] == "none"
+    assert kwargs["extra_body"]["think"] is False   # inert on /v1, kept for /api/chat
+
+    kwargs.pop("timeout", None)
+    seen = _capture_wire_body(**kwargs)
+    assert seen["parsed"]["reasoning_effort"] == "none"
+
+
+def test_documented_reasoning_overrides_recipe_resolves_for_the_routed_model():
+    """The README recipe must actually parse — `"qwen3.5:9b": none` → disabled.
+
+    YAML gives a bare ``none`` as the STRING "none" (null is ``null``/``~``), and
+    parse_reasoning_effort maps none/false/disabled → {"enabled": False}.
+    """
+    from hermes_constants import resolve_reasoning_config
+
+    cfg = {
+        "model": {"default": "z-ai/glm-5.3"},
+        "agent": {"reasoning_overrides": {"qwen3.5:9b": "none"}},
+    }
+    # Resolved against the ROUTED model, which is what switch_model passes
+    # (agent/agent_runtime_helpers.py: agent.reasoning_config =
+    #  resolve_reasoning_config(_reasoning_cfg, agent.model)).
+    assert resolve_reasoning_config(cfg, "qwen3.5:9b") == {"enabled": False}
+    # The premium primary is untouched by the cheap tier's override.
+    assert resolve_reasoning_config(cfg, "z-ai/glm-5.3") != {"enabled": False}

--- a/tests/plugins/intelligent_routing/test_cheap_extra_body_wire_semantics.py
+++ b/tests/plugins/intelligent_routing/test_cheap_extra_body_wire_semantics.py
@@ -157,18 +157,41 @@ def test_reasoning_overrides_is_the_supported_route_to_the_same_wire_shape(trans
     assert seen["parsed"]["reasoning_effort"] == "none"
 
 
+# Verbatim from plugins/intelligent_routing/README.md, "Pointing the cheap
+# tier at a LOCAL model". Parsed here by the loader the runtime actually uses,
+# so the recipe is proved end to end rather than asserted in prose.
+README_RECIPE = """
+model:
+  default: "z-ai/glm-5.3"
+
+routing:
+  intelligent: true
+  cheap_model: "qwen3.5:9b"
+  cheap_provider: custom
+
+agent:
+  reasoning_overrides:
+    "qwen3.5:9b": none
+"""
+
+
 def test_documented_reasoning_overrides_recipe_resolves_for_the_routed_model():
     """The README recipe must actually parse — `"qwen3.5:9b": none` → disabled.
 
-    YAML gives a bare ``none`` as the STRING "none" (null is ``null``/``~``), and
-    parse_reasoning_effort maps none/false/disabled → {"enabled": False}.
+    The YAML hop is load-bearing, not incidental. A bare ``none`` parses as the
+    STRING "none" (YAML null is ``null``/``~``/empty), and parse_reasoning_effort
+    maps none/false/disabled → {"enabled": False}. Had it parsed as a Python
+    ``None``, resolve_reasoning_config would return None — NO override at all —
+    and the documented recipe would silently no-op, leaving the cheap model
+    burning its whole max_tokens budget on reasoning. So parse it for real.
     """
     from hermes_constants import resolve_reasoning_config
+    from utils import fast_safe_load
 
-    cfg = {
-        "model": {"default": "z-ai/glm-5.3"},
-        "agent": {"reasoning_overrides": {"qwen3.5:9b": "none"}},
-    }
+    cfg = fast_safe_load(README_RECIPE)
+    assert cfg["agent"]["reasoning_overrides"]["qwen3.5:9b"] == "none", (
+        "bare `none` must parse as the STRING 'none', not YAML null"
+    )
     # Resolved against the ROUTED model, which is what switch_model passes
     # (agent/agent_runtime_helpers.py: agent.reasoning_config =
     #  resolve_reasoning_config(_reasoning_cfg, agent.model)).

--- a/tests/plugins/intelligent_routing/test_extra_body_and_metrics.py
+++ b/tests/plugins/intelligent_routing/test_extra_body_and_metrics.py
@@ -4,10 +4,16 @@ Two gaps this closes:
 
 1. **extra_body** — `routing_override` forwarded only base_url/api_key/api_mode,
    so there was no way to send a provider-specific body param with a routed
-   turn. That blocks a LOCAL cheap tier: ollama's OpenAI-compatible endpoint
-   leaves thinking ON by default, so a mechanical turn on qwen3.5:9b burns
-   ~1800 reasoning tokens for an 8-token answer, and returns an EMPTY string
-   under any modest max_tokens. Measured on the Mini 2026-08-26.
+   turn (ollama `options.num_ctx`, an aggregator's `provider` preferences).
+
+   ⚠️ CORRECTION: this file originally justified the passthrough as the way to
+   send `{"think": false}` to a local ollama tier. That was never measured and
+   is wrong — ollama's OpenAI-compat /v1 endpoint ignores `think` entirely
+   (ollama#14820). Thinking is disabled per-model via `agent.reasoning_overrides`,
+   which `switch_model` re-resolves for the ROUTED model. See
+   `test_cheap_extra_body_wire_semantics.py` for the measured behaviour.
+   The `{"think": ...}` literals below are just opaque body dicts exercising the
+   plumbing; they are NOT a working recipe for disabling thinking.
 
 2. **metrics** — the plugin emitted no per-turn decision record, which is the
    stated blocker on the upstream PR (spec 2026-07-23: "Routing decisions must


### PR DESCRIPTION
## What

- Corrects every doc site that justified `routing.cheap_extra_body` with `{"think": false}` — `agent/routing_override.py` (module docstring + the inline comment at the apply site), `plugins/intelligent_routing/config.py`, `plugins/intelligent_routing/registration.py`, and the `test_extra_body_and_metrics.py` module docstring. (`plugin.yaml` never made the claim, so it is untouched.)
- Documents the supported way to run a **local** cheap tier in `plugins/intelligent_routing/README.md`: `agent.reasoning_overrides: {"<cheap model>": none}`. No new config key, no new code path.
- Adds `tests/plugins/intelligent_routing/test_cheap_extra_body_wire_semantics.py` — proves, hermetically, the SDK behaviour PR #163's mechanism actually depends on, so it cannot silently regress.
- Fixes a latent bug in `agent/transports/chat_completions.py`: the legacy (no provider-profile) path **replaced** the assembled `extra_body` with `request_overrides["extra_body"]` instead of merging it. Covered by `tests/agent/transports/test_request_overrides_extra_body_merge.py` (written red, then fixed).

## Why

PR #163 shipped the `extra_body` passthrough on a justification that was never measured and is wrong. On ollama's OpenAI-compatible `/v1/chat/completions`, `think: false` does nothing — and neither do `chat_template_kwargs` or an in-prompt `/no_think` (ollama#14820). The only switch that stops a thinking model is the first-class `reasoning_effort: "none"`.

The merged code still works, for a reason nobody wrote down: the OpenAI SDK merges `extra_body` into the JSON body **last**, so a key there silently overrides a same-named **typed** parameter the transport already emitted. That is the load-bearing fact, and it was missing from all four comment sites. A comment that asserts an invariant it does not have is how the next person configures a dead flag and concludes the feature is broken.

The framework already has the correct, first-class, per-model mechanism. `switch_model` re-resolves `reasoning_config` against the **routed** model (`agent/agent_runtime_helpers.py`, `resolve_reasoning_config`), and the `custom`/ollama provider profile then emits top-level `reasoning_effort: "none"` plus ollama's native `think: false` for `/api/chat`. So this PR ships zero new design: it demotes `cheap_extra_body` in the docs to what `extra_body` actually means (`options.num_ctx`, aggregator `provider` preferences) and points thinking control at `reasoning_overrides`.

## Verification

Measured against **real ollama** through the real transport and the real `custom`/ollama provider profile, inside `hermes-personal` on the Mini (qwen3.5:9b via `host.docker.internal:11434`, `max_tokens=200`, httpx event hook capturing the literal request body):

| scenario | wire `reasoning_effort` | completion tokens | content |
|---|---|---|---|
| control (no override) | `medium` | 200 | `""` (finish_reason `length`) |
| `cheap_extra_body` (PR #163 as merged) | `none` — one key, extra_body won | 2 | `OK` |
| `reasoning_overrides` (recommended) | `none` + `think: false` | 2 | `OK` |

The SDK merge-order fact is re-proved hermetically in CI via `httpx.MockTransport` (no network), including the assertion that `reasoning_effort` appears exactly **once** in the request body.

Test runs (`python -m pytest … -q -p no:randomly`):
- `tests/plugins/intelligent_routing/ tests/agent/transports/` — **528 passed** (post-audit)
- `tests/plugins/intelligent_routing/` — **131 passed**
- `tests/agent/transports/ tests/agent/test_custom_provider_extra_body.py tests/providers/` — **517 passed**
- `tests/test_ctx_halving_fix.py tests/cli/test_fast_command.py tests/run_agent/test_provider_parity.py tests/providers/test_profile_wiring.py tests/providers/test_e2e_wiring.py tests/tools/test_delegate.py` — **345 passed**
- `tests/agent/` — **125 failed / 6001 passed**, identical failure count to `origin/main` stashed baseline (**125 failed / 5993 passed**); the +8 passes are the new transport tests. Those 125 are pre-existing suite-pollution failures that also reproduce on clean main and pass in isolation.

The legacy-path fix was written red first: 4 of the 8 new transport tests failed before the change (`KeyError: 'provider'` — the assembled provider preferences and reasoning config were gone), all 8 pass after.

## Risk

Low, and the blast radius of the doc half is nil: swept every `~/.hermes*/config.yaml` on the Mini read-only — **no live agent sets `cheap_extra_body`**, and all 7 routing-enabled agents point their cheap tier at a cloud model (`deepseek/deepseek-v4-flash-0731` via OpenRouter). No agent has a local/ollama cheap tier, so the shipped feature is currently unexercised in the fleet.

The one behaviour change is the legacy-path `extra_body` merge. Today's behaviour there is data loss, so the direction is not in question — but the **trigger is not routing-only**, and an earlier draft of this section said it was. Two callers reach it:

1. a routed turn carrying `routing.cheap_extra_body` onto a provider with no registered profile (currently unexercised — no live agent sets `cheap_extra_body`);
2. `agent_init._merge_custom_provider_extra_body`, which writes `request_overrides["extra_body"]` **at agent init** for any `provider: custom:<key>` agent. For those agents this merge runs on **every turn**, routed or not.

Case 2 is the real blast radius, and it is narrow: the merge only changes the wire body when the agent is `provider: custom:<key>` **and** its `base_url` is one the legacy assembly recognises (openrouter, nousresearch.com, ollama.com, Kimi, LM Studio), or a caller passes `extra_body_additions`. Verified directly: `custom:myllm` at a bespoke `https://llm.internal/v1` produces a byte-identical body before and after. `custom:myllm` at OpenRouter with provider preferences gains the assembled `provider` and `reasoning` keys it was previously dropping — which is the fix working.

**Outstanding pre-merge check:** the fleet sweep in this PR looked for `cheap_extra_body`, which is the wrong key for case 2. Someone with Mini access should sweep `~/.hermes*/config.yaml` for `custom_providers:` entries / `provider: custom:<key>` agents before merge. Not done here (this session was scoped away from the Mini).

Merge depth is **shallow** (one level), on both paths: a colliding nested dict is replaced wholesale, not merged into. `reasoning` is the live case — an override of `{"effort": "none"}` drops the assembled `enabled`. That is deliberate last-write-wins and is now pinned by tests and stated in the README and the transport comments.

Non-dict `extra_body` override values keep the old last-write-wins behaviour on the legacy path; the profile path assigns them top-level and then discards them whenever it assembled an extra_body of its own. The two paths genuinely disagree there. The plugin cannot emit a non-dict (`config.py` coerces to `{}`), so only a hand-written `agent.request_overrides` reaches it; the divergence is pinned by tests rather than silently "fixed" to one arbitrary side. Non-`extra_body` override keys (`service_tier`, …) still land top-level unchanged.

The legacy path has no native-Gemini unknown-key scrub (the profile path does). This does not create a new hard-400: with a native Gemini `base_url` and a `custom:<key>` provider the legacy assembly produces an empty extra_body, so there is nothing for the missing scrub to act on. Checked, not assumed.

**Do not merge on my say-so** — org rule is an independent audit before merge. This PR corrects a merged PR whose own justification did not survive measurement, which is exactly the case for a second pair of eyes.

## Links

- Corrects: #163
- ollama#14820 — `think` ignored on the OpenAI-compat `/v1` endpoint


## Audit follow-up (63edd47c25)

Retitled from `docs(routing):` to `fix(agent):`. The original type was wrong:
this diff changes `agent/transports/chat_completions.py::build_kwargs`, the
shared path every provider call goes through. No `docs(` commit in this repo
has ever carried a behaviour change, and `routing` names the plugin, not the
transport. (No CI gate was skipped — `.github/workflows/` has no `paths-ignore`
and no semantic-title lint — but the git history record was wrong.)

Also landed, all documentation/test-accuracy, no runtime change:

- Corrected the Risk section and the transport comment to name
  `_merge_custom_provider_extra_body` as the second, **non-routed** trigger.
- Pinned shallow-merge semantics on both paths (the `reasoning` nested
  collision is lossy today and nothing tested it — the existing collision test
  used a single-key nested dict, so shallow and deep were indistinguishable).
- Pinned the defensive copy at the legacy path (`dict(v)`); both new tests go
  red when it is removed.
- Narrowed the parity docstring to dict values and added the missing
  profile-path non-dict cases, where the two paths really do disagree.
- The README-recipe test now parses the verbatim README YAML through
  `utils.fast_safe_load` instead of hand-writing the parsed dict. The
  string-vs-null hop is load-bearing: a Python `None` resolves to *no override
  at all*, which would silently no-op the documented recipe.
